### PR TITLE
chore(release): prepare version 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2025-11-15
+- refactor: Replaced manual constructors with @RequiredArgsConstructor in ChequeraController and MercadoPagoCoreController
+
+> Based on deep analysis of git diff HEAD.
+
 ## [2.3.1] - 2025-11-11
 - fix: Added compensada filter to ChequeraCuotaRepository.findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndPagadoAndBajaAndCompensadaAndImporte1GreaterThan to exclude compensated cuotas from pending queries
 - Updated ChequeraCuotaService.findAllPendientes to include compensada parameter

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 3.5.6.
 
-**Versión actual (SemVer): 2.3.1**
+**Versión actual (SemVer): 2.3.2**
+
+## Novedades 2.3.2 (verificado en código)
+- Refactorización para usar @RequiredArgsConstructor en ChequeraController y MercadoPagoCoreController
 
 ## Novedades 2.3.1 (verificado en código)
 - Añadido filtro de compensada en ChequeraCuotaRepository para excluir cuotas compensadas de consultas pendientes

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/controller/facade/ChequeraController.java
+++ b/src/main/java/um/tesoreria/core/controller/facade/ChequeraController.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import jakarta.mail.MessagingException;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -44,6 +45,7 @@ import um.tesoreria.core.kotlin.model.SpoterData;
  */
 @RestController
 @RequestMapping({"/chequera", "/api/tesoreria/core/chequera"})
+@RequiredArgsConstructor
 public class ChequeraController {
 
     private final ChequeraService service;
@@ -51,14 +53,6 @@ public class ChequeraController {
     private final FormulariosToPdfService formularioToPdfService;
     private final SpoterDataService spoterDataService;
     private final ChequeraCuotaService chequeraCuotaService;
-
-    public ChequeraController(ChequeraService service, MailChequeraService mailChequeraService, FormulariosToPdfService formularioToPdfService, SpoterDataService spoterDataService, ChequeraCuotaService chequeraCuotaService) {
-        this.service = service;
-        this.mailChequeraService = mailChequeraService;
-        this.formularioToPdfService = formularioToPdfService;
-        this.spoterDataService = spoterDataService;
-        this.chequeraCuotaService = chequeraCuotaService;
-    }
 
     @DeleteMapping("/delete/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{usuarioId}")
     public ResponseEntity<Void> deleteByChequera(@PathVariable Integer facultadId, @PathVariable Integer tipoChequeraId,

--- a/src/main/java/um/tesoreria/core/controller/facade/MercadoPagoCoreController.java
+++ b/src/main/java/um/tesoreria/core/controller/facade/MercadoPagoCoreController.java
@@ -1,5 +1,6 @@
 package um.tesoreria.core.controller.facade;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,13 +12,10 @@ import um.tesoreria.core.service.facade.MercadoPagoCoreService;
 
 @RestController
 @RequestMapping("/api/tesoreria/core/mercadopago")
+@RequiredArgsConstructor
 public class MercadoPagoCoreController {
 
     private final MercadoPagoCoreService service;
-
-    public MercadoPagoCoreController(MercadoPagoCoreService service) {
-        this.service = service;
-    }
 
     @GetMapping("/makeContext/{chequeraCuotaId}")
     public ResponseEntity<UMPreferenceMPDto> makeContext(@PathVariable Long chequeraCuotaId) {


### PR DESCRIPTION
## Descripción
Preparar la versión 2.3.2 del servicio core de tesorería, incluyendo refactorización de controladores y actualización de documentación.

Este PR resuelve la issue #179 para preparar el lanzamiento de la versión 2.3.2.

## Cambios Realizados
- [x] Refactorizar ChequeraController y MercadoPagoCoreController para usar @RequiredArgsConstructor en lugar de constructores manuales
- [x] Actualizar pom.xml a versión 2.3.2
- [x] Agregar entrada en CHANGELOG.md para la versión 2.3.2
- [x] Actualizar README.md con la nueva versión y sección de novedades

## Impacto Potencial
- [x] Mejora en la consistencia de inyección de dependencias
- [x] No hay cambios disruptivos en la API
- [x] Documentación actualizada para reflejar los cambios

## Verificación
Para verificar los cambios:
1. `git checkout 179-prepare-release-232-controller-refactoring-and-documentation-updates`
2. `mvn clean compile` - Verificar que el código compila correctamente
3. `mvn test` - Ejecutar tests para asegurar que no se rompió nada
4. Revisar CHANGELOG.md y README.md para confirmar las actualizaciones

## Notas Adicionales
Los cambios siguen las mejores prácticas de Spring Boot con Lombok para simplificar la inyección de dependencias. La versión se incrementa como patch debido a la naturaleza no disruptiva de los cambios.