### PR TITLE
fix(api): remove geograficaId parameter from lectivo endpoint

### DIFF
--- a/src/main/java/um/tesoreria/core/controller/ChequeraSerieController.java
+++ b/src/main/java/um/tesoreria/core/controller/ChequeraSerieController.java
@@ -44,10 +44,10 @@ public class ChequeraSerieController {
         this.chequeraCuotaService = chequeraCuotaService;
     }
 
-    @GetMapping("/lectivo/{facultadId}/{geograficaId}/{lectivoId}")
-    public ResponseEntity<List<ChequeraSerie>> findAllByLectivo(@PathVariable Integer facultadId, @PathVariable Integer geograficaId, @PathVariable Integer lectivoId) {
+    @GetMapping("/lectivo/{facultadId}/{lectivoId}")
+    public ResponseEntity<List<ChequeraSerie>> findAllByLectivo(@PathVariable Integer facultadId, @PathVariable Integer lectivoId) {
         log.debug("Processing ChequeraSerieController.findAllByLectivo");
-        return ResponseEntity.ok(service.findAllByLectivo(facultadId, geograficaId, lectivoId));
+        return ResponseEntity.ok(service.findAllByLectivoIdAndFacultadId(lectivoId, facultadId));
     }
 
     @GetMapping("/persona/{personaId}/{documentoId}")

--- a/src/main/java/um/tesoreria/core/repository/ChequeraSerieRepository.java
+++ b/src/main/java/um/tesoreria/core/repository/ChequeraSerieRepository.java
@@ -18,8 +18,6 @@ import um.tesoreria.core.kotlin.model.ChequeraSerie;
  */
 public interface ChequeraSerieRepository extends JpaRepository<ChequeraSerie, Long> {
 
-	List<ChequeraSerie> findAllByFacultadIdAndGeograficaIdAndLectivoId(Integer facultadId, Integer geograficaId, Integer lectivoId);
-
 	List<ChequeraSerie> findAllByPersonaIdAndDocumentoId(BigDecimal personaId, Integer documentoId, Sort sort);
 
 	List<ChequeraSerie> findAllByFacultadIdAndLectivoId(Integer facultadId, Integer lectivoId);

--- a/src/main/java/um/tesoreria/core/service/ChequeraSerieService.java
+++ b/src/main/java/um/tesoreria/core/service/ChequeraSerieService.java
@@ -68,11 +68,6 @@ public class ChequeraSerieService {
         this.chequeraImpresionCabeceraService = chequeraImpresionCabeceraService;
     }
 
-    public List<ChequeraSerie> findAllByLectivo(Integer facultadId, Integer geograficaId, Integer lectivoId) {
-        log.debug("Processing ChequeraSerieService.findAllByLectivo");
-        return repository.findAllByFacultadIdAndGeograficaIdAndLectivoId(facultadId, geograficaId, lectivoId);
-    }
-
     public List<ChequeraSerie> findAllByPersona(BigDecimal personaId, Integer documentoId) {
         return repository.findAllByPersonaIdAndDocumentoId(personaId, documentoId, Sort.by("lectivoId").descending());
     }


### PR DESCRIPTION
BREAKING CHANGE: The geograficaId parameter has been removed from the /lectivo/{facultadId}/{lectivoId} endpoint. This is a breaking change that requires clients to update their API calls.

- Removed geograficaId parameter from endpoint

- Updated repository and service methods

- Removed unused methods

- Updated documentation

Closes #1