### PR TITLE
chore(deps): actualizar dependencias a versión 3.5.2

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -105,4 +105,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -54,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -75,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.2] - 2026-04-04
+### Changed
+- chore(deps): Actualización de Spring Boot de 4.0.2 a 4.0.5
+- chore(deps): Actualización de Kotlin de 2.3.10 a 2.3.20
+- chore(deps): Actualización de log4j2 de 4.0.2 a 4.0.5
+- chore(deps): Actualización de springdoc-openapi de 3.0.1 a 3.0.2
+- chore(deps): Actualización de openpdf de 3.0.0 a 3.0.3
+- chore(deps): Actualización de json-path de 2.10.0 a 3.0.0
+- chore(ci): Actualización de GitHub Actions (checkout v4→v6, setup-java v4→v5, cache v4→v5, login-action v3→v4, metadata-action v5→v6, buildx-action v3→v4, build-push-action v6→v7, deploy-pages v4→v5)
+- feat(deps): Nueva dependencia commons-fileupload 1.6.0
+
+> Basado en análisis de `git diff HEAD` (cambios staged) y `pom.xml`.
+
 ## [3.5.1] - 2026-03-14
 ### Changed
 - refactor(model): Migración de FacturacionElectronica de Kotlin a Java

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.2.
 
-**Versión actual (SemVer): 3.5.1**
+**Versión actual (SemVer): 3.5.2**
+
+## Novedades 3.5.2 (verificado en código)
+- chore(deps): Actualización de Spring Boot de 4.0.2 a 4.0.5
+- chore(deps): Actualización de Kotlin de 2.3.10 a 2.3.20
+- chore(deps): Actualización de log4j2 de 4.0.2 a 4.0.5
+- chore(deps): Actualización de springdoc-openapi de 3.0.1 a 3.0.2
+- chore(deps): Actualización de openpdf de 3.0.0 a 3.0.3
+- chore(deps): Actualización de json-path de 2.10.0 a 3.0.0
+- chore(ci): Actualización de GitHub Actions (checkout v4→v6, setup-java v4→v5, cache v4→v5, login-action v3→v4, metadata-action v5→v6, buildx-action v3→v4, build-push-action v6→v7, deploy-pages v4→v5)
+- feat(deps): Nueva dependencia commons-fileupload 1.6.0
 
 ## Novedades 3.5.1 (verificado en código)
 - refactor(model): Migración de FacturacionElectronica de Kotlin a Java
@@ -211,15 +221,16 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.2
 - Docker (opcional)
 
 ## Versiones de Dependencias Principales (verificado en `pom.xml`)
-- Spring Boot: 4.0.2
+- Spring Boot: 4.0.5
 - Spring Cloud: 2025.1.0
-- Kotlin: 2.3.10
+- Kotlin: 2.3.20
 - MySQL Connector: 9.6.0
-- SpringDoc OpenAPI: 3.0.1
+- SpringDoc OpenAPI: 3.0.2
 - Apache POI: 5.5.1
-- OpenPDF: 3.0.0
+- OpenPDF: 3.0.3
 - ModelMapper: 3.2.6
 - Guava: 33.5.0-jre
+- json-path: 3.0.0
 
 ## Optimizaciones de Rendimiento (verificado en código)
 - **Computación paralela**: La función `calculateDeuda` utiliza `CompletableFuture` para ejecutar consultas en paralelo
@@ -459,11 +470,11 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 # UM Tesorería Core Service
 
 [![Java](https://img.shields.io/badge/Java-25-blue.svg)](https://www.java.com/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.5-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen.svg)](https://spring.io/projects/spring-cloud)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.10-purple.svg)](https://kotlinlang.org/)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.5.1-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.5.2-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)
@@ -483,9 +494,9 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 
 ## Tecnologías Utilizadas
 - Java 25
-- Spring Boot 4.0.2
+- Spring Boot 4.0.5
 - Spring Cloud 2025.1.0
-- Kotlin 2.3.10
+- Kotlin 2.3.20
 - JPA/Hibernate
 - ModelMapper
 - MySQL

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.5.0**
+**Versión actual del servicio: 3.5.2**
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.5</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.5.1</version>
+    <version>3.5.2</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>
         <java.version>25</java.version>
-        <kotlin.version>2.3.10</kotlin.version>
+        <kotlin.version>2.3.20</kotlin.version>
         <spring-cloud.version>2025.1.0</spring-cloud.version>
         <sonar.organization>um-services</sonar.organization>
         <sonar.projectKey>UM-services_UM.tesoreria.core-service</sonar.projectKey>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.5</version>
         </dependency>
         <dependency>
             <groupId>com.mysql</groupId>
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.10.0</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -176,6 +176,11 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>1.6.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Closes #223

## Descripción

Actualización de dependencias del proyecto a versión 3.5.2, incluyendo Spring Boot, Kotlin y GitHub Actions.

## Cambios Realizados

### GitHub Actions (`.github/workflows/`)

**generate-docs.yml:**
- `actions/checkout@v4` → `@v6`
- `actions/setup-java@v4` → `@v5` (Java 25, Temurin)
- `actions/deploy-pages@v4` → `@v5`

**maven.yml:**
- `actions/checkout@v4` → `@v6`
- `actions/setup-java@v4` → `@v5` (Java 25, Temurin)
- `actions/cache@v4` → `@v5`
- `docker/login-action@v3` → `@v4`
- `docker/metadata-action@v5` → `@v6`
- `docker/setup-buildx-action@v3` → `@v4`
- `docker/build-push-action@v6` → `@v7`

### Dependencias Maven (`pom.xml`)

**Actualizadas:**
- Spring Boot: `4.0.2` → `4.0.5`
- Kotlin: `2.3.10` → `2.3.20`
- log4j2: `4.0.2` → `4.0.5`
- springdoc-openapi: `3.0.1` → `3.0.2`
- openpdf: `3.0.0` → `3.0.3`
- json-path: `2.10.0` → `3.0.0`

**Nueva dependencia:**
- commons-fileupload: `1.6.0`

### Documentación Actualizada

- `CHANGELOG.md`: Añadida entrada para versión 3.5.2
- `README.md`: Actualizadas versiones de dependencias y badge
- `docs/README.md`: Actualizada versión a 3.5.2

## Verificación

- [ ] Compilación exitosa con Maven (`mvn clean compile`)
- [ ] Tests unitarios pasando (`mvn test`)
- [ ] Build de GitHub Actions pasando
