### PR TITLE
refactor(persona): rename personaEntity field to persona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.20.0] - 2026-05-20
+### Changed
+- refactor(contrato): Renombrado de campo `personaEntity` a `persona` en `ContratoEntity`
+  - Campo de relación `@ManyToOne` renombrado de `personaEntity` a `persona` para consistencia de nomenclatura
+  - Actualización de `SheetService` para usar `getPersona()` en lugar de `getPersonaEntity()` al generar hojas de cálculo de contratos
+- refactor(chequeraSerie): Renombrado de campo `personaEntity` a `persona` en vistas `ChequeraSerieAlta` y `ChequeraSerieAltaFull`
+  - Campo de relación renombrado en ambos modelos Kotlin para consistencia con `ContratoEntity`
+  - `ChequeraSerieAltaFullService` actualizado con null-safe `Objects.requireNonNull(getPersona())` en logging
+
+> Basado en análisis profundo de `git diff HEAD` (5 archivos modificados, +8/-7 líneas).
+
 ## [3.19.1] - 2026-05-18
 ### Fixed
 - fix(chequeraCuota): Agregado filtro `baja=0` en consulta de cuotas filtradas para excluir registros soft-deleted

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.6.
 
-**Versión actual (SemVer): 3.19.1**
+**Versión actual (SemVer): 3.20.0**
+
+## Novedades 3.20.0 (verificado en código)
+- refactor(contrato): Renombrado de campo `personaEntity` a `persona` en `ContratoEntity`
+  - Campo de relación `@ManyToOne` renombrado para consistencia de nomenclatura
+  - `SheetService` actualizado para usar `getPersona()` en generación de hojas de cálculo
+- refactor(chequeraSerie): Renombrado de campo `personaEntity` a `persona` en `ChequeraSerieAlta` y `ChequeraSerieAltaFull`
+  - Consistencia de nomenclatura con `ContratoEntity`
+  - `ChequeraSerieAltaFullService` actualizado con null-safe `Objects.requireNonNull()`
+
+> Basado en análisis profundo de `git diff HEAD` (5 archivos modificados, +8/-7 líneas).
 
 ## Novedades 3.19.1 (verificado en código)
 - fix(chequeraCuota): Agregado filtro `baja=0` en consulta de cuotas filtradas para excluir registros soft-deleted
@@ -787,7 +797,7 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen.svg)](https://spring.io/projects/spring-cloud)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.19.1-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.20.0-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.19.1**
+**Versión actual del servicio: 3.20.0**
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.19.0</version>
+    <version>3.20.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/hexagonal/contrato/infrastructure/persistence/entity/ContratoEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contrato/infrastructure/persistence/entity/ContratoEntity.java
@@ -127,7 +127,7 @@ public class ContratoEntity extends Auditable implements Serializable {
             @JoinColumn(name = "con_per_id", referencedColumnName = "per_id", insertable = false, updatable = false),
             @JoinColumn(name = "con_doc_id", referencedColumnName = "per_doc_id", insertable = false, updatable = false)
     })
