### PR TITLE
chore(release): preparar versión 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2025-09-11
+- feat(controller,repository,service): agregar endpoint de resumen por lectivo (`/resumen/lectivo/{lectivoId}`) que devuelve la cantidad de chequeras agrupadas por facultad y sede
+- refactor(controller,service): reemplazar constructores con inyección de dependencias por `@RequiredArgsConstructor` en `ChequeraSerieController` y `ChequeraSerieService`
+- feat(model): crear nuevo DTO `FacultadSedeChequeraDto` para representar los datos del resumen
+
+> Basado en análisis de código (`git diff HEAD`), historial de commits y `pom.xml`.
+
 ## [1.5.0] - 2025-09-07
 - feat: Añadido nuevo endpoint para buscar `ChequeraSerie` por sede (`/sede/facultad/{facultadId}/lectivo/{lectivoId}/geografica/{geograficaId}`).
 - refactor: Refactorizados `GeograficaController` y `LegajoController` para usar inyección de dependencias por constructor, `ResponseEntity.ok()` y manejo de excepciones mejorado.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 3.5.5.
 
-**Versión actual (SemVer): 1.5.0**
+**Versión actual (SemVer): 1.6.0**
+
+## Novedades 1.6.0 (verificado en código)
+- Nuevo endpoint de resumen por lectivo (`/resumen/lectivo/{lectivoId}`) que devuelve la cantidad de chequeras agrupadas por facultad y sede
+- Refactorización de `ChequeraSerieController` y `ChequeraSerieService` para usar `@RequiredArgsConstructor` en lugar de constructores explícitos
+- Creación del DTO `FacultadSedeChequeraDto` para representar los datos del resumen
 
 ## Novedades 1.5.0 (verificado en código)
 - Añadido nuevo endpoint para buscar `ChequeraSerie` por sede (`/sede/facultad/{facultadId}/lectivo/{lectivoId}/geografica/{geograficaId}`).

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/controller/ChequeraSerieController.java
+++ b/src/main/java/um/tesoreria/core/controller/ChequeraSerieController.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 import um.tesoreria.core.kotlin.model.ChequeraSerie;
 import um.tesoreria.core.kotlin.model.view.ChequeraSerieAlta;
 import um.tesoreria.core.kotlin.model.view.ChequeraSerieAltaFull;
+import um.tesoreria.core.model.internal.FacultadSedeChequeraDto;
 import um.tesoreria.core.model.view.ChequeraIncompleta;
 import um.tesoreria.core.model.view.ChequeraKey;
 import um.tesoreria.core.service.ChequeraCuotaService;
@@ -34,15 +36,11 @@ import um.tesoreria.core.service.ChequeraSerieService;
 @RestController
 @RequestMapping({"/chequeraserie", "/api/tesoreria/core/chequeraSerie"})
 @Slf4j
