### PR TITLE
release(v3.3.2): Refactor de controladores, manejo de excepciones y actualización de JDK

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2026-02-19
+### Changed
+- refactor(controller): Migración a inyección por constructor con `@RequiredArgsConstructor` en ArancelTipoController, FacultadController y TipoChequeraSedeController
+  - Reemplazo de `@Resource`/`@Autowired` por `final` + constructor Lombok
+  - Uso de `ResponseEntity.ok()` en lugar de `new ResponseEntity<>()`
+  - Simplificación de código y mejor testabilidad
+
+### Fixed
+- fix(api): Agregado manejo de excepciones con `ResponseStatusException` en ArancelTipoController, FacultadController y TipoChequeraSedeController
+  - Nuevo manejo de excepciones para findByArancelTipoId, findByArancelTipoIdCompleto, findByFacultadId, findByTipoChequeraId
+  - Devolución de HTTP 400 Bad Request en lugar de 200 para errores de negocio
+- fix(transaction): Agregado `@Transactional` en MercadoPagoContextService.processPaymentEvent()
+  - Corrección del manejo transaccional para procesamiento de eventos de pago
+  - Asegura consistencia en la actualización de contextos de MercadoPago
+
+> Basado en análisis profundo de `git diff HEAD` (cambios no commiteados).
+
 ## [3.3.1] - 2026-02-19
 ### Fixed
 - fix(performance): Optimización de rendimiento en actualización de último login de usuario

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.2.
 
-**Versión actual (SemVer): 3.3.1**
+**Versión actual (SemVer): 3.3.2**
+
+## Novedades 3.3.2 (verificado en código)
+- refactor: Migración a inyección por constructor con `@RequiredArgsConstructor` en ArancelTipoController, FacultadController y TipoChequeraSedeController
+  - Reemplazo de `@Resource`/`@Autowired` por `final` + constructor Lombok
+  - Uso de `ResponseEntity.ok()` en lugar de `new ResponseEntity<>()`
+- fix(api): Agregado manejo de excepciones con `ResponseStatusException` en controladores
+  - Devolución de HTTP 400 Bad Request para errores de negocio
+- fix(transaction): Agregado `@Transactional` en MercadoPagoContextService.processPaymentEvent()
 
 ## Novedades 3.3.1 (verificado en código)
 - fix(performance): Optimización de rendimiento en actualización de último login