-    private PersonaEntity personaEntity = null;
+    private PersonaEntity persona;
 
     public String jsonify() {
         return Jsonifier.builder(this).build();

--- a/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraSerieAlta.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraSerieAlta.kt
@@ -90,7 +90,7 @@ data class ChequeraSerieAlta(
         JoinColumn(name = "chs_per_id", referencedColumnName = "per_id", insertable = false, updatable = false),
         JoinColumn(name = "chs_doc_id", referencedColumnName = "per_doc_id", insertable = false, updatable = false)
     )
-    var personaEntity: PersonaEntity? = null,
+    var persona: PersonaEntity? = null,
 
     @OneToOne
     @JoinColumns(

--- a/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraSerieAltaFull.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraSerieAltaFull.kt
@@ -55,7 +55,7 @@ data class ChequeraSerieAltaFull(
         JoinColumn(name = "personaId", referencedColumnName = "per_id", insertable = false, updatable = false),
         JoinColumn(name = "documentoId", referencedColumnName = "per_doc_id", insertable = false, updatable = false)
     )
-    var personaEntity: PersonaEntity? = null,
+    var persona: PersonaEntity? = null,
 
     @OneToOne
     @JoinColumns(

--- a/src/main/java/um/tesoreria/core/service/facade/SheetService.java
+++ b/src/main/java/um/tesoreria/core/service/facade/SheetService.java
@@ -1231,9 +1231,9 @@ public class SheetService {
 
         for (ContratoPeriodo contratoPeriodo : contratoPeriodoService.findAllByPeriodo(anho, mes)) {
             row = sheet.createRow(++fila);
-            this.setCellBigDecimal(row, 0, contratoPeriodo.getContrato().getPersonaEntity().getPersonaId(), styleNormal);
-            this.setCellString(row, 1, contratoPeriodo.getContrato().getPersonaEntity().getApellidoNombre(), styleNormal);
-            this.setCellString(row, 2, contratoPeriodo.getContrato().getPersonaEntity().getCuit(), styleNormal);
+            this.setCellBigDecimal(row, 0, contratoPeriodo.getContrato().getPersona().getPersonaId(), styleNormal);
+            this.setCellString(row, 1, contratoPeriodo.getContrato().getPersona().getApellidoNombre(), styleNormal);
+            this.setCellString(row, 2, contratoPeriodo.getContrato().getPersona().getCuit(), styleNormal);
             this.setCellString(row, 3, contratoPeriodo.getContrato().getFacultad().getNombre(), styleNormal);
             this.setCellString(row, 4, contratoPeriodo.getContrato().getGeografica().getNombre(), styleNormal);
             this.setCellOffsetDateTime(row, 5, contratoPeriodo.getContrato().getDesde(), styleDate);

--- a/src/main/java/um/tesoreria/core/service/view/ChequeraSerieAltaFullService.java
+++ b/src/main/java/um/tesoreria/core/service/view/ChequeraSerieAltaFullService.java
@@ -12,6 +12,7 @@ import um.tesoreria.core.service.ChequeraCuotaService;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @Slf4j
@@ -27,7 +28,7 @@ public class ChequeraSerieAltaFullService {
     public List<ChequeraSerieAltaFull> findAllByLectivoIdAndFacultadIdAndGeograficaIdAndTipoChequeraId(Integer lectivoId, Integer facultadId, Integer geograficaId, Integer tipoChequeraId, OffsetDateTime fechaDesdePrimerVencimiento, ChequeraCuotaService chequeraCuotaService) {
         List<ChequeraSerieAltaFull> chequeras = new ArrayList<>();
         for (ChequeraSerieAltaFull chequeraSerieAltaFull : repository.findAllByLectivoIdAndFacultadIdAndGeograficaIdAndTipoChequeraId(lectivoId, facultadId, geograficaId, tipoChequeraId)) {
-            log.debug(chequeraSerieAltaFull.getPersonaEntity().getApellidoNombre());
+            log.debug(Objects.requireNonNull(chequeraSerieAltaFull.getPersona()).getApellidoNombre());
             try {
                 ChequeraCuota chequeraCuota = chequeraCuotaService.findOneActivaImpagaPrevia(chequeraSerieAltaFull.getFacultadId(), chequeraSerieAltaFull.getTipoChequeraId(), chequeraSerieAltaFull.getChequeraSerieId(), chequeraSerieAltaFull.getAlternativaId(), fechaDesdePrimerVencimiento);
                 if (chequeraCuota.getVencimiento1().isBefore(fechaDesdePrimerVencimiento)) {


### PR DESCRIPTION
Closes #239

## Descripción

Refactorización de nomenclatura: renombrado del campo `personaEntity` a `persona` en entidades y servicios del core, para mantener consistencia en la nomenclatura del modelo de domino.

## Cambios Realizados

### Refactor de entidades/modelos
- **`ContratoEntity.java`**: Campo de relación `@ManyToOne` renombrado de `personaEntity` a `persona`.
- **`ChequeraSerieAlta.kt`**: Campo de relación renombrado de `personaEntity` a `persona`.
- **`ChequeraSerieAltaFull.kt`**: Campo de relación renombrado de `personaEntity` a `persona`.

### Refactor de servicios
- **`SheetService.java`**: Actualizadas las referencias de `getPersonaEntity()` a `getPersona()` en la generación de hojas de cálculo de contratos (3 usos).
- **`ChequeraSerieAltaFullService.java`**: Actualizada referencia con null-safe `Objects.requireNonNull(getPersona())` en logging.

### Versionado y documentación
- **`pom.xml`**: Versión actualizada de `3.19.0` a `3.20.0`.
- **`CHANGELOG.md`**: Documentados los cambios de la versión 3.20.0.
- **`README.md`**: Actualizada la versión actual y sección de novedades.
- **`docs/README.md`**: Actualizada la versión del servicio.

### Archivos modificados (9 archivos, +33/-11 líneas)
| Archivo | Cambio |
|---|---|
| `pom.xml` | Versión 3.19.0 → 3.20.0 |
| `ContratoEntity.java` | `personaEntity` → `persona` |
| `ChequeraSerieAlta.kt` | `personaEntity` → `persona` |
| `ChequeraSerieAltaFull.kt` | `personaEntity` → `persona` |
| `SheetService.java` | `getPersonaEntity()` → `getPersona()` |
| `ChequeraSerieAltaFullService.java` | `getPersonaEntity()` → `Objects.requireNonNull(getPersona())` |
| `CHANGELOG.md` | Documentación v3.20.0 |
| `README.md` | Documentación v3.20.0 |
| `docs/README.md` | Versión actualizada |

## Verificación
- [ ] Compilación exitosa con `mvn compile`
- [ ] Pruebas unitarias pasan con `mvn test`
- [ ] Compatibilidad: cambio de nomenclatura interna únicamente. No afecta contratos de API REST ni base de datos.
- [ ] Riesgo bajo: rename controlado con cobertura de compilación en Java/Kotlin.
