### PR TITLE
feat(api): nuevo endpoint /habilitados y refactor de inyección de dependencias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-03-02
+### Added
+- feat(api): Nuevo endpoint `/habilitados` en ArancelTipoController para obtener tipos de arancel habilitados
+  - Nuevo método `findAllHabilitados()` en ArancelTipoService
+  - Nuevo método `findAllByHabilitado()` en ArancelTipoRepository
+  - Retorna solo registros con campo `habilitado = 1`
+
+### Changed
+- refactor(controller): Migración a inyección por constructor con `@RequiredArgsConstructor` en ArancelTipoService
+  - Reemplazo de `@Resource` por campos `final` + constructor Lombok
+  - Uso de `ResponseEntity.ok()` en lugar de `new ResponseEntity<>()` en CostoController
+- refactor(model): Agregado campo `habilitado` (Byte) en ArancelTipo.kt
+  - Agregado método `jsonify()` para logging estructurado
+  - Actualización de método `update()` en ArancelTipoService para mantener el campo habilitado
+- refactor(logging): Mejoras en logging con `jsonify()` en ArancelTipoService
+
+### Fixed
+- fix(validation): Agregado `assert` en CostoService para validación de objeto Entrega en deleteDesignacion
+
+> Basado en análisis profundo de `git diff HEAD` (cambios no commiteados).
+
 ## [3.3.2] - 2026-02-19
 ### Changed
 - refactor(controller): Migración a inyección por constructor con `@RequiredArgsConstructor` en ArancelTipoController, FacultadController y TipoChequeraSedeController

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.2.
 
-**Versión actual (SemVer): 3.3.2**
+**Versión actual (SemVer): 3.4.0**
+
+## Novedades 3.4.0 (verificado en código)
+- feat(api): Nuevo endpoint `/habilitados` en ArancelTipoController para obtener tipos de arancel habilitados
+  - Nuevo método `findAllHabilitados()` en ArancelTipoService
+  - Nuevo método `findAllByHabilitado()` en ArancelTipoRepository
+  - Retorna solo registros con campo `habilitado = 1`
+- refactor: Migración a inyección por constructor con `@RequiredArgsConstructor` en ArancelTipoService
+  - Reemplazo de `@Resource` por campos `final` + constructor Lombok
+- refactor: Uso de `ResponseEntity.ok()` en lugar de `new ResponseEntity<>()` en CostoController
+- fix: Agregado `assert` en CostoService para validación de objeto Entrega
 
 ## Novedades 3.3.2 (verificado en código)
 - refactor: Migración a inyección por constructor con `@RequiredArgsConstructor` en ArancelTipoController, FacultadController y TipoChequeraSedeController
