### PR TITLE
fix(chequera): add compensada filter to pending cuotas queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2025-11-11
+- fix: Added compensada filter to ChequeraCuotaRepository.findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndPagadoAndBajaAndCompensadaAndImporte1GreaterThan to exclude compensated cuotas from pending queries
+- Updated ChequeraCuotaService.findAllPendientes to include compensada parameter
+
+> Based on deep analysis of git diff HEAD.
+
 ## [2.3.0] - 2025-11-11
 - feat: Added MercadoPagoContextHistory module for tracking history of MercadoPago contexts
 - refactor: Replaced @Autowired with @RequiredArgsConstructor in PagarFileController and PagarFileService

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 3.5.6.
 
-**Versión actual (SemVer): 2.3.0**
+**Versión actual (SemVer): 2.3.1**
+
+## Novedades 2.3.1 (verificado en código)
+- Añadido filtro de compensada en ChequeraCuotaRepository para excluir cuotas compensadas de consultas pendientes
+- Actualizado ChequeraCuotaService.findAllPendientes para incluir parámetro compensada
 
 ## Novedades 2.3.0 (verificado en código)
 - Añadido módulo MercadoPagoContextHistory para seguimiento del historial de contextos de MercadoPago

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/repository/ChequeraCuotaRepository.java
+++ b/src/main/java/um/tesoreria/core/repository/ChequeraCuotaRepository.java
@@ -40,7 +40,7 @@ public interface ChequeraCuotaRepository extends JpaRepository<ChequeraCuota, Lo
 
 	List<ChequeraCuota> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndProductoIdAndAlternativaIdAndPagado(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Byte pagado);
 
-	List<ChequeraCuota> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndPagadoAndBajaAndImporte1GreaterThan(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer alternativaId, Byte pagado, Byte baja, BigDecimal zero);
+	List<ChequeraCuota> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndPagadoAndBajaAndCompensadaAndImporte1GreaterThan(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer alternativaId, Byte pagado, Byte baja, Byte compensada, BigDecimal zero);
 
 	List<ChequeraCuota> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndPagadoAndBaja(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer alternativaId, Byte pagado, Byte baja);
 

--- a/src/main/java/um/tesoreria/core/service/ChequeraCuotaService.java
+++ b/src/main/java/um/tesoreria/core/service/ChequeraCuotaService.java
@@ -185,7 +185,7 @@ public class ChequeraCuotaService {
     }
 
     public List<ChequeraCuota> findAllPendientes(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer alternativaId) {
-        return repository.findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndPagadoAndBajaAndImporte1GreaterThan(facultadId, tipoChequeraId, chequeraSerieId, alternativaId, (byte) 0, (byte) 0, BigDecimal.ZERO);
+        return repository.findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndPagadoAndBajaAndCompensadaAndImporte1GreaterThan(facultadId, tipoChequeraId, chequeraSerieId, alternativaId, (byte) 0, (byte) 0, (byte) 0, BigDecimal.ZERO);
     }
 
     public List<ChequeraCuota> findAllPendientesBaja(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer alternativaId) {


### PR DESCRIPTION
## Descripción
Este PR prepara el lanzamiento de la versión 2.3.1, corrigiendo la consulta de cuotas pendientes para incluir un filtro por estado compensada, asegurando que las cuotas compensadas sean excluidas de las listas de pendientes.

Resuelve el issue #177.

## Cambios Realizados
- [x] Añadido parámetro `compensada` al método `findAllBy...AndCompensadaAndImporte1GreaterThan` en `ChequeraCuotaRepository`.
- [x] Actualizado `ChequeraCuotaService.findAllPendientes` para incluir el filtro de compensada (valor 0).
- [x] Actualizada versión en `pom.xml` de 2.3.0 a 2.3.1.
- [x] Añadida entrada en `CHANGELOG.md` para la versión 2.3.1.
- [x] Actualizado `README.md` con la nueva versión y notas de cambios.

## Impacto Potencial
- [x] Mejora la precisión de las consultas de cuotas pendientes al excluir cuotas compensadas.
- [x] No hay cambios disruptivos en la API pública.
- [x] No requiere migraciones de base de datos ni cambios en variables de entorno.

## Verificación
Para verificar los cambios:
1. `git checkout 177-prepare-release-231---add-compensada-filter-to-pending-cuotas-queries`
2. `mvn clean compile`
3. Ejecutar tests unitarios: `mvn test`
4. Verificar que las consultas de cuotas pendientes excluyan correctamente las compensadas.

## Notas Adicionales
Los cambios se basan en el análisis profundo del código y siguen el versionado semántico (PATCH para corrección de bug).