@@ -427,7 +435,7 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen.svg)](https://spring.io/projects/spring-cloud)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.0-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.3.1-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.3.2-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.3.1</version>
+    <version>3.3.2</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/controller/ArancelTipoController.java
+++ b/src/main/java/um/tesoreria/core/controller/ArancelTipoController.java
@@ -6,6 +6,7 @@ package um.tesoreria.core.controller;
 import java.util.List;
 
 import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.web.server.ResponseStatusException;
+import um.tesoreria.core.exception.ArancelTipoException;
 import um.tesoreria.core.kotlin.model.ArancelTipo;
 import um.tesoreria.core.model.view.ArancelTipoLectivo;
 import um.tesoreria.core.service.ArancelTipoService;
@@ -27,51 +30,58 @@ import um.tesoreria.core.service.ArancelTipoService;
  */
 @RestController
 @RequestMapping("/aranceltipo")
+@RequiredArgsConstructor
 public class ArancelTipoController {
 
-	@Resource
-	private ArancelTipoService service;
+	private final ArancelTipoService service;
 
 	@GetMapping("/")
 	public ResponseEntity<List<ArancelTipo>> findAll() {
-		return new ResponseEntity<List<ArancelTipo>>(service.findAll(), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAll());
 	}
 
 	@GetMapping("/lectivo/{lectivoId}")
 	public ResponseEntity<List<ArancelTipoLectivo>> findAllByLectivoId(@PathVariable Integer lectivoId) {
-		return new ResponseEntity<List<ArancelTipoLectivo>>(service.findAllByLectivoId(lectivoId), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAllByLectivoId(lectivoId));
 	}
 
 	@GetMapping("/{arancelTipoId}")
 	public ResponseEntity<ArancelTipo> findByArancelTipoId(@PathVariable Integer arancelTipoId) {
-		return new ResponseEntity<ArancelTipo>(service.findByArancelTipoId(arancelTipoId), HttpStatus.OK);
+		try {
+			return ResponseEntity.ok(service.findByArancelTipoId(arancelTipoId));
+		} catch (ArancelTipoException e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+		}
 	}
 
 	@GetMapping("/completo/{arancelTipoIdCompleto}")
 	public ResponseEntity<ArancelTipo> findByArancelTipoIdCompleto(@PathVariable Integer arancelTipoIdCompleto) {
-		return new ResponseEntity<ArancelTipo>(service.findByArancelTipoIdCompleto(arancelTipoIdCompleto),
-				HttpStatus.OK);
+		try {
+			return ResponseEntity.ok(service.findByArancelTipoIdCompleto(arancelTipoIdCompleto));
+		} catch (ArancelTipoException e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+		}
 	}
 
 	@GetMapping("/last")
 	public ResponseEntity<ArancelTipo> findLast() {
-		return new ResponseEntity<ArancelTipo>(service.findLast(), HttpStatus.OK);
+		return ResponseEntity.ok(service.findLast());
 	}
 
 	@PostMapping("/")
 	public ResponseEntity<ArancelTipo> add(@RequestBody ArancelTipo arancelTipo) {
-		return new ResponseEntity<ArancelTipo>(service.add(arancelTipo), HttpStatus.OK);
+		return ResponseEntity.ok(service.add(arancelTipo));
 	}
 
 	@PutMapping("/{arancelTipoId}")
 	public ResponseEntity<ArancelTipo> update(@RequestBody ArancelTipo arancelTipo,
 			@PathVariable Integer arancelTipoId) {
-		return new ResponseEntity<ArancelTipo>(service.update(arancelTipo, arancelTipoId), HttpStatus.OK);
+		return ResponseEntity.ok(service.update(arancelTipo, arancelTipoId));
 	}
 
 	@DeleteMapping("/{arancelTipoId}")
 	public ResponseEntity<Void> deleteByAranceltipoId(@PathVariable Integer arancelTipoId) {
 		service.deleteByArancelTipoId(arancelTipoId);
-		return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/um/tesoreria/core/controller/FacultadController.java
+++ b/src/main/java/um/tesoreria/core/controller/FacultadController.java
@@ -6,6 +6,7 @@ package um.tesoreria.core.controller;
 import java.math.BigDecimal;
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.web.server.ResponseStatusException;
+import um.tesoreria.core.exception.FacultadException;
 import um.tesoreria.core.kotlin.model.Facultad;
 import um.tesoreria.core.model.view.FacultadLectivo;
 import um.tesoreria.core.model.view.FacultadLectivoSede;
@@ -25,17 +28,14 @@ import um.tesoreria.core.service.FacultadService;
  */
 @RestController
 @RequestMapping({"/facultad", "/api/tesoreria/core/facultad"})
+@RequiredArgsConstructor
 public class FacultadController {
 
 	private final FacultadService service;
 
-	public FacultadController(FacultadService service) {
-		this.service = service;
-	}
-
 	@GetMapping("/")
 	public ResponseEntity<List<Facultad>> findAll() {
-		return new ResponseEntity<>(service.findAll(), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAll());
 	}
 
 	@GetMapping("/facultades")
@@ -63,7 +63,11 @@ public class FacultadController {
 
 	@GetMapping("/{facultadId}")
 	public ResponseEntity<Facultad> findByFacultadId(@PathVariable Integer facultadId) {
-        return ResponseEntity.ok(service.findByFacultadId(facultadId));
+		try {
+			return ResponseEntity.ok(service.findByFacultadId(facultadId));
+		} catch (FacultadException e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+		}
 	}
 
 }

--- a/src/main/java/um/tesoreria/core/controller/view/TipoChequeraSedeController.java
+++ b/src/main/java/um/tesoreria/core/controller/view/TipoChequeraSedeController.java
@@ -6,7 +6,7 @@ package um.tesoreria.core.controller.view;
 import java.math.BigDecimal;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.web.server.ResponseStatusException;
+import um.tesoreria.core.exception.view.TipoChequeraSedeException;
 import um.tesoreria.core.model.view.TipoChequeraSede;
 import um.tesoreria.core.service.view.TipoChequeraSedeService;
 
@@ -23,46 +25,46 @@ import um.tesoreria.core.service.view.TipoChequeraSedeService;
  */
 @RestController
 @RequestMapping("/tipochequerasede")
+@RequiredArgsConstructor
 public class TipoChequeraSedeController {
 
-	@Autowired
-	private TipoChequeraSedeService service;
+	private final TipoChequeraSedeService service;
 
 	@GetMapping("/")
 	public ResponseEntity<List<TipoChequeraSede>> findAll() {
-		return new ResponseEntity<List<TipoChequeraSede>>(service.findAll(), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAll());
 	}
 
 	@GetMapping("/sede/{geograficaId}/{modulo}")
 	public ResponseEntity<List<TipoChequeraSede>> findAllByGeograficaId(@PathVariable Integer geograficaId,
 			@PathVariable String modulo) {
-		return new ResponseEntity<List<TipoChequeraSede>>(service.findAllByGeograficaId(geograficaId, modulo),
-				HttpStatus.OK);
+		return ResponseEntity.ok(service.findAllByGeograficaId(geograficaId, modulo));
 	}
 
 	@GetMapping("/lectivo/{lectivoId}/{facultadId}/{geograficaId}/{modulo}")
 	public ResponseEntity<List<TipoChequeraSede>> findAllByGeograficaId(@PathVariable Integer lectivoId,
 			@PathVariable Integer facultadId, @PathVariable Integer geograficaId, @PathVariable String modulo) {
-		return new ResponseEntity<List<TipoChequeraSede>>(
-				service.findAllByLectivoIdAndFacultadId(lectivoId, facultadId, geograficaId, modulo), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAllByLectivoIdAndFacultadId(lectivoId, facultadId, geograficaId, modulo));
 	}
 
 	@GetMapping("/persona/{personaId}/{documentoId}/{lectivoId}/{facultadId}")
 	public ResponseEntity<List<TipoChequeraSede>> findAllByPersonaId(@PathVariable BigDecimal personaId,
 			@PathVariable Integer documentoId, @PathVariable Integer lectivoId, @PathVariable Integer facultadId) {
-		return new ResponseEntity<List<TipoChequeraSede>>(
-				service.findAllByPersonaId(personaId, documentoId, lectivoId, facultadId), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAllByPersonaId(personaId, documentoId, lectivoId, facultadId));
 	}
 
 	@GetMapping("/tablero/{lectivoId}/{geograficaId}")
 	public ResponseEntity<List<TipoChequeraSede>> findAllByLectivoIdAndGeograficaId(@PathVariable Integer lectivoId,
 			@PathVariable Integer geograficaId) {
-		return new ResponseEntity<List<TipoChequeraSede>>(
-				service.findAllByLectivoIdAndGeograficaId(lectivoId, geograficaId), HttpStatus.OK);
+		return ResponseEntity.ok(service.findAllByLectivoIdAndGeograficaId(lectivoId, geograficaId));
 	}
 
 	@GetMapping("/{tipoChequeraId}")
 	public ResponseEntity<TipoChequeraSede> findByTipoChequeraId(@PathVariable Integer tipoChequeraId) {
-		return new ResponseEntity<TipoChequeraSede>(service.findByTipoChequeraId(tipoChequeraId), HttpStatus.OK);
+		try {
+			return ResponseEntity.ok(service.findByTipoChequeraId(tipoChequeraId));
+		} catch (TipoChequeraSedeException e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+		}
 	}
 }

--- a/src/main/java/um/tesoreria/core/service/MercadoPagoContextService.java
+++ b/src/main/java/um/tesoreria/core/service/MercadoPagoContextService.java
@@ -104,6 +104,7 @@ public class MercadoPagoContextService {
                 .orElseThrow(() -> new MercadoPagoContextException("Context not found for id", mercadoPagoContextId));
     }
 
+    @Transactional
     public void processPaymentEvent(PaymentProcessedEvent event) {
         log.debug("\n\nProcessing payment event for contextId: {}\n\n", event.getMercadoPagoContextId());
         var context = findByMercadoPagoContextId(event.getMercadoPagoContextId());


### PR DESCRIPTION
Closes #215

## Descripción
Release 3.3.2 que incluye refactorización de controladores con inyección por constructor Lombok, agregado de manejo de excepciones con ResponseStatusException, y actualización de JDK 24 a 25 en el workflow de CI/CD.

## Cambios Realizados
- **Refactor de Controladores**: Migración de `@Resource`/`@Autowired` a `final` + constructor Lombok con `@RequiredArgsConstructor` en ArancelTipoController, FacultadController y TipoChequeraSedeController
- **Manejo de Excecciones**: Agregado `ResponseStatusException` para devolver HTTP 400 en errores de negocio (findByArancelTipoId, findByArancelTipoIdCompleto, findByFacultadId, findByTipoChequeraId)
- **Transacciones**: Agregado `@Transactional` en MercadoPagoContextService.processPaymentEvent()
- **Versión**: Actualización de 3.3.1 a 3.3.2 en pom.xml, README.md y CHANGELOG.md
- **CI/CD**: Actualización de JDK 24 a JDK 25 en generate-docs.yml

## Verificación
- [ ] Compilación exitosa con `mvn clean install`
- [ ] Tests passing
- [ ] Pipeline de GitHub Actions exitoso
