### PR TITLE
refactor(model): rename personaEntity, add @Serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.21.2] - 2026-05-28
+### Fixed
+- fix(model): Add `@Serial` annotation to `serialVersionUID` in serializable model classes
+  - `PersonaBeneficiario`, `ChequeraIncompleta`, `ChequeraKey`, `ChequeraPreuniv` now use `@Serial` for proper serialization metadata
+
+### Changed
+- refactor(model): Rename `personaEntity` field to `persona` in model classes for naming consistency
+  - `PersonaBeneficiario`, `ChequeraIncompleta`, `ChequeraKey`, `ChequeraPreuniv`: field `personaEntity` → `persona`
+  - `SheetService`: Updated references from `getPersonaEntity()` → `getPersona()` to match renamed field
+  - Consistency with `ContratoEntity` naming convention established in v3.20.0
+
+> Basado en análisis profundo de `git diff HEAD` (5 archivos modificados, +17/-9 líneas).
+
 ## [3.21.1] - 2026-05-21
 ### Fixed
 - fix(tables): Add missing `@Table(name = ...)` annotations to `BajaEntity` and `ChequeraSerieEntity` for explicit table mapping

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.6.
 
-**Versión actual (SemVer): 3.21.1**
+**Versión actual (SemVer): 3.21.2**
+
+## Novedades 3.21.2 (verificado en código)
+- fix(model): Agregada anotación `@Serial` a `serialVersionUID` en clases serializables
+  - `PersonaBeneficiario`, `ChequeraIncompleta`, `ChequeraKey`, `ChequeraPreuniv` ahora usan `@Serial` para metadatos de serialización
+- refactor(model): Renombrado de campo `personaEntity` a `persona` en clases de modelo para consistencia de nomenclatura
+  - `PersonaBeneficiario`, `ChequeraIncompleta`, `ChequeraKey`, `ChequeraPreuniv`: campo `personaEntity` → `persona`
+  - `SheetService`: Referencias actualizadas de `getPersonaEntity()` → `getPersona()`
+  - Consistencia con la convención de `ContratoEntity` establecida en v3.20.0
+
+> Basado en análisis profundo de `git diff HEAD` (5 archivos modificados, +17/-9 líneas).
 
 ## Novedades 3.21.1 (verificado en código)
 - fix(tables): Agregadas anotaciones `@Table(name = ...)` faltantes en `BajaEntity` y `ChequeraSerieEntity`
