### PR TITLE
feat(campanha): new hexagonal module with dep updates and refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.22.0] - 2026-06-13
+### Added
+- feat(campanha): Nuevo módulo Campanha con arquitectura hexagonal completa
+  - Modelo de dominio: `Campanha` con campos `campanhaId` (UUID), `nombre`, `activa`
+  - Puertos de entrada (5): `CreateCampanhaUseCase`, `GetCampanhaByIdUseCase`, `GetAllCampanhasUseCase`, `UpdateCampanhaUseCase`, `DeleteCampanhaUseCase`
+  - Puerto de salida: `CampanhaRepository` con métodos CRUD completos
+  - Casos de uso: Implementaciones completas en `application/usecases/` con inyección de dependencias
+  - Servicio de aplicación: `CampanhaService` con delegación a casos de uso y retornos `Optional`
+  - Adaptador JPA: `JpaCampanhaRepositoryAdapter` con mapeo dominio ↔ entidad
+  - Entidad JPA: `CampanhaEntity` con herencia de `Auditable` y mapeo a tabla `campanha`
+  - Repositorio JPA: `JpaCampanhaRepository` con consultas por identificación
+  - Mapper: `CampanhaMapper` para conversión entidad ↔ dominio
+  - Controlador REST: `CampanhaController` con endpoints CRUD bajo `GET/POST/PUT/DELETE /api/tesoreria/umhub/campanha/`
+  - DTOs: `CampanhaRequest` y `CampanhaResponse`
+  - DTO Mapper: `CampanhaDtoMapper` para conversión DTO ↔ dominio
+  - Excepción: `CampanhaException` para manejo de errores del dominio
+
+### Changed
+- chore(deps): Actualización de Spring Boot de 4.0.6 a 4.1.0
+- chore(deps): Actualización de Kotlin de 2.3.21 a 2.4.0
+- chore(deps): Actualización de Spring Cloud de 2025.1.0 a 2025.1.2
+- refactor(service): Migración de `ChequeraIncompletaService` de inyección `@Autowired` a `@RequiredArgsConstructor` con campo `final`
+
+> Basado en análisis profundo de `git diff HEAD` (25 archivos modificados, +488/-6 líneas) y cambios en `pom.xml`, `ChequeraIncompletaService`, y nuevo módulo `hexagonal/umhub/campanha/`.
+
 ## [3.21.2] - 2026-05-28
 ### Fixed
 - fix(model): Add `@Serial` annotation to `serialVersionUID` in serializable model classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.23.0] - 2026-06-13
+### Added
+- feat(campanha): Nuevo campo `created` (LocalDateTime) en modelo de dominio `Campanha`
+  - `Campanha.domain.model.Campanha`: nuevo campo `created` para fecha de creación
+  - `CampanhaResponse`: expone el campo `created` en respuestas REST
+  - `CampanhaMapper`: mapeo bidireccional del campo `created` entre entidad y dominio
+  - `CampanhaDtoMapper`: mapeo del campo `created` de dominio a DTO de respuesta
+
+### Changed
+- refactor(campanha): Actualización parcial (partial update) en `JpaCampanhaRepositoryAdapter.update()`
+  - Cambio de reemplazo completo de entidad a carga de entidad existente con actualización selectiva de campos no nulos
+  - `CampanhaEntity.setCreated()` invocado explícitamente en `CampanhaMapper.toEntity()` para preservar el campo `created`
+
+> Basado en análisis profundo de `git diff HEAD` (5 archivos modificados, +20/-8 líneas).
+
 ## [3.22.0] - 2026-06-13
 ### Added
 - feat(campanha): Nuevo módulo Campanha con arquitectura hexagonal completa

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.22.0**
+**Versión actual (SemVer): 3.23.0**
+
+## Novedades 3.23.0 (verificado en código)
+- feat(campanha): Nuevo campo `created` (LocalDateTime) en modelo `Campanha`
+  - `Campanha.domain.model.Campanha`: nuevo campo `created` para fecha de creación
+  - `CampanhaResponse`: expone el campo `created` en respuestas REST
+  - `CampanhaMapper` y `CampanhaDtoMapper`: mapeo bidireccional del campo `created`
+- refactor(campanha): Actualización parcial (partial update) en `JpaCampanhaRepositoryAdapter.update()`
+  - Cambio de reemplazo completo de entidad a carga de entidad existente con actualización selectiva de campos no nulos
+
+> Basado en análisis profundo de `git diff HEAD` (5 archivos modificados, +20/-8 líneas).
 
 ## Novedades 3.22.0 (verificado en código)
 - feat(campanha): Nuevo módulo Campanha con arquitectura hexagonal completa bajo `hexagonal/umhub/campanha/`
@@ -796,20 +806,20 @@ src/
 │   │       ├── hexagonal/
 │   │       │   ├── ubicacion/         # Módulo Ubicacion (v3.14.0)
 │   │       │   ├── ubicacionArticulo/ # Módulo UbicacionArticulo (v3.14.0)
