### PR TITLE
feat(articulo): enrich article responses with Cuenta object, refactors and dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.16.0] - 2026-05-07
+### Added
+- feat(articulo): Enriquecimiento de respuestas con objeto `Cuenta` vía `CuentaService`
+  - Nuevo campo `Cuenta cuenta` en `ArticuloSearchResponse` para incluir datos de cuenta asociada
+  - Nuevo campo `articuloId` en `ArticuloRequest` para especificar ID en creación
+  - Los endpoints `GET /articulo/{id}`, `POST /articulo/search` y `GET /articulo/page` ahora resuelven y adjuntan el objeto `Cuenta` completo cuando `numeroCuenta` está presente
+
+### Changed
+- refactor(articulo): Cambio de `@Data` a `@Getter`/`@Setter` en `Articulo` para mayor control de mutabilidad
+- refactor(articulo): Renombrado de campo `cuenta` a `numeroCuenta` en `ArticuloSearch`, `ArticuloKey`, `ArticuloSearchResponse` y mappers para claridad semántica
+  - Compatibilidad BD asegurada vía `@Column(name = "cuenta")` en `ArticuloKey`
+- refactor(articulo): Migración de `@Data` a `@Getter`/`@Setter` + `@Serial` en `ArticuloKey`
+- refactor(dto): Uso de importación `OffsetDateTime` en lugar de FQCN en `ArticuloSearch` y `ArticuloSearchResponse`
+
+> Basado en análisis profundo de `git diff HEAD` (8 archivos modificados, +72/-27 líneas).
+
 ## [3.15.0] - 2026-05-07
 ### Added
 - feat(facturaPendiente): Nuevo módulo FacturaPendiente con arquitectura hexagonal completa

--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.6.
 
-**Versión actual (SemVer): 3.15.0**
+**Versión actual (SemVer): 3.16.0**
+
+## Novedades 3.16.0 (verificado en código)
+- feat(articulo): Enriquecimiento de respuestas con objeto `Cuenta` vía `CuentaService`
+  - Nuevo campo `Cuenta cuenta` en `ArticuloSearchResponse` para incluir datos de cuenta asociada
+  - Nuevo campo `articuloId` en `ArticuloRequest` para especificar ID en creación
+  - Los endpoints `GET /articulo/{id}`, `POST /articulo/search` y `GET /articulo/page` ahora resuelven y adjuntan el objeto `Cuenta` completo
+- refactor(articulo): Cambio de `@Data` a `@Getter`/`@Setter` en `Articulo` para mayor control de mutabilidad
+- refactor(articulo): Renombrado de campo `cuenta` a `numeroCuenta` en `ArticuloSearch`, `ArticuloKey`, `ArticuloSearchResponse` y mappers
+  - Compatibilidad BD asegurada vía `@Column(name = "cuenta")`
+- refactor(dto): Uso de importación `OffsetDateTime` en lugar de FQCN en `ArticuloSearch` y `ArticuloSearchResponse`
+
+> Basado en análisis profundo de `git diff HEAD` (8 archivos modificados, +72/-27 líneas).
 
 ## Novedades 3.15.0 (verificado en código)
 - feat(facturaPendiente): Nuevo módulo FacturaPendiente con arquitectura hexagonal completa
@@ -424,7 +436,7 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.6
 ## Versiones de Dependencias Principales (verificado en `pom.xml`)
 - Spring Boot: 4.0.6
 - Spring Cloud: 2025.1.0
-- Kotlin: 2.3.20
+- Kotlin: 2.3.21
 - MySQL Connector: 9.6.0
 - SpringDoc OpenAPI: 3.0.2
 - Apache POI: 5.5.1