@@ -435,7 +445,7 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen.svg)](https://spring.io/projects/spring-cloud)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.0-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.3.2-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.4.0-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.3.2</version>
+    <version>3.4.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/controller/ArancelTipoController.java
+++ b/src/main/java/um/tesoreria/core/controller/ArancelTipoController.java
@@ -40,6 +40,11 @@ public class ArancelTipoController {
 		return ResponseEntity.ok(service.findAll());
 	}
 
+	@GetMapping("/habilitados")
+	public ResponseEntity<List<ArancelTipo>> findAllHabilitados() {
+		return ResponseEntity.ok(service.findAllHabilitados());
+	}
+
 	@GetMapping("/lectivo/{lectivoId}")
 	public ResponseEntity<List<ArancelTipoLectivo>> findAllByLectivoId(@PathVariable Integer lectivoId) {
 		return ResponseEntity.ok(service.findAllByLectivoId(lectivoId));

--- a/src/main/java/um/tesoreria/core/controller/facade/CostoController.java
+++ b/src/main/java/um/tesoreria/core/controller/facade/CostoController.java
@@ -24,26 +24,26 @@ public class CostoController {
 
     @PostMapping("/addAsignacion")
     public ResponseEntity<Boolean> addAsignacion(@RequestBody AsignacionCostoDto asignacionCostoDto) {
-        return new ResponseEntity<>(service.addAsignacion(asignacionCostoDto), HttpStatus.OK);
+        return ResponseEntity.ok(service.addAsignacion(asignacionCostoDto));
     }
 
     @GetMapping("/deleteDesignacion/{entregaId}")
     public ResponseEntity<Boolean> deleteAsignacion(@PathVariable Long entregaId) {
         log.debug("DeleteDesignacion - {}", entregaId);
-        return new ResponseEntity<>(service.deleteDesignacion(entregaId), HttpStatus.OK);
+        return ResponseEntity.ok(service.deleteDesignacion(entregaId));
     }
 
     @GetMapping("/depurarGastosProveedor/{proveedorId}/{geograficaId}")
     public ResponseEntity<Boolean> depurarGastosProveedor(@PathVariable Integer proveedorId, @PathVariable Integer geograficaId) {
         log.debug("DepurarGastosProveedor - {}/{}", proveedorId, geograficaId);
-        return new ResponseEntity<>(service.depurarGastosProveedor(proveedorId, geograficaId), HttpStatus.OK);
+        return ResponseEntity.ok(service.depurarGastosProveedor(proveedorId, geograficaId));
     }
 
     @GetMapping("/recalcularAsignado/{proveedorArticuloId}")
     public ResponseEntity<Void> recalcularAsignado(@PathVariable Long proveedorArticuloId) {
         log.debug("Recalcular Asignado {}", proveedorArticuloId);
         service.recalcularAsignado(proveedorArticuloId);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/cursoCargoContratado/infrastructure/web/controller/CursoCargoContratadoController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/cursoCargoContratado/infrastructure/web/controller/CursoCargoContratadoController.java
@@ -36,7 +36,6 @@ import um.tesoreria.core.hexagonal.cursoCargoContratado.infrastructure.web.mappe
 public class CursoCargoContratadoController {
 
     private final CursoCargoContratadoService service;
-
     private final GetAllCargosByPersonaUseCase getAllCargosByPersonaUseCase;
     private final CursoCargoContratadoDtoMapper cursoCargoContratadoDtoMapper;
 

--- a/src/main/java/um/tesoreria/core/kotlin/model/ArancelTipo.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ArancelTipo.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Table
 import jakarta.persistence.Id
 import jakarta.persistence.Column
+import um.tesoreria.core.util.Jsonifier
 
 @Entity
 @Table
@@ -17,6 +18,13 @@ data class ArancelTipo(
 	var descripcion: String = "",
 
 	var medioArancel: Byte = 0,
-	var arancelTipoIdCompleto: Int? = null
+	var arancelTipoIdCompleto: Int? = null,
+	var habilitado: Byte = 0
 
-) : Auditable()
+) : Auditable() {
+
+	fun jsonify(): String {
+		return Jsonifier.builder(this).build()
+	}
+
+}

--- a/src/main/java/um/tesoreria/core/repository/ArancelTipoRepository.java
+++ b/src/main/java/um/tesoreria/core/repository/ArancelTipoRepository.java
@@ -3,8 +3,10 @@
  */
 package um.tesoreria.core.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import um.tesoreria.core.kotlin.model.ArancelTipo;
@@ -14,6 +16,8 @@ import um.tesoreria.core.kotlin.model.ArancelTipo;
  *
  */
 public interface ArancelTipoRepository extends JpaRepository<ArancelTipo, Integer> {
+
+	List<ArancelTipo> findAllByHabilitado(Byte habilitado, Sort sort);
 
 	Optional<ArancelTipo> findByArancelTipoId(Integer arancelTipoId);
 

--- a/src/main/java/um/tesoreria/core/service/ArancelTipoService.java
+++ b/src/main/java/um/tesoreria/core/service/ArancelTipoService.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -23,16 +24,18 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class ArancelTipoService {
 
-	@Resource
-	private ArancelTipoRepository repository;
-
-	@Resource
-	private ArancelTipoLectivoRepository arancelTipoLectivoRepository;
+	private final ArancelTipoRepository repository;
+	private final ArancelTipoLectivoRepository arancelTipoLectivoRepository;
 
 	public List<ArancelTipo> findAll() {
 		return repository.findAll(Sort.by("arancelTipoId").ascending());
+	}
+
+	public List<ArancelTipo> findAllHabilitados() {
+		return repository.findAllByHabilitado((byte) 1, Sort.by("arancelTipoId").ascending());
 	}
 
 	public List<ArancelTipoLectivo> findAllByLectivoId(Integer lectivoId) {
@@ -60,16 +63,19 @@ public class ArancelTipoService {
 
 	public ArancelTipo add(ArancelTipo arancelTipo) {
 		arancelTipo = repository.save(arancelTipo);
-		log.debug("ArancelTipo -> " + arancelTipo);
+		log.debug("ArancelTipo added -> " + arancelTipo.jsonify());
 		return arancelTipo;
 	}
 
 	public ArancelTipo update(ArancelTipo newArancelTipo, Integer arancelTipoId) {
+		log.debug("ArancelTipo new -> {}", newArancelTipo.jsonify());
 		return repository.findByArancelTipoId(arancelTipoId).map(arancelTipo -> {
-			arancelTipo = new ArancelTipo(newArancelTipo.getArancelTipoId(), newArancelTipo.getDescripcion(),
-					newArancelTipo.getMedioArancel(), newArancelTipo.getArancelTipoIdCompleto());
+			arancelTipo.setDescripcion(newArancelTipo.getDescripcion());
+			arancelTipo.setMedioArancel(newArancelTipo.getMedioArancel());
+			arancelTipo.setArancelTipoIdCompleto(newArancelTipo.getArancelTipoIdCompleto());
+			arancelTipo.setHabilitado(newArancelTipo.getHabilitado());
 			arancelTipo = repository.save(arancelTipo);
-			log.debug("ArancelTipo -> " + arancelTipo);
+			log.debug("ArancelTipo updated -> " + arancelTipo.jsonify());
 			return arancelTipo;
 		}).orElseThrow(() -> new ArancelTipoException(arancelTipoId));
 	}

--- a/src/main/java/um/tesoreria/core/service/facade/CostoService.java
+++ b/src/main/java/um/tesoreria/core/service/facade/CostoService.java
@@ -163,6 +163,7 @@ public class CostoService {
             for (EntregaDetalle entregaDetalle : entregaDetalleService.findAllByEntregaId(entregaId)) {
                 log.debug("EntregaDetalle in deleteDesignacion -> {}", entregaDetalle.jsonify());
                 entrega = entregaDetalle.getEntrega();
+                assert entrega != null;
                 trackId = entrega.getTrackId();
                 log.debug("Entrega in deleteDesignacion -> {}", entrega.jsonify());
                 if (entregaDetalle.getProveedorArticulo() != null) {


### PR DESCRIPTION
Closes #217

## Descripción
Se implementa nuevo endpoint `/habilitados` para obtener tipos de arancel habilitados, junto con refactor de inyección de dependencias usando `@RequiredArgsConstructor` de Lombok.

## Cambios Realizados
- **feat(api):** Nuevo endpoint `GET /habilitados` en ArancelTipoController
  - Nuevo método `findAllHabilitados()` en ArancelTipoService
  - Nuevo método `findAllByHabilitado()` en ArancelTipoRepository
  - Retorna solo registros con campo `habilitado = 1`
- **refactor(service):** Migración a inyección por constructor con `@RequiredArgsConstructor` en ArancelTipoService
  - Reemplazo de `@Resource` por campos `final` + constructor Lombok
- **refactor(controller):** Uso de `ResponseEntity.ok()` en lugar de `new ResponseEntity<>()` en CostoController
- **refactor(model):** Agregado campo `habilitado` (Byte) y método `jsonify()` en ArancelTipo.kt
- **fix(validation):** Agregado `assert` en CostoService para validación de objeto Entrega

## Verificación
- Compilación exitosa con Maven
- Tests unitarios existentes pasan
- Endpoint probando manualmente con GET /aranceltipo/habilitados