-│   │   │   ├── umhub/campanha/    # Módulo Campanha (v3.22.0)
-│   │   │   ├── contrato/          # Módulo Contrato (v3.19.0)
-│   │       ├── chequeraSerie/     # Módulo ChequeraSerie (v3.21.0)
-│   │       ├── baja/              # Módulo Baja (v3.21.0)
-│   │       ├── dependencia/       # Módulo Dependencia (v3.17.0)
-│   │       │   ├── facultad/          # Módulo Facultad (v3.18.0)
-│   │       │   ├── facturaPendiente/  # Módulo FacturaPendiente (v3.15.0)
-│   │       │   ├── articulo/          # Módulo Artículo (v3.13.0)
-│   │       │   ├── cuenta/            # Módulo Cuenta (v3.8.0)
-│   │       │   ├── chequeraCuota/     # Módulo ChequeraCuota (v3.2.0)
-│   │       │   ├── persona/           # Módulo Persona (v3.1.0)
-│   │       │   ├── auth/              # Módulo Auth (v3.6.0)
-│   │       │   ├── geografica/        # Módulo Geografica (v3.6.0)
-│   │       │   ├── proveedor/         # Módulo Proveedor (v3.9.0)
+│   │       │   ├── umhub/campanha/    # Módulo Campanha (v3.23.0)
+│   │       │   ├── contrato/          # Módulo Contrato (v3.19.0)
+│   │       │   ├── chequeraSerie/     # Módulo ChequeraSerie (v3.21.0)
+│   │       │   ├── baja/              # Módulo Baja (v3.21.0)
+│   │   ├── dependencia/       # Módulo Dependencia (v3.17.0)
+│   │   ├── facultad/          # Módulo Facultad (v3.18.0)
+│   │   ├── facturaPendiente/  # Módulo FacturaPendiente (v3.15.0)
+│   │   ├── articulo/          # Módulo Artículo (v3.13.0)
+│   │   ├── cuenta/            # Módulo Cuenta (v3.8.0)
+│   │   ├── chequeraCuota/     # Módulo ChequeraCuota (v3.2.0)
+│   │   ├── persona/           # Módulo Persona (v3.1.0)
+│   │   ├── auth/              # Módulo Auth (v3.6.0)
+│   │   ├── geografica/        # Módulo Geografica (v3.6.0)
+│   │   │   ├── proveedor/         # Módulo Proveedor (v3.9.0)
 │   │       │   └── matriculacionContext/
 │   │       ├── model/                 # Modelos legacy
 │   │       ├── service/               # Servicios legacy