@@ -685,9 +697,9 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 [![Java](https://img.shields.io/badge/Java-25-blue.svg)](https://www.java.com/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.6-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen.svg)](https://spring.io/projects/spring-cloud)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-purple.svg)](https://kotlinlang.org/)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.15.0-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.16.0-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)
@@ -709,7 +721,7 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 - Java 25
 - Spring Boot 4.0.6
 - Spring Cloud 2025.1.0
-- Kotlin 2.3.20
+- Kotlin 2.3.21
 - JPA/Hibernate
 - ModelMapper
 - MySQL

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.13.0**
+**Versión actual del servicio: 3.16.0**
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -14,6 +14,8 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-proveedor.mmd`: Arquitectura hexagonal del módulo Proveedor (gestión de proveedores).
 - `hexagonal-cuenta.mmd`: Arquitectura hexagonal del módulo Cuenta (gestión de cuentas contables) - v3.8.0.
 - `hexagonal-mercadopago-context-history.mmd`: Historial de contexto de MercadoPago.
+- `hexagonal-ubicacion.mmd`: Arquitectura hexagonal del módulo Ubicacion (gestión de ubicaciones) - v3.14.0.
+- `hexagonal-ubicacionArticulo.mmd`: Arquitectura hexagonal del módulo UbicacionArticulo (gestión de ubicaciones de artículos) - v3.14.0.
 - `deployment.mmd`: Diagrama de despliegue del microservicio.
 
 ## Diagramas de Datos

--- a/docs/hexagonal-articulo.mmd
+++ b/docs/hexagonal-articulo.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo Artículo (v3.13.0)
+title: Arquitectura Hexagonal - Módulo Artículo (v3.16.0)
 ---
 
 classDiagram
@@ -29,11 +29,13 @@ classDiagram
             +BigDecimal precio
             +Byte inventariable
             +Long stockMinimo
-            +BigDecimal cuenta
+            +BigDecimal numeroCuenta
             +String tipo
             +Byte directo
             +Byte habilitado
             +String search
+            +OffsetDateTime fechaAuditoria
+            +String usuarioAuditoria
         }
 
         class ArticuloRepository {
@@ -205,6 +207,7 @@ classDiagram
             class ArticuloController {
                 -ArticuloService articuloService
                 -ArticuloDtoMapper articuloDtoMapper
+                -CuentaService cuentaService
                 +createArticulo(ArticuloRequest) ResponseEntity~ArticuloResponse~
                 +getArticuloById(Long) ResponseEntity~ArticuloResponse~
                 +getAllArticulos() ResponseEntity~List~ArticuloResponse~~
@@ -212,10 +215,11 @@ classDiagram
                 +deleteArticulo(Long) ResponseEntity~Void~
                 +getNewArticulo() ResponseEntity~ArticuloResponse~
                 +getPaginatedArticulos(int, int) ResponseEntity~PaginatedResponse~ArticuloResponse~~
-                +searchArticulos(String) ResponseEntity~List~ArticuloSearchResponse~~
+                +searchArticulos(List~String~) ResponseEntity~List~ArticuloSearchResponse~~
             }
 
             class ArticuloRequest {
+                +Long articuloId
                 +String nombre
                 +String descripcion
                 +String unidad
@@ -251,11 +255,14 @@ classDiagram
                 +BigDecimal precio
                 +Byte inventariable
                 +Long stockMinimo
-                +BigDecimal cuenta
+                +BigDecimal numeroCuenta
+                +Cuenta cuenta
                 +String tipo
                 +Byte directo
                 +Byte habilitado
                 +String search
+                +OffsetDateTime fechaAuditoria
+                +String usuarioAuditoria
             }
 
             class ArticuloDtoMapper {
@@ -263,6 +270,8 @@ classDiagram
                 +toResponse(Articulo) ArticuloResponse
                 +toSearchResponse(ArticuloSearch) ArticuloSearchResponse
             }
+
+            ArticuloController --> CuentaService : calls
         }
     }
 

--- a/docs/sequence-consulta-articulos.mmd
+++ b/docs/sequence-consulta-articulos.mmd
@@ -1,9 +1,10 @@
 ---
-title: Consulta de Artículos (Arquitectura Hexagonal v3.13.0)
+title: Consulta de Artículos (Arquitectura Hexagonal v3.16.0)
 ---
 sequenceDiagram
     participant C as Cliente
     participant Ctrl as ArticuloController
+    participant CS as CuentaService
     participant S as ArticuloService
     participant R as JpaArticuloRepositoryAdapter
     participant DB as BaseDeDatos
@@ -16,19 +17,23 @@ sequenceDiagram
     DB-->>R: Page~ArticuloEntity~
     R-->>S: PaginatedResponse~Articulo~
     S-->>Ctrl: PaginatedResponse~ArticuloResponse~
+    Ctrl->>CS: findByNumeroCuenta(numeroCuenta)
+    CS-->>Ctrl: Optional~Cuenta~
     Ctrl-->>C: ResponseEntity~PaginatedResponse~ 200 OK
 
     %% Búsqueda por criterio
-    C->>Ctrl: GET /articulo/search?criterio=nombre
-    Ctrl->>S: searchArticulos("nombre")
-    S->>R: search("nombre")
-    R->>DB: SELECT * FROM articulos WHERE nombre LIKE '%nombre%'
+    C->>Ctrl: POST /articulo/search
+    Ctrl->>S: searchArticulos(conditions)
+    S->>R: search(criterio)
+    R->>DB: SELECT * FROM articulos WHERE condiciones
     DB-->>R: List~ArticuloSearch~
     R-->>S: List~ArticuloSearch~
     S-->>Ctrl: List~ArticuloSearchResponse~
+    Ctrl->>CS: findByNumeroCuenta(numeroCuenta)
+    CS-->>Ctrl: Optional~Cuenta~
     Ctrl-->>C: ResponseEntity~List~ArticuloSearchResponse~~ 200 OK
 
-    %% Consulta general (legacy)
+    %% Consulta general
     C->>Ctrl: GET /articulo/
     Ctrl->>S: getAllArticulos()
     S->>R: findAll()

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.15.0</version>
+    <version>3.16.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/hexagonal/articulo/domain/model/Articulo.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/articulo/domain/model/Articulo.java
@@ -1,13 +1,11 @@
 package um.tesoreria.core.hexagonal.articulo.domain.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import um.tesoreria.core.hexagonal.cuenta.domain.model.Cuenta;
 import java.math.BigDecimal;
 
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/um/tesoreria/core/hexagonal/articulo/domain/model/ArticuloSearch.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/articulo/domain/model/ArticuloSearch.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 
 @Data
 @Builder
@@ -18,11 +19,11 @@ public class ArticuloSearch {
     private BigDecimal precio;
     private Byte inventariable;
     private Long stockMinimo;
-    private BigDecimal cuenta;
+    private BigDecimal numeroCuenta;
     private String tipo;
     private Byte directo;
     private Byte habilitado;
     private String search;
-    private java.time.OffsetDateTime fechaAuditoria;
+    private OffsetDateTime fechaAuditoria;
     private String usuarioAuditoria;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/persistence/entity/ArticuloKey.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/persistence/entity/ArticuloKey.java
@@ -3,9 +3,11 @@
  */
 package um.tesoreria.core.hexagonal.articulo.infrastructure.persistence.entity;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -31,7 +33,8 @@ import um.tesoreria.core.kotlin.model.Auditable;
 @AllArgsConstructor
 public class ArticuloKey extends Auditable implements Serializable {
 
-	private static final long serialVersionUID = -8530914093311572829L;
+	@Serial
+    private static final long serialVersionUID = -8530914093311572829L;
 
 	@Id
 	private Long articuloId;
@@ -42,7 +45,9 @@ public class ArticuloKey extends Auditable implements Serializable {
 	private BigDecimal precio;
 	private Byte inventariable;
 	private Long stockMinimo;
-	private BigDecimal cuenta;
+
+	@Column(name = "cuenta")
+	private BigDecimal numeroCuenta;
 	private String tipo;
 	private Byte directo;
 	private Byte habilitado;

--- a/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/persistence/mapper/ArticuloMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/persistence/mapper/ArticuloMapper.java
@@ -61,7 +61,7 @@ public class ArticuloMapper {
                 .precio(entity.getPrecio())
                 .inventariable(entity.getInventariable())
                 .stockMinimo(entity.getStockMinimo())
-                .cuenta(entity.getCuenta())
+                .numeroCuenta(entity.getNumeroCuenta())
                 .tipo(entity.getTipo())
                 .directo(entity.getDirecto())
                 .habilitado(entity.getHabilitado())

--- a/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/web/controller/ArticuloController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/web/controller/ArticuloController.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import um.tesoreria.core.hexagonal.articulo.application.service.ArticuloService;
+import um.tesoreria.core.hexagonal.cuenta.application.service.CuentaService;
 import um.tesoreria.core.hexagonal.articulo.domain.model.Articulo;
 import um.tesoreria.core.hexagonal.articulo.infrastructure.web.dto.ArticuloRequest;
 import um.tesoreria.core.hexagonal.articulo.infrastructure.web.dto.ArticuloSearchResponse;
@@ -23,6 +24,7 @@ public class ArticuloController {
 
     private final ArticuloService articuloService;
     private final ArticuloDtoMapper articuloDtoMapper;
+    private final CuentaService cuentaService;
     
 
     @PostMapping("/")
@@ -35,14 +37,28 @@ public class ArticuloController {
     @GetMapping("/{id}")
     public ResponseEntity<ArticuloResponse> getArticuloById(@PathVariable Long id) {
         return articuloService.getArticuloById(id)
-                .map(articulo -> new ResponseEntity<>(articuloDtoMapper.toResponse(articulo), HttpStatus.OK))
+                .map(domain -> {
+                    ArticuloResponse dto = articuloDtoMapper.toResponse(domain);
+                    if (dto.getNumeroCuenta() != null) {
+                        cuentaService.findByNumeroCuenta(dto.getNumeroCuenta())
+                                .ifPresent(dto::setCuenta);
+                    }
+                    return new ResponseEntity<>(dto, HttpStatus.OK);
+                })
                 .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }
 
     @PostMapping("/search")
     public ResponseEntity<List<ArticuloSearchResponse>> findByStrings(@RequestBody List<String> conditions) {
         List<ArticuloSearchResponse> responses = articuloService.searchArticulos(conditions).stream()
-                .map(articuloDtoMapper::toSearchResponse)
+                .map(domain -> {
+                    ArticuloSearchResponse dto = articuloDtoMapper.toSearchResponse(domain);
+                    if (dto.getNumeroCuenta() != null) {
+                        cuentaService.findByNumeroCuenta(dto.getNumeroCuenta())
+                                .ifPresent(dto::setCuenta);
+                    }
+                    return dto;
+                })
                 .collect(Collectors.toList());
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }
@@ -64,7 +80,14 @@ public class ArticuloController {
         PaginatedResponse<Articulo> domainPage = articuloService.getPaginatedArticulosByTipo(tipo, page, size);
         
         List<ArticuloResponse> responseList = domainPage.getData().stream()
-                .map(articuloDtoMapper::toResponse)
+                .map(domain -> {
+                    ArticuloResponse dto = articuloDtoMapper.toResponse(domain);
+                    if (dto.getNumeroCuenta() != null) {
+                        cuentaService.findByNumeroCuenta(dto.getNumeroCuenta())
+                                .ifPresent(dto::setCuenta);
+                    }
+                    return dto;
+                })
                 .collect(Collectors.toList());
                 
         PaginatedResponse<ArticuloResponse> paginatedResponse = new PaginatedResponse<>(

--- a/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/web/dto/ArticuloRequest.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/web/dto/ArticuloRequest.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 
 @Data
 public class ArticuloRequest {
+    private Long articuloId;
     private String nombre;
     private String descripcion;
     private String unidad;

--- a/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/web/dto/ArticuloSearchResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/web/dto/ArticuloSearchResponse.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
+import um.tesoreria.core.hexagonal.cuenta.domain.model.Cuenta;
+import java.time.OffsetDateTime;
 
 @Data
 @Builder
@@ -18,11 +20,12 @@ public class ArticuloSearchResponse {
     private BigDecimal precio;
     private Byte inventariable;
     private Long stockMinimo;
-    private BigDecimal cuenta;
+    private BigDecimal numeroCuenta;
+    private Cuenta cuenta;
     private String tipo;
     private Byte directo;
     private Byte habilitado;
     private String search;
-    private java.time.OffsetDateTime fechaAuditoria;
+    private OffsetDateTime fechaAuditoria;
     private String usuarioAuditoria;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/web/mapper/ArticuloDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/web/mapper/ArticuloDtoMapper.java
@@ -13,6 +13,7 @@ public class ArticuloDtoMapper {
     public Articulo toDomain(ArticuloRequest request) {
         if (request == null) return null;
         return Articulo.builder()
+                .articuloId(request.getArticuloId())
                 .nombre(request.getNombre())
                 .descripcion(request.getDescripcion())
                 .unidad(request.getUnidad())
@@ -36,11 +37,10 @@ public class ArticuloDtoMapper {
                 .precio(domain.getPrecio())
                 .inventariable(domain.getInventariable())
                 .stockMinimo(domain.getStockMinimo())
-                .numeroCuenta(domain.getNumeroCuenta())
                 .tipo(domain.getTipo())
                 .directo(domain.getDirecto())
                 .habilitado(domain.getHabilitado())
-                .cuenta(domain.getCuenta())
+                .numeroCuenta(domain.getNumeroCuenta())
                 .build();
     }
 
@@ -54,7 +54,7 @@ public class ArticuloDtoMapper {
                 .precio(domain.getPrecio())
                 .inventariable(domain.getInventariable())
                 .stockMinimo(domain.getStockMinimo())
-                .cuenta(domain.getCuenta())
+                .numeroCuenta(domain.getNumeroCuenta())
                 .tipo(domain.getTipo())
                 .directo(domain.getDirecto())
                 .habilitado(domain.getHabilitado())


### PR DESCRIPTION
Closes #227

## Descripción
Enriquecimiento de respuestas del módulo Artículo con datos de `Cuenta` vía `CuentaService`, refactors de código (renombrado `cuenta` → `numeroCuenta`, migración `@Data` → `@Getter`/`@Setter`) y actualización de dependencias (Kotlin 2.3.20 → 2.3.21, versión proyecto 3.15.0 → 3.16.0).

## Cambios Realizados
- [x] **feat(articulo):** Nuevo campo `Cuenta cuenta` en `ArticuloSearchResponse` para incluir datos de cuenta asociada
- [x] **feat(articulo):** Nuevo campo `articuloId` en `ArticuloRequest` para especificar ID en creación
- [x] **feat(controller):** Endpoints `GET /articulo/{id}`, `POST /articulo/search` y `GET /articulo/page` ahora resuelven y adjuntan el objeto `Cuenta` completo vía `CuentaService`
- [x] **refactor(articulo):** Cambio de `@Data` a `@Getter`/`@Setter` en `Articulo`
- [x] **refactor(articulo):** Renombrado de campo `cuenta` → `numeroCuenta` en `ArticuloSearch`, `ArticuloKey`, `ArticuloSearchResponse` y mappers (compatibilidad BD vía `@Column(name = "cuenta")`)
- [x] **refactor(articulo):** Migración de `@Data` a `@Getter`/`@Setter` + `@Serial` en `ArticuloKey`
- [x] **refactor(dto):** Uso de importación `OffsetDateTime` en lugar de FQCN en `ArticuloSearch` y `ArticuloSearchResponse`
- [x] **deps:** Kotlin 2.3.20 → 2.3.21, bump versión proyecto 3.15.0 → 3.16.0
- [x] **docs:** Actualización de diagramas Mermaid, `CHANGELOG.md`, `README.md` y `docs/README.md`

## Verificación
- Los cambios son retrocompatibles a nivel BD (`@Column(name = "cuenta")` preserva el esquema existente)
- Compilación verificada con Maven
- 14 archivos modificados (+110/-35 líneas)