@@ -824,7 +834,7 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen.svg)](https://spring.io/projects/spring-cloud)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.21.1-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.21.2-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.21.1**
+**Versión actual del servicio: 3.21.2**
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/src/main/java/um/tesoreria/core/model/PersonaBeneficiario.java
+++ b/src/main/java/um/tesoreria/core/model/PersonaBeneficiario.java
@@ -3,6 +3,7 @@
  */
 package um.tesoreria.core.model;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
 
@@ -35,7 +36,8 @@ public class PersonaBeneficiario extends Auditable implements Serializable {
 	/**
 	* 
 	*/
-	private static final long serialVersionUID = 4529768518427197870L;
+	@Serial
+    private static final long serialVersionUID = 4529768518427197870L;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,6 +51,6 @@ public class PersonaBeneficiario extends Auditable implements Serializable {
 
 	@OneToOne
 	@JoinColumn(name = "personaUniqueId", insertable = false, updatable = false)
-	private PersonaEntity personaEntity;
+	private PersonaEntity persona;
 
 }

--- a/src/main/java/um/tesoreria/core/model/view/ChequeraIncompleta.java
+++ b/src/main/java/um/tesoreria/core/model/view/ChequeraIncompleta.java
@@ -3,6 +3,7 @@
  */
 package um.tesoreria.core.model.view;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -40,7 +41,8 @@ public class ChequeraIncompleta implements Serializable {
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 6073097611183861167L;
+	@Serial
+    private static final long serialVersionUID = 6073097611183861167L;
 
 	@Id
 	private Long chequeraId;
@@ -80,7 +82,7 @@ public class ChequeraIncompleta implements Serializable {
 	@JoinColumns({
 			@JoinColumn(name = "personaId", referencedColumnName = "per_id", insertable = false, updatable = false),
 			@JoinColumn(name = "documentoId", referencedColumnName = "per_doc_id", insertable = false, updatable = false) })
-	private PersonaEntity personaEntity;
+	private PersonaEntity persona;
 
 	@OneToOne
 	@JoinColumns({

--- a/src/main/java/um/tesoreria/core/model/view/ChequeraKey.java
+++ b/src/main/java/um/tesoreria/core/model/view/ChequeraKey.java
@@ -3,6 +3,7 @@
  */
 package um.tesoreria.core.model.view;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -44,7 +45,8 @@ public class ChequeraKey extends Auditable implements Serializable {
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 6401541993132700141L;
+	@Serial
+    private static final long serialVersionUID = 6401541993132700141L;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -86,7 +88,7 @@ public class ChequeraKey extends Auditable implements Serializable {
 	@JoinColumns({
 			@JoinColumn(name = "personaId", referencedColumnName = "per_id", insertable = false, updatable = false),
 			@JoinColumn(name = "documentoId", referencedColumnName = "per_doc_id", insertable = false, updatable = false) })
-	private PersonaEntity personaEntity;
+	private PersonaEntity persona;
 
 	@OneToOne
 	@JoinColumn(name = "lectivoId", insertable = false, updatable = false)

--- a/src/main/java/um/tesoreria/core/model/view/ChequeraPreuniv.java
+++ b/src/main/java/um/tesoreria/core/model/view/ChequeraPreuniv.java
@@ -3,6 +3,7 @@
  */
 package um.tesoreria.core.model.view;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.text.MessageFormat;
@@ -38,7 +39,8 @@ public class ChequeraPreuniv implements Serializable {
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -5081653677665140152L;
+	@Serial
+    private static final long serialVersionUID = -5081653677665140152L;
 
 	@Id
 	private Long chequeraId;
@@ -81,6 +83,6 @@ public class ChequeraPreuniv implements Serializable {
 	@JoinColumns({
 			@JoinColumn(name = "personaId", referencedColumnName = "per_id", insertable = false, updatable = false),
 			@JoinColumn(name = "documentoId", referencedColumnName = "per_doc_id", insertable = false, updatable = false) })
-	private PersonaEntity personaEntity;
+	private PersonaEntity persona;
 
 }

--- a/src/main/java/um/tesoreria/core/service/facade/SheetService.java
+++ b/src/main/java/um/tesoreria/core/service/facade/SheetService.java
@@ -612,7 +612,7 @@ public class SheetService {
             row = sheet.createRow(++fila);
             this.setCellString(row, 0, chequeraPreuniv.getFacultad().getNombre(), styleNormal);
             this.setCellString(row, 1, chequeraPreuniv.getGeografica().getNombre(), styleNormal);
-            this.setCellString(row, 2, "(" + chequeraPreuniv.getPersonaKey() + ") - " + chequeraPreuniv.getPersonaEntity().getApellido() + ", " + chequeraPreuniv.getPersonaEntity().getNombre(), styleNormal);
+            this.setCellString(row, 2, "(" + chequeraPreuniv.getPersonaKey() + ") - " + chequeraPreuniv.getPersona().getApellido() + ", " + chequeraPreuniv.getPersona().getNombre(), styleNormal);
             this.setCellString(row, 3, chequeraPreuniv.getChequera(), styleNormal);
             // Calcula Deuda
             BigDecimal deuda = BigDecimal.ZERO;


### PR DESCRIPTION
Closes #243

## Descripción
Agrega la anotación `@Serial` a los campos `serialVersionUID` en clases serializables del modelo y renombra el campo `personaEntity` a `persona` para mantener consistencia con la convención de `ContratoEntity` establecida en v3.20.0.

## Cambios Realizados
- **fix(model):** Agregada anotación `@Serial` a `serialVersionUID` en `PersonaBeneficiario`, `ChequeraIncompleta`, `ChequeraKey` y `ChequeraPreuniv`
- **refactor(model):** Renombrado campo `personaEntity` → `persona` en las 4 clases del modelo
- **refactor(service):** Actualizadas referencias en `SheetService` de `getPersonaEntity()` a `getPersona()`
- **docs:** Actualizados `CHANGELOG.md`, `README.md` y `docs/README.md` para la versión 3.21.2

## Verificación
- [x] Compilación exitosa con `mvn compile`
- [x] Los getters/setters reflejan el nuevo nombre del campo (`getPersona()` / `setPersona()`)
- [x] No hay referencias remanentes a `personaEntity` en el código fuente