@@ -854,7 +864,7 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-brightgreen.svg)](https://spring.io/projects/spring-cloud)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.22.0-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.23.0-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,28 @@
 
 ## Descripción
 
-Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.6.
+Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.21.2**
+**Versión actual (SemVer): 3.22.0**
+
+## Novedades 3.22.0 (verificado en código)
+- feat(campanha): Nuevo módulo Campanha con arquitectura hexagonal completa bajo `hexagonal/umhub/campanha/`
+  - Modelo de dominio: `Campanha` con campos `campanhaId` (UUID), `nombre`, `activa`
+  - Puertos de entrada: `CreateCampanhaUseCase`, `GetCampanhaByIdUseCase`, `GetAllCampanhasUseCase`, `UpdateCampanhaUseCase`, `DeleteCampanhaUseCase`
+  - Puerto de salida: `CampanhaRepository` con métodos CRUD
+  - Casos de uso: `CreateCampanhaUseCaseImpl`, `GetCampanhaByIdUseCaseImpl`, `GetAllCampanhasUseCaseImpl`, `UpdateCampanhaUseCaseImpl`, `DeleteCampanhaUseCaseImpl`
+  - Servicio de aplicación: `CampanhaService` con delegación a casos de uso
+  - Adaptador JPA: `JpaCampanhaRepositoryAdapter` con `CampanhaMapper` para conversión dominio ↔ entidad
+  - Entidad JPA: `CampanhaEntity` extends `Auditable`, mapeo a tabla `campanha`
+  - Repositorio JPA: `JpaCampanhaRepository` con consultas por ID
+  - Controlador REST: `CampanhaController` con endpoints CRUD bajo `GET/POST/PUT/DELETE /api/tesoreria/umhub/campanha/`
+  - DTOs: `CampanhaRequest`, `CampanhaResponse`
+  - DTO Mapper: `CampanhaDtoMapper` para conversión DTO ↔ dominio
+  - Excepción: `CampanhaException`
+- chore(deps): Actualización de Spring Boot 4.0.6 → 4.1.0, Kotlin 2.3.21 → 2.4.0, Spring Cloud 2025.1.0 → 2025.1.2
+- refactor(service): Migración de `ChequeraIncompletaService` a inyección por constructor con `@RequiredArgsConstructor`
+
+> Basado en análisis profundo de `git diff HEAD` (25 archivos modificados, +488/-6 líneas).
 
 ## Novedades 3.21.2 (verificado en código)
 - fix(model): Agregada anotación `@Serial` a `serialVersionUID` en clases serializables
@@ -564,9 +583,9 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.0.6
 - Docker (opcional)
 
 ## Versiones de Dependencias Principales (verificado en `pom.xml`)
-- Spring Boot: 4.0.6
-- Spring Cloud: 2025.1.0
-- Kotlin: 2.3.21
+- Spring Boot: 4.1.0
+- Spring Cloud: 2025.1.2
+- Kotlin: 2.4.0
 - MySQL Connector: 9.6.0
 - SpringDoc OpenAPI: 3.0.2
 - Apache POI: 5.5.1
@@ -777,6 +796,7 @@ src/
 │   │       ├── hexagonal/
 │   │       │   ├── ubicacion/         # Módulo Ubicacion (v3.14.0)
 │   │       │   ├── ubicacionArticulo/ # Módulo UbicacionArticulo (v3.14.0)
+│   │   │   ├── umhub/campanha/    # Módulo Campanha (v3.22.0)
 │   │   │   ├── contrato/          # Módulo Contrato (v3.19.0)
 │   │       ├── chequeraSerie/     # Módulo ChequeraSerie (v3.21.0)
 │   │       ├── baja/              # Módulo Baja (v3.21.0)
@@ -830,11 +850,11 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 # UM Tesorería Core Service
 
 [![Java](https://img.shields.io/badge/Java-25-blue.svg)](https://www.java.com/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.6-brightgreen.svg)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen.svg)](https://spring.io/projects/spring-cloud)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-purple.svg)](https://kotlinlang.org/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-brightgreen.svg)](https://spring.io/projects/spring-cloud)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.21.2-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.22.0-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.21.2**
+**Versión actual del servicio: 3.22.0**
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -22,6 +22,7 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-contrato.mmd`: Arquitectura hexagonal del módulo Contrato (gestión de contratos) - v3.19.0.
 - `hexagonal-chequeraSerie.mmd`: Arquitectura hexagonal del módulo ChequeraSerie (gestión de series de chequeras) - v3.21.0.
 - `hexagonal-baja.mmd`: Arquitectura hexagonal del módulo Baja (gestión de bajas de chequeras) - v3.21.0.
+- `hexagonal-campanha.mmd`: Arquitectura hexagonal del módulo Campanha (gestión de campañas UM Hub) - v3.22.0.
 - `deployment.mmd`: Diagrama de despliegue del microservicio.
 
 ## Diagramas de Datos

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.22.0**
+**Versión actual del servicio: 3.23.0**
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -22,7 +22,7 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-contrato.mmd`: Arquitectura hexagonal del módulo Contrato (gestión de contratos) - v3.19.0.
 - `hexagonal-chequeraSerie.mmd`: Arquitectura hexagonal del módulo ChequeraSerie (gestión de series de chequeras) - v3.21.0.
 - `hexagonal-baja.mmd`: Arquitectura hexagonal del módulo Baja (gestión de bajas de chequeras) - v3.21.0.
-- `hexagonal-campanha.mmd`: Arquitectura hexagonal del módulo Campanha (gestión de campañas UM Hub) - v3.22.0.
+- `hexagonal-campanha.mmd`: Arquitectura hexagonal del módulo Campanha (gestión de campañas UM Hub) - v3.23.0.
 - `deployment.mmd`: Diagrama de despliegue del microservicio.
 
 ## Diagramas de Datos

--- a/docs/hexagonal-campanha.mmd
+++ b/docs/hexagonal-campanha.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo Campanha (v3.22.0)
+title: Arquitectura Hexagonal - Módulo Campanha (v3.23.0)
 ---
 
 classDiagram
@@ -10,6 +10,7 @@ classDiagram
             +UUID campanhaId
             +String nombre
             +Byte activa
+            +LocalDateTime created
         }
 
         class CampanhaRepository {
@@ -87,6 +88,7 @@ classDiagram
                 +UUID campanhaId
                 +String nombre
                 +Byte activa
+                +LocalDateTime created
             }
 
             class JpaCampanhaRepository {
@@ -133,6 +135,7 @@ classDiagram
                 +UUID campanhaId
                 +String nombre
                 +Byte activa
+                +LocalDateTime created
             }
 
             class CampanhaDtoMapper {

--- a/docs/hexagonal-campanha.mmd
+++ b/docs/hexagonal-campanha.mmd
@@ -1,0 +1,175 @@
+---
+title: Arquitectura Hexagonal - Módulo Campanha (v3.22.0)
+---
+
+classDiagram
+    direction TB
+
+    namespace domain {
+        class Campanha {
+            +UUID campanhaId
+            +String nombre
+            +Byte activa
+        }
+
+        class CampanhaRepository {
+            <<interface>>
+            +create(Campanha) Campanha
+            +findById(UUID) Optional~Campanha~
+            +findAll() List~Campanha~
+            +update(UUID, Campanha) Optional~Campanha~
+            +deleteByCampanhaId(UUID) boolean
+        }
+    }
+
+    namespace application {
+        class CampanhaService {
+            -CreateCampanhaUseCase createCampanhaUseCase
+            -GetCampanhaByIdUseCase getCampanhaByIdUseCase
+            -GetAllCampanhasUseCase getAllCampanhasUseCase
+            -UpdateCampanhaUseCase updateCampanhaUseCase
+            -DeleteCampanhaUseCase deleteCampanhaUseCase
+            +createCampanha(Campanha) Campanha
+            +getCampanhaById(UUID) Optional~Campanha~
+            +getAllCampanhas() List~Campanha~
+            +updateCampanha(UUID, Campanha) Optional~Campanha~
+            +deleteCampanha(UUID) boolean
+        }
+
+        namespace usecases {
+            class CreateCampanhaUseCaseImpl {
+                -CampanhaRepository repository
+                +createCampanha(Campanha) Campanha
+            }
+            class GetCampanhaByIdUseCaseImpl {
+                -CampanhaRepository repository
+                +getCampanhaById(UUID) Optional~Campanha~
+            }
+            class GetAllCampanhasUseCaseImpl {
+                -CampanhaRepository repository
+                +getAllCampanhas() List~Campanha~
+            }
+            class UpdateCampanhaUseCaseImpl {
+                -CampanhaRepository repository
+                +updateCampanha(UUID, Campanha) Optional~Campanha~
+            }
+            class DeleteCampanhaUseCaseImpl {
+                -CampanhaRepository repository
+                +deleteCampanha(UUID) boolean
+            }
+        }
+
+        class CreateCampanhaUseCase {
+            <<interface>>
+            +createCampanha(Campanha) Campanha
+        }
+        class GetCampanhaByIdUseCase {
+            <<interface>>
+            +getCampanhaById(UUID) Optional~Campanha~
+        }
+        class GetAllCampanhasUseCase {
+            <<interface>>
+            +getAllCampanhas() List~Campanha~
+        }
+        class UpdateCampanhaUseCase {
+            <<interface>>
+            +updateCampanha(UUID, Campanha) Optional~Campanha~
+        }
+        class DeleteCampanhaUseCase {
+            <<interface>>
+            +deleteCampanha(UUID) boolean
+        }
+    }
+
+    namespace infrastructure {
+        namespace persistence {
+            class CampanhaEntity {
+                +UUID campanhaId
+                +String nombre
+                +Byte activa
+            }
+
+            class JpaCampanhaRepository {
+                <<JpaRepository>>
+                +findByCampanhaId(UUID) Optional~CampanhaEntity~
+                +existsByCampanhaId(UUID) boolean
+                +deleteByCampanhaId(UUID) void
+            }
+
+            class JpaCampanhaRepositoryAdapter {
+                -JpaCampanhaRepository repository
+                -CampanhaMapper mapper
+                +create(Campanha) Campanha
+                +findById(UUID) Optional~Campanha~
+                +findAll() List~Campanha~
+                +update(UUID, Campanha) Optional~Campanha~
+                +deleteByCampanhaId(UUID) boolean
+            }
+
+            class CampanhaMapper {
+                +toEntity(Campanha) CampanhaEntity
+                +toDomainModel(CampanhaEntity) Campanha
+            }
+        }
+
+        namespace web {
+            class CampanhaController {
+                -CampanhaService campanhaService
+                -CampanhaDtoMapper campanhaDtoMapper
+                +findByCampanhaId(UUID) ResponseEntity~CampanhaResponse~
+                +add(CampanhaRequest) ResponseEntity~CampanhaResponse~
+                +getAll() ResponseEntity~List~CampanhaResponse~~
+                +update(UUID, CampanhaRequest) ResponseEntity~CampanhaResponse~
+                +delete(UUID) ResponseEntity~Void~
+            }
+
+            class CampanhaRequest {
+                +UUID campanhaId
+                +String nombre
+                +Byte activa
+            }
+
+            class CampanhaResponse {
+                +UUID campanhaId
+                +String nombre
+                +Byte activa
+            }
+
+            class CampanhaDtoMapper {
+                +toDomain(CampanhaRequest) Campanha
+                +toResponse(Campanha) CampanhaResponse
+            }
+        }
+    }
+
+    CampanhaService --> CreateCampanhaUseCase : uses
+    CampanhaService --> GetCampanhaByIdUseCase : uses
+    CampanhaService --> GetAllCampanhasUseCase : uses
+    CampanhaService --> UpdateCampanhaUseCase : uses
+    CampanhaService --> DeleteCampanhaUseCase : uses
+
+    CreateCampanhaUseCaseImpl ..|> CreateCampanhaUseCase : implements
+    GetCampanhaByIdUseCaseImpl ..|> GetCampanhaByIdUseCase : implements
+    GetAllCampanhasUseCaseImpl ..|> GetAllCampanhasUseCase : implements
+    UpdateCampanhaUseCaseImpl ..|> UpdateCampanhaUseCase : implements
+    DeleteCampanhaUseCaseImpl ..|> DeleteCampanhaUseCase : implements
+
+    CreateCampanhaUseCaseImpl --> CampanhaRepository : uses
+    GetCampanhaByIdUseCaseImpl --> CampanhaRepository : uses
+    GetAllCampanhasUseCaseImpl --> CampanhaRepository : uses
+    UpdateCampanhaUseCaseImpl --> CampanhaRepository : uses
+    DeleteCampanhaUseCaseImpl --> CampanhaRepository : uses
+
+    JpaCampanhaRepositoryAdapter ..|> CampanhaRepository : implements
+    JpaCampanhaRepositoryAdapter --> JpaCampanhaRepository : uses
+    JpaCampanhaRepositoryAdapter --> CampanhaMapper : uses
+
+    CampanhaMapper --> Campanha : maps
+    CampanhaMapper --> CampanhaEntity : maps
+    JpaCampanhaRepository --> CampanhaEntity : persists
+
+    CampanhaController --> CampanhaService : calls
+    CampanhaController --> CampanhaDtoMapper : uses
+    CampanhaDtoMapper --> Campanha : maps
+    CampanhaDtoMapper --> CampanhaRequest : maps
+    CampanhaDtoMapper --> CampanhaResponse : maps

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,6 +31,7 @@
     <div id="hexagonal-contrato" class="section"></div>
     <div id="hexagonal-chequeraSerie" class="section"></div>
     <div id="hexagonal-baja" class="section"></div>
+    <div id="hexagonal-campanha" class="section"></div>
   <div id="dependencies-diagram" class="section"></div>
   <div id="erd-diagram" class="section"></div>
   <div id="deployment-diagram" class="section"></div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -94,6 +94,7 @@ const diagrams = [
   { id: 'hexagonal-contrato', file: 'hexagonal-contrato.mmd', title: '🔷 Arquitectura Hexagonal - Contrato' },
   { id: 'hexagonal-chequeraSerie', file: 'hexagonal-chequeraSerie.mmd', title: '🔷 Arquitectura Hexagonal - ChequeraSerie' },
   { id: 'hexagonal-baja', file: 'hexagonal-baja.mmd', title: '🔷 Arquitectura Hexagonal - Baja' },
+  { id: 'hexagonal-campanha', file: 'hexagonal-campanha.mmd', title: '🔷 Arquitectura Hexagonal - Campanha (UM Hub)' },
   { id: 'dependencies-diagram', file: 'dependencies.mmd', title: '📦 Diagrama de Dependencias' },
   { id: 'erd-diagram', file: 'entities.mmd', title: '🗃️ Diagrama de Entidad-Relación (Simplificado)' },
   { id: 'deployment-diagram', file: 'deployment.mmd', title: '🚀 Diagrama de Despliegue' },

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.22.0</version>
+    <version>3.23.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,19 +5,19 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.21.1</version>
+    <version>3.22.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>
         <java.version>25</java.version>
-        <kotlin.version>2.3.21</kotlin.version>
-        <spring-cloud.version>2025.1.0</spring-cloud.version>
+        <kotlin.version>2.4.0</kotlin.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
         <sonar.organization>um-services</sonar.organization>
         <sonar.projectKey>UM-services_UM.tesoreria.core-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/exception/CampanhaException.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/exception/CampanhaException.java
@@ -1,0 +1,9 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.application.exception;
+
+import java.util.UUID;
+
+public class CampanhaException extends RuntimeException {
+    public CampanhaException(UUID id) {
+        super("Could not find campanha with id: " + id);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/service/CampanhaService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/service/CampanhaService.java
@@ -1,0 +1,41 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CampanhaService {
+
+    private final CreateCampanhaUseCase createCampanhaUseCase;
+    private final GetCampanhaByIdUseCase getCampanhaByIdUseCase;
+    private final GetAllCampanhasUseCase getAllCampanhasUseCase;
+    private final UpdateCampanhaUseCase updateCampanhaUseCase;
+    private final DeleteCampanhaUseCase deleteCampanhaUseCase;
+
+    public Campanha createCampanha(Campanha campanha) {
+        return createCampanhaUseCase.createCampanha(campanha);
+    }
+
+    public Optional<Campanha> getCampanhaById(UUID id) {
+        return getCampanhaByIdUseCase.getCampanhaById(id);
+    }
+
+    public List<Campanha> getAllCampanhas() {
+        return getAllCampanhasUseCase.getAllCampanhas();
+    }
+
+    public Optional<Campanha> updateCampanha(UUID id, Campanha campanha) {
+        return updateCampanhaUseCase.updateCampanha(id, campanha);
+    }
+
+    public boolean deleteCampanha(UUID id) {
+        return deleteCampanhaUseCase.deleteCampanha(id);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/CreateCampanhaUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/CreateCampanhaUseCaseImpl.java
@@ -1,0 +1,24 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in.CreateCampanhaUseCase;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.out.CampanhaRepository;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class CreateCampanhaUseCaseImpl implements CreateCampanhaUseCase {
+
+    private final CampanhaRepository repository;
+
+    @Override
+    public Campanha createCampanha(Campanha campanha) {
+        if (campanha.getCampanhaId() == null) {
+            campanha.setCampanhaId(UUID.randomUUID());
+        }
+        return repository.create(campanha);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/DeleteCampanhaUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/DeleteCampanhaUseCaseImpl.java
@@ -1,0 +1,20 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in.DeleteCampanhaUseCase;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.out.CampanhaRepository;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteCampanhaUseCaseImpl implements DeleteCampanhaUseCase {
+
+    private final CampanhaRepository repository;
+
+    @Override
+    public boolean deleteCampanha(UUID campanhaId) {
+        return repository.deleteByCampanhaId(campanhaId);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/GetAllCampanhasUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/GetAllCampanhasUseCaseImpl.java
@@ -1,0 +1,21 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in.GetAllCampanhasUseCase;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.out.CampanhaRepository;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GetAllCampanhasUseCaseImpl implements GetAllCampanhasUseCase {
+
+    private final CampanhaRepository repository;
+
+    @Override
+    public List<Campanha> getAllCampanhas() {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/GetCampanhaByIdUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/GetCampanhaByIdUseCaseImpl.java
@@ -1,0 +1,22 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in.GetCampanhaByIdUseCase;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.out.CampanhaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class GetCampanhaByIdUseCaseImpl implements GetCampanhaByIdUseCase {
+
+    private final CampanhaRepository repository;
+
+    @Override
+    public Optional<Campanha> getCampanhaById(UUID id) {
+        return repository.findById(id);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/UpdateCampanhaUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/application/usecases/UpdateCampanhaUseCaseImpl.java
@@ -1,0 +1,22 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in.UpdateCampanhaUseCase;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.out.CampanhaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateCampanhaUseCaseImpl implements UpdateCampanhaUseCase {
+
+    private final CampanhaRepository repository;
+
+    @Override
+    public Optional<Campanha> updateCampanha(UUID id, Campanha campanha) {
+        return repository.update(id, campanha);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/model/Campanha.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/model/Campanha.java
@@ -1,0 +1,15 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.domain.model;
+
+import lombok.*;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Campanha {
+    private UUID campanhaId;
+    private String nombre;
+    private Byte activa;
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/model/Campanha.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/model/Campanha.java
@@ -1,6 +1,7 @@
 package um.tesoreria.core.hexagonal.umhub.campanha.domain.model;
 
 import lombok.*;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -12,4 +13,5 @@ public class Campanha {
     private UUID campanhaId;
     private String nombre;
     private Byte activa;
+    private LocalDateTime created;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/CreateCampanhaUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/CreateCampanhaUseCase.java
@@ -1,0 +1,7 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+
+public interface CreateCampanhaUseCase {
+    Campanha createCampanha(Campanha campanha);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/DeleteCampanhaUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/DeleteCampanhaUseCase.java
@@ -1,0 +1,7 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in;
+
+import java.util.UUID;
+
+public interface DeleteCampanhaUseCase {
+    boolean deleteCampanha(UUID id);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/GetAllCampanhasUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/GetAllCampanhasUseCase.java
@@ -1,0 +1,8 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import java.util.List;
+
+public interface GetAllCampanhasUseCase {
+    List<Campanha> getAllCampanhas();
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/GetCampanhaByIdUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/GetCampanhaByIdUseCase.java
@@ -1,0 +1,9 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GetCampanhaByIdUseCase {
+    Optional<Campanha> getCampanhaById(UUID id);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/UpdateCampanhaUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/in/UpdateCampanhaUseCase.java
@@ -1,0 +1,9 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UpdateCampanhaUseCase {
+    Optional<Campanha> updateCampanha(UUID id, Campanha campanha);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/out/CampanhaRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/domain/ports/out/CampanhaRepository.java
@@ -1,0 +1,14 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.out;
+
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CampanhaRepository {
+    Campanha create(Campanha campanha);
+    Optional<Campanha> findById(UUID campanhaId);
+    List<Campanha> findAll();
+    Optional<Campanha> update(UUID campanhaId, Campanha campanha);
+    boolean deleteByCampanhaId(UUID campanhaId);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/adapter/JpaCampanhaRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/adapter/JpaCampanhaRepositoryAdapter.java
@@ -1,0 +1,62 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.persistence.adapter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.ports.out.CampanhaRepository;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.persistence.entity.CampanhaEntity;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.persistence.mapper.CampanhaMapper;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.persistence.repository.JpaCampanhaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class JpaCampanhaRepositoryAdapter implements CampanhaRepository {
+
+    private final JpaCampanhaRepository jpaCampanhaRepository;
+    private final CampanhaMapper campanhaMapper;
+
+    @Override
+    public Campanha create(Campanha campanha) {
+        CampanhaEntity entity = campanhaMapper.toEntity(campanha);
+        CampanhaEntity saved = jpaCampanhaRepository.save(entity);
+        return campanhaMapper.toDomainModel(saved);
+    }
+
+    @Override
+    public Optional<Campanha> findById(UUID id) {
+        return jpaCampanhaRepository.findById(id)
+                .map(campanhaMapper::toDomainModel);
+    }
+
+    @Override
+    public List<Campanha> findAll() {
+        return jpaCampanhaRepository.findAll().stream()
+                .map(campanhaMapper::toDomainModel)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Campanha> update(UUID campanhaId, Campanha campanha) {
+        if (jpaCampanhaRepository.existsById(campanhaId)) {
+            CampanhaEntity entity = campanhaMapper.toEntity(campanha);
+            entity.setCampanhaId(campanhaId);
+            CampanhaEntity updated = jpaCampanhaRepository.save(entity);
+            return Optional.of(campanhaMapper.toDomainModel(updated));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean deleteByCampanhaId(UUID campanhaId) {
+        if (jpaCampanhaRepository.existsByCampanhaId(campanhaId)) {
+            jpaCampanhaRepository.deleteByCampanhaId(campanhaId);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/adapter/JpaCampanhaRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/adapter/JpaCampanhaRepositoryAdapter.java
@@ -42,13 +42,17 @@ public class JpaCampanhaRepositoryAdapter implements CampanhaRepository {
 
     @Override
     public Optional<Campanha> update(UUID campanhaId, Campanha campanha) {
-        if (jpaCampanhaRepository.existsById(campanhaId)) {
-            CampanhaEntity entity = campanhaMapper.toEntity(campanha);
-            entity.setCampanhaId(campanhaId);
-            CampanhaEntity updated = jpaCampanhaRepository.save(entity);
-            return Optional.of(campanhaMapper.toDomainModel(updated));
-        }
-        return Optional.empty();
+        return jpaCampanhaRepository.findById(campanhaId)
+                .map(existingEntity -> {
+                    if (campanha.getNombre() != null) {
+                        existingEntity.setNombre(campanha.getNombre());
+                    }
+                    if (campanha.getActiva() != null) {
+                        existingEntity.setActiva(campanha.getActiva());
+                    }
+                    CampanhaEntity updated = jpaCampanhaRepository.save(existingEntity);
+                    return campanhaMapper.toDomainModel(updated);
+                });
     }
 
     @Override

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/entity/CampanhaEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/entity/CampanhaEntity.java
@@ -1,0 +1,25 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.persistence.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+import um.tesoreria.core.kotlin.model.Auditable;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "campanha")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CampanhaEntity extends Auditable {
+
+    @Id
+    private UUID campanhaId;
+    private String nombre;
+    private Byte activa;
+
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/mapper/CampanhaMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/mapper/CampanhaMapper.java
@@ -1,0 +1,27 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.persistence.mapper;
+
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.persistence.entity.CampanhaEntity;
+
+@Component
+public class CampanhaMapper {
+
+    public Campanha toDomainModel(CampanhaEntity entity) {
+        if (entity == null) return null;
+        return Campanha.builder()
+                .campanhaId(entity.getCampanhaId())
+                .nombre(entity.getNombre())
+                .activa(entity.getActiva())
+                .build();
+    }
+
+    public CampanhaEntity toEntity(Campanha domain) {
+        if (domain == null) return null;
+        return CampanhaEntity.builder()
+                .campanhaId(domain.getCampanhaId())
+                .nombre(domain.getNombre())
+                .activa(domain.getActiva())
+                .build();
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/mapper/CampanhaMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/mapper/CampanhaMapper.java
@@ -13,15 +13,18 @@ public class CampanhaMapper {
                 .campanhaId(entity.getCampanhaId())
                 .nombre(entity.getNombre())
                 .activa(entity.getActiva())
+                .created(entity.getCreated())
                 .build();
     }
 
     public CampanhaEntity toEntity(Campanha domain) {
         if (domain == null) return null;
-        return CampanhaEntity.builder()
+        CampanhaEntity entity = CampanhaEntity.builder()
                 .campanhaId(domain.getCampanhaId())
                 .nombre(domain.getNombre())
                 .activa(domain.getActiva())
                 .build();
+        entity.setCreated(domain.getCreated());
+        return entity;
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/repository/JpaCampanhaRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/persistence/repository/JpaCampanhaRepository.java
@@ -1,0 +1,16 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.stereotype.Repository;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.persistence.entity.CampanhaEntity;
+
+import java.util.UUID;
+
+@Repository
+public interface JpaCampanhaRepository extends JpaRepository<CampanhaEntity, UUID> {
+    boolean existsByCampanhaId(UUID campanhaId);
+
+    @Modifying
+    void deleteByCampanhaId(UUID campanhaId);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/controller/CampanhaController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/controller/CampanhaController.java
@@ -1,0 +1,64 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import um.tesoreria.core.hexagonal.umhub.campanha.application.service.CampanhaService;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.dto.CampanhaRequest;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.dto.CampanhaResponse;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.mapper.CampanhaDtoMapper;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/tesoreria/umhub/campanha")
+@RequiredArgsConstructor
+public class CampanhaController {
+
+    private final CampanhaService campanhaService;
+    private final CampanhaDtoMapper campanhaDtoMapper;
+
+    @GetMapping("/{campanhaId}")
+    public ResponseEntity<CampanhaResponse> findByCampanhaId(@PathVariable UUID campanhaId) {
+        return campanhaService.getCampanhaById(campanhaId)
+                .map(domain -> new ResponseEntity<>(campanhaDtoMapper.toResponse(domain), HttpStatus.OK))
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    @PostMapping("/")
+    public ResponseEntity<CampanhaResponse> add(@RequestBody CampanhaRequest request) {
+        Campanha domain = campanhaDtoMapper.toDomain(request);
+        Campanha created = campanhaService.createCampanha(domain);
+        return new ResponseEntity<>(campanhaDtoMapper.toResponse(created), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<List<CampanhaResponse>> getAll() {
+        List<CampanhaResponse> responses = campanhaService.getAllCampanhas().stream()
+                .map(campanhaDtoMapper::toResponse)
+                .collect(Collectors.toList());
+        return new ResponseEntity<>(responses, HttpStatus.OK);
+    }
+
+    @PutMapping("/{campanhaId}")
+    public ResponseEntity<CampanhaResponse> update(@PathVariable UUID campanhaId, @RequestBody CampanhaRequest request) {
+        Campanha domain = campanhaDtoMapper.toDomain(request);
+        return campanhaService.updateCampanha(campanhaId, domain)
+                .map(updated -> new ResponseEntity<>(campanhaDtoMapper.toResponse(updated), HttpStatus.OK))
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    @DeleteMapping("/{campanhaId}")
+    public ResponseEntity<Void> delete(@PathVariable UUID campanhaId) {
+        boolean deleted = campanhaService.deleteCampanha(campanhaId);
+        if (deleted) {
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/dto/CampanhaRequest.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/dto/CampanhaRequest.java
@@ -1,0 +1,15 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.dto;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class CampanhaRequest {
+    private UUID campanhaId;
+    private String nombre;
+    private Byte activa;
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/dto/CampanhaResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/dto/CampanhaResponse.java
@@ -2,6 +2,7 @@ package um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.dto;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -13,4 +14,5 @@ public class CampanhaResponse {
     private UUID campanhaId;
     private String nombre;
     private Byte activa;
+    private LocalDateTime created;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/dto/CampanhaResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/dto/CampanhaResponse.java
@@ -1,0 +1,16 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.dto;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CampanhaResponse {
+    private UUID campanhaId;
+    private String nombre;
+    private Byte activa;
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/mapper/CampanhaDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/mapper/CampanhaDtoMapper.java
@@ -1,0 +1,28 @@
+package um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.mapper;
+
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.dto.CampanhaRequest;
+import um.tesoreria.core.hexagonal.umhub.campanha.infrastructure.web.dto.CampanhaResponse;
+
+@Component
+public class CampanhaDtoMapper {
+
+    public Campanha toDomain(CampanhaRequest request) {
+        if (request == null) return null;
+        return Campanha.builder()
+                .campanhaId(request.getCampanhaId())
+                .nombre(request.getNombre())
+                .activa(request.getActiva())
+                .build();
+    }
+
+    public CampanhaResponse toResponse(Campanha domain) {
+        if (domain == null) return null;
+        return CampanhaResponse.builder()
+                .campanhaId(domain.getCampanhaId())
+                .nombre(domain.getNombre())
+                .activa(domain.getActiva())
+                .build();
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/mapper/CampanhaDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/campanha/infrastructure/web/mapper/CampanhaDtoMapper.java
@@ -23,6 +23,7 @@ public class CampanhaDtoMapper {
                 .campanhaId(domain.getCampanhaId())
                 .nombre(domain.getNombre())
                 .activa(domain.getActiva())
+                .created(domain.getCreated())
                 .build();
     }
 }

--- a/src/main/java/um/tesoreria/core/service/view/ChequeraIncompletaService.java
+++ b/src/main/java/um/tesoreria/core/service/view/ChequeraIncompletaService.java
@@ -5,6 +5,7 @@ package um.tesoreria.core.service.view;
 
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -17,10 +18,10 @@ import um.tesoreria.core.repository.view.ChequeraIncompletaRepository;
  *
  */
 @Service
+@RequiredArgsConstructor
 public class ChequeraIncompletaService {
 
-	@Autowired
-	private ChequeraIncompletaRepository repository;
+	private final ChequeraIncompletaRepository repository;
 
 	public List<ChequeraIncompleta> findAllByLectivoIdAndFacultadIdAndGeograficaId(Integer lectivoId,
                                                                                    Integer facultadId, Integer geograficaId) {


### PR DESCRIPTION
Closes #245

## Descripción
Nuevo módulo **Campanha** con arquitectura hexagonal completa (domain, application, infrastructure) bajo `hexagonal/umhub/campanha/`, actualización de dependencias principales, y refactor de inyección de dependencias en `ChequeraIncompletaService`.

## Cambios Realizados
- [x] **feat(campanha):** Implementación completa del módulo Campanha con arquitectura hexagonal (CRUD REST, JPA, DTOs, mappers, excepciones)
- [x] **feat(campanha):** Agregado campo `created` en modelo y DTO de respuesta; refactor de `update()` a partial update para preservar timestamp
- [x] **chore(deps):** Actualización Spring Boot 4.0.6 → 4.1.0, Kotlin 2.3.21 → 2.4.0, Spring Cloud 2025.1.0 → 2025.1.2
- [x] **refactor(chequera-incompleta):** Migración de `@Autowired` field injection a constructor injection con `@RequiredArgsConstructor`
- [x] **docs:** Actualización de `CHANGELOG.md`, `README.md`, y nuevo diagrama `docs/hexagonal-campanha.mmd`

## Verificación
- [ ] Compilación: `mvn clean compile`
- [ ] Tests: `mvn test`
- [ ] Validar endpoints REST en `/api/tesoreria/umhub/campanha/`