+@RequiredArgsConstructor
 public class ChequeraSerieController {
 
     private final ChequeraSerieService service;
     private final ChequeraCuotaService chequeraCuotaService;
-
-    public ChequeraSerieController(ChequeraSerieService service, ChequeraCuotaService chequeraCuotaService) {
-        this.service = service;
-        this.chequeraCuotaService = chequeraCuotaService;
-    }
 
     @GetMapping("/lectivo/{facultadId}/{lectivoId}")
     public ResponseEntity<List<ChequeraSerie>> findAllByLectivo(@PathVariable Integer facultadId,
@@ -191,6 +189,11 @@ public class ChequeraSerieController {
                                                   @PathVariable Integer tipoChequeraId,
                                                   @PathVariable Long chequeraSerieId) {
         return ResponseEntity.ok(service.markSent(facultadId, tipoChequeraId, chequeraSerieId));
+    }
+
+    @GetMapping("/resumen/lectivo/{lectivoId}")
+    public ResponseEntity<List<FacultadSedeChequeraDto>> resumenLectivo(@PathVariable Integer lectivoId) {
+        return ResponseEntity.ok(service.resumenLectivo(lectivoId));
     }
 
 }

--- a/src/main/java/um/tesoreria/core/model/internal/FacultadSedeChequeraDto.java
+++ b/src/main/java/um/tesoreria/core/model/internal/FacultadSedeChequeraDto.java
@@ -1,0 +1,18 @@
+package um.tesoreria.core.model.internal;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FacultadSedeChequeraDto {
+
+    private Integer facultadId;
+    private String facultad;
+    private Integer geograficaId;
+    private String geografica;
+    private Long cantidad;
+
+}

--- a/src/main/java/um/tesoreria/core/repository/ChequeraSerieRepository.java
+++ b/src/main/java/um/tesoreria/core/repository/ChequeraSerieRepository.java
@@ -10,7 +10,11 @@ import java.util.Optional;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import um.tesoreria.core.kotlin.model.ChequeraSerie;
+import um.tesoreria.core.model.internal.CuotaPeriodoDto;
+import um.tesoreria.core.model.internal.FacultadSedeChequeraDto;
 
 /**
  * @author daniel
@@ -76,5 +80,14 @@ public interface ChequeraSerieRepository extends JpaRepository<ChequeraSerie, Lo
 	@Modifying
 	void deleteAllByFacultadIdAndTipoChequeraIdAndChequeraSerieId(Integer facultadId, Integer tipoChequeraId,
 			Long chequeraSerieId);
+
+    @Query("SELECT new um.tesoreria.core.model.internal.FacultadSedeChequeraDto(cs.facultadId, f.nombre, cs.geograficaId, g.nombre, COUNT(*)) " +
+            "FROM ChequeraSerie cs " +
+            "JOIN Facultad f ON cs.facultadId = f.facultadId " +
+            "JOIN Geografica g on cs.geograficaId = g.geograficaId " +
+            "WHERE cs.lectivoId = :lectivoId " +
+            "GROUP BY cs.facultadId, cs.geograficaId " +
+            "ORDER BY cs.facultadId, cs.geograficaId")
+    List<FacultadSedeChequeraDto> findAllFacultadSedeByLectivo(@Param("lectivoId") Integer lectivoId);
 
 }

--- a/src/main/java/um/tesoreria/core/service/ChequeraSerieService.java
+++ b/src/main/java/um/tesoreria/core/service/ChequeraSerieService.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 import jakarta.transaction.Transactional;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +22,7 @@ import um.tesoreria.core.kotlin.model.TipoChequera;
 import um.tesoreria.core.kotlin.model.view.ChequeraSerieAlta;
 import um.tesoreria.core.kotlin.model.view.ChequeraSerieAltaFull;
 import um.tesoreria.core.model.Debito;
+import um.tesoreria.core.model.internal.FacultadSedeChequeraDto;
 import um.tesoreria.core.model.view.ChequeraIncompleta;
 import um.tesoreria.core.model.view.ChequeraKey;
 import um.tesoreria.core.repository.ChequeraSerieRepository;
@@ -36,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class ChequeraSerieService {
 
     private final ChequeraSerieRepository repository;
@@ -46,25 +48,6 @@ public class ChequeraSerieService {
     private final DebitoService debitoService;
     private final ChequeraKeyService chequeraKeyService;
     private final ChequeraImpresionCabeceraService chequeraImpresionCabeceraService;
-
-    @Autowired
-    public ChequeraSerieService(ChequeraSerieRepository repository,
-                                ChequeraIncompletaService chequeraIncompletaService,
-                                ChequeraSerieAltaService chequeraSerieAltaService,
-                                ChequeraSerieAltaFullService chequeraSerieAltaFullService,
-                                TipoChequeraService tipoChequeraService,
-                                DebitoService debitoService,
-                                ChequeraKeyService chequeraKeyService,
-                                ChequeraImpresionCabeceraService chequeraImpresionCabeceraService) {
-        this.repository = repository;
-        this.chequeraIncompletaService = chequeraIncompletaService;
-        this.chequeraSerieAltaService = chequeraSerieAltaService;
-        this.chequeraSerieAltaFullService = chequeraSerieAltaFullService;
-        this.tipoChequeraService = tipoChequeraService;
-        this.debitoService = debitoService;
-        this.chequeraKeyService = chequeraKeyService;
-        this.chequeraImpresionCabeceraService = chequeraImpresionCabeceraService;
-    }
 
     public List<ChequeraSerie> findAllByPersona(BigDecimal personaId, Integer documentoId) {
         return repository.findAllByPersonaIdAndDocumentoId(personaId, documentoId, Sort.by("lectivoId").descending());
@@ -397,6 +380,10 @@ public class ChequeraSerieService {
                                                                          Long chequeraSerieId) {
         repository.deleteAllByFacultadIdAndTipoChequeraIdAndChequeraSerieId(facultadId, tipoChequeraId,
                 chequeraSerieId);
+    }
+
+    public List<FacultadSedeChequeraDto> resumenLectivo(Integer lectivoId) {
+        return repository.findAllFacultadSedeByLectivo(lectivoId);
     }
 
 }


### PR DESCRIPTION
## Descripción
Este PR documenta los cambios realizados en la versión 1.6.0 del servicio. Se incluye un nuevo endpoint para obtener un resumen de chequeras por lectivo, agrupado por facultad y sede. Además, se realizó una refactorización en `ChequeraSerieController` y `ChequeraSerieService` para utilizar `@RequiredArgsConstructor` en lugar de constructores explícitos. Los cambios están relacionados con el issue #160.

## Cambios Realizados
- [x] Agregar endpoint `/resumen/lectivo/{lectivoId}` en `ChequeraSerieController` para obtener un resumen de chequeras por lectivo.
- [x] Crear DTO `FacultadSedeChequeraDto` para representar los datos del resumen.
- [x] Implementar método `resumenLectivo` en `ChequeraSerieService` y su correspondiente método en `ChequeraSerieRepository`.
- [x] Refactorizar `ChequeraSerieController` y `ChequeraSerieService` para usar `@RequiredArgsConstructor`.
- [x] Actualizar `CHANGELOG.md` y `README.md` con los cambios de la nueva versión.

## Impacto Potencial
- [x] Los cambios son principalmente aditivos (nuevo endpoint) y de refactorización (inyección de dependencias), por lo que el impacto en otras áreas del sistema debería ser mínimo.
- [x] No se requieren migraciones de base de datos ni cambios en variables de entorno.

## Verificación
1. `git checkout 160-documentar-cambios-versión-160-nuevo-endpoint-resumen-y-refactorización`
2. Verificar que la aplicación compila correctamente con `mvn clean install`.
3. Ejecutar la aplicación y probar el nuevo endpoint `GET /api/tesoreria/core/chequeraSerie/resumen/lectivo/{lectivoId}` con un ID de lectivo válido.
4. Verificar que el endpoint devuelve una lista de `FacultadSedeChequeraDto` correctamente formateada.

## Notas Adicionales
La refactorización de constructores con `@RequiredArgsConstructor` mejora la legibilidad del código y reduce el boilerplate. El nuevo endpoint de resumen proporciona una vista agregada útil para reportes.