### PR TITLE
fix(chequeraCuota): Excluir registros soft-deleted en consulta de cuotas filtradas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.19.1] - 2026-05-18
+### Fixed
+- fix(chequeraCuota): Agregado filtro `baja=0` en consulta de cuotas filtradas para excluir registros soft-deleted
+  - Nueva query `findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndBajaAndImporte1GreaterThan` en `ChequeraCuotaRepository`
+  - `ChequeraCuotaService.findAllCuotasFiltradas()` actualizado para usar la nueva query con `baja = (byte) 0`
+  - La query anterior sin filtro `baja` podía retornar registros con soft-delete, causando resultados inconsistentes
+  - Método anterior comentado y reemplazado por nueva implementación con filtro de baja
+
+> Basado en análisis profundo de `git diff HEAD` (2 archivos modificados, +12/-2 líneas).
+
 ## [3.19.0] - 2026-05-13
 ### Added
 - feat(contrato): Nuevo módulo Contrato con arquitectura hexagonal completa

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.6.
 
-**Versión actual (SemVer): 3.19.0**
+**Versión actual (SemVer): 3.19.1**
+
+## Novedades 3.19.1 (verificado en código)
+- fix(chequeraCuota): Agregado filtro `baja=0` en consulta de cuotas filtradas para excluir registros soft-deleted
+  - Nueva query `findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndBajaAndImporte1GreaterThan` en `ChequeraCuotaRepository`
+  - `ChequeraCuotaService` actualizado para usar la nueva query con `baja = (byte) 0`
+  - Previene retorno de registros con soft-delete en resultados de cuotas
+
+> Basado en análisis profundo de `git diff HEAD` (2 archivos modificados, +12/-2 líneas).
 
 ## Novedades 3.19.0 (verificado en código)
 - feat(contrato): Nuevo módulo Contrato con arquitectura hexagonal completa
@@ -779,7 +787,7 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen.svg)](https://spring.io/projects/spring-cloud)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.19.0-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.19.1-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.19.0**
+**Versión actual del servicio: 3.19.1**
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,9 +27,9 @@
     <div id="hexagonal-mercadopago" class="section"></div>
     <div id="hexagonal-dependencia" class="section"></div>
     <div id="hexagonal-facturaPendiente" class="section"></div>
+    <div id="hexagonal-facultad" class="section"></div>
     <div id="hexagonal-contrato" class="section"></div>
   <div id="dependencies-diagram" class="section"></div>
-  <div id="sequence-diagram" class="section"></div>
   <div id="erd-diagram" class="section"></div>
   <div id="deployment-diagram" class="section"></div>
   <div id="sequence-diagrams" class="section"></div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -90,6 +90,7 @@ const diagrams = [
   { id: 'hexagonal-mercadopago', file: 'hexagonal-mercadopago-context-history.mmd', title: '🔷 Arquitectura Hexagonal - MercadoPago Context History' },
   { id: 'hexagonal-dependencia', file: 'hexagonal-dependencia.mmd', title: '🔷 Arquitectura Hexagonal - Dependencia' },
   { id: 'hexagonal-facturaPendiente', file: 'hexagonal-facturaPendiente.mmd', title: '🔷 Arquitectura Hexagonal - Factura Pendiente' },
+  { id: 'hexagonal-facultad', file: 'hexagonal-facultad.mmd', title: '🔷 Arquitectura Hexagonal - Facultad' },
   { id: 'hexagonal-contrato', file: 'hexagonal-contrato.mmd', title: '🔷 Arquitectura Hexagonal - Contrato' },
   { id: 'dependencies-diagram', file: 'dependencies.mmd', title: '📦 Diagrama de Dependencias' },
   { id: 'erd-diagram', file: 'entities.mmd', title: '🗃️ Diagrama de Entidad-Relación (Simplificado)' },

--- a/src/main/java/um/tesoreria/core/repository/ChequeraCuotaRepository.java
+++ b/src/main/java/um/tesoreria/core/repository/ChequeraCuotaRepository.java
@@ -36,6 +36,10 @@ public interface ChequeraCuotaRepository extends JpaRepository<ChequeraCuota, Lo
 			Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer alternativaId, BigDecimal importe1,
 			Sort sort);
 
+	List<ChequeraCuota> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndBajaAndImporte1GreaterThan(
+			Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer alternativaId, Byte baja, BigDecimal importe1,
+			Sort sort);
+
 	List<ChequeraCuota> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndProductoIdAndAlternativaIdAndBaja(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Byte baja);
 
 	List<ChequeraCuota> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndProductoIdAndAlternativaIdAndPagado(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Byte pagado);

--- a/src/main/java/um/tesoreria/core/service/ChequeraCuotaService.java
+++ b/src/main/java/um/tesoreria/core/service/ChequeraCuotaService.java
@@ -104,9 +104,15 @@ public class ChequeraCuotaService {
 
         // Encuentra todas las cuotas filtradas por facultad, tipo de chequera, serie de
         // chequera, alternativa y con importe > 0, con ordenación
+//        List<ChequeraCuota> cuotasFiltradas = repository
+//                .findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndImporte1GreaterThan(
+//                        facultadId, tipoChequeraId, chequeraSerieId, alternativaId, BigDecimal.ZERO,
+//                        Sort.by("vencimiento1").ascending()
+//                                .and(Sort.by("productoId").ascending().and(Sort.by("cuotaId").ascending())));
+
         List<ChequeraCuota> cuotasFiltradas = repository
-                .findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndImporte1GreaterThan(
-                        facultadId, tipoChequeraId, chequeraSerieId, alternativaId, BigDecimal.ZERO,
+                .findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndBajaAndImporte1GreaterThan(
+                        facultadId, tipoChequeraId, chequeraSerieId, alternativaId, (byte) 0, BigDecimal.ZERO,
                         Sort.by("vencimiento1").ascending()
                                 .and(Sort.by("productoId").ascending().and(Sort.by("cuotaId").ascending())));
 


### PR DESCRIPTION
Closes #237

## Descripción
Se ha corregido un error en la consulta de cuotas filtradas donde se incluían registros eliminados lógicamente (soft-deleted). Además, se ha actualizado la versión del servicio a la **3.19.1** y se han realizado mejoras en la documentación de arquitectura.

## Cambios Realizados
- **Core (Lógica de Negocio):**
  - `ChequeraCuotaRepository`: Adición del método `findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaIdAndBajaAndImporte1GreaterThan` para permitir el filtrado por el campo `baja`.
  - `ChequeraCuotaService`: Actualización de la lógica en `findAllCuotasFiltradas` para invocar el nuevo método del repositorio, pasando explícitamente `baja = 0`. Se mantuvo comentada la implementación anterior para referencia.
- **Documentación y Versiones:**
  - Actualización de `CHANGELOG.md` y `README.md` a la versión `3.19.1`.
  - Inclusión del diagrama de arquitectura hexagonal para el módulo de **Facultad** en el portal de documentación (`docs/index.html` y `docs/script.js`).
  - Sincronización de la versión en `docs/README.md`.

## Verificación
- [x] Verificación manual de la consulta de cuotas filtradas confirmando la exclusión de registros con `baja = 1`.
- [x] Verificación de la renderización del nuevo diagrama en el portal de documentación local.
- [x] Validación de la estructura de Conventional Commits en los mensajes de commit.
