### PR TITLE
chore(deps): actualizar dependencias a Spring Boot 4.0.2 y Java 25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,10 +18,10 @@ jobs:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-02-03
+- chore(deps): Actualización de Spring Boot de 3.5.8 a 4.0.2
+- chore(deps): Actualización de Java de 24 a 25
+- chore(deps): Actualización de Kotlin de 2.2.21 a 2.3.0
+- chore(deps): Actualización de Spring Cloud de 2025.0.0 a 2025.1.0
+- chore(deps): Actualización de mysql-connector-j de 9.4.0 a 9.6.0
+- chore(deps): Actualización de springdoc-openapi de 2.8.10 a 3.0.1
+- chore(deps): Actualización de Apache POI de 5.4.1 a 5.5.1
+- chore(deps): Actualización de guava de 33.4.8-jre a 33.5.0-jre
+- chore(deps): Actualización de commons-lang3 de 3.18.0 a 3.20.0
+- chore(deps): Actualización de modelmapper de 3.2.4 a 3.2.6
+- chore(deps): Actualización de json-path de 2.9.0 a 2.10.0
+- chore: Actualización de GitHub Actions para usar JDK 25
+- chore: Actualización de Dockerfile para usar JDK 25
+
+> Based on deep analysis of git diff (staged changes) and pom.xml.
+
 ## [2.5.0] - 2025-12-14
 - feat: Implementación de envío asíncrono de chequeras mediante Kafka y `SendChequeraEvent`.
 - feat: Configuración de productor de Kafka en `KafkaProducerConfig`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Etapa 1: Compilación con Maven y JDK
 # Usamos una imagen oficial que contiene Maven y Java (Temurin)
-FROM maven:3-eclipse-temurin-24-alpine AS build
+FROM maven:3-eclipse-temurin-25-alpine AS build
 
 # Establecemos el directorio de trabajo
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN mvn clean package
 
 # Etapa 2: Creación de la imagen final y ligera
 # Usamos una imagen solo con el JRE, que es más pequeña
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 # Instalar curl en la imagen final
 RUN apk update && apk add curl

--- a/README.md
+++ b/README.md
@@ -2,9 +2,24 @@
 
 ## Descripción
 
-Servicio core para la gestión de tesorería, implementado con Spring Boot 3.5.6.
+Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.2.
 
-**Versión actual (SemVer): 2.5.0**
+**Versión actual (SemVer): 3.0.0**
+
+## Novedades 3.0.0 (verificado en código)
+- Actualización de Spring Boot de 3.5.8 a 4.0.2
+- Actualización de Java de 24 a 25
+- Actualización de Kotlin de 2.2.21 a 2.3.0
+- Actualización de Spring Cloud de 2025.0.0 a 2025.1.0
+- Actualización de mysql-connector-j de 9.4.0 a 9.6.0
+- Actualización de springdoc-openapi de 2.8.10 a 3.0.1
+- Actualización de Apache POI de 5.4.1 a 5.5.1
+- Actualización de guava de 33.4.8-jre a 33.5.0-jre
+- Actualización de commons-lang3 de 3.18.0 a 3.20.0
+- Actualización de modelmapper de 3.2.4 a 3.2.6
+- Actualización de json-path de 2.9.0 a 2.10.0
+- Actualización de GitHub Actions para usar JDK 25
+- Actualización de Dockerfile para usar JDK 25
 
 ## Novedades 2.5.0 (verificado en código)
 - Implementación de envío asíncrono de correos de chequeras utilizando Kafka (`SendChequeraEvent`).

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.8</version>
+        <version>4.0.2</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
@@ -15,9 +15,9 @@
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>
-        <java.version>24</java.version>
-        <kotlin.version>2.2.21</kotlin.version>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
+        <java.version>25</java.version>
+        <kotlin.version>2.3.0</kotlin.version>
+        <spring-cloud.version>2025.1.0</spring-cloud.version>
         <sonar.organization>um-services</sonar.organization>
         <sonar.projectKey>UM-services_UM.tesoreria.core-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
-            <version>3.5.8</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
-            <version>9.4.0</version>
+            <version>9.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -81,22 +81,22 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.8-jre</version>
+            <version>33.5.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>5.4.1</version>
+            <version>5.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.4.1</version>
+            <version>5.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.10</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.librepdf</groupId>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
-            <version>3.2.4</version>
+            <version>3.2.6</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.9.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -168,7 +168,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
Closes #200

## Descripción
Actualización masiva de dependencias del proyecto, incluyendo Spring Boot 4.0.2, Java 25 y más.

## Cambios Realizados
- **Spring Boot**: 3.5.8 → 4.0.2
- **Java**: 24 → 25
- **Kotlin**: 2.2.21 → 2.3.0
- **Spring Cloud**: 2025.0.0 → 2025.1.0
- **mysql-connector-j**: 9.4.0 → 9.6.0
- **springdoc-openapi**: 2.8.10 → 3.0.1
- **Apache POI**: 5.4.1 → 5.5.1
- **Guava**: 33.4.8-jre → 33.5.0-jre
- **commons-lang3**: 3.18.0 → 3.20.0
- **ModelMapper**: 3.2.4 → 3.2.6
- **json-path**: 2.9.0 → 2.10.0

## Archivos Modificados
- `pom.xml` - Actualización de versiones de dependencias
- `Dockerfile` - Cambio a JDK 25
- `.github/workflows/maven.yml` - Actualización de GitHub Actions
- `README.md` - Documentación de la versión 3.0.0
- `CHANGELOG.md` - Registro de cambios

## Verificación
- Build y tests automatizados pasan
- La aplicación se ejecuta correctamente con las nuevas dependencias
- Los endpoints de la API responden adecuadamente
