### PR TITLE
feat(mercadopagoContext): integrate MercadoPago with reservaVacante

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.26.0] - 2026-06-15
+### Added
+- feat(mercadopagoContext): New `FindActiveByReservaVacanteIdUseCase` for retrieving active MP context by `reservaVacanteId` (UUID)
+  - New input port: `FindActiveByReservaVacanteIdUseCase` with method `findActiveByReservaVacanteId(UUID)`
+  - New use case: `FindActiveByReservaVacanteIdUseCaseImpl` with delegation to repository
+  - New repository method: `findByReservaVacanteIdAndActivo(UUID, Byte)` in `MercadoPagoContextRepository`
+  - New JPA method: `findByReservaVacanteId(UUID)` in `JpaMercadoPagoContextRepository`
+  - Adapter method: `findByReservaVacanteIdAndActivo()` in `JpaMercadoPagoContextRepositoryAdapter`
+- feat(mercadopagoContext): New `PreferenceVacanteClient` Feign client for creating vacante preferences via `tesoreria-mercadopago-service`
+- feat(mercadopagoContext): Added `jsonify()` method to `MercadoPagoContext` domain model for structured logging
+- feat(reservaVacante): MercadoPago integration on reservation creation
+  - `CreateReservaVacanteUseCaseImpl` now creates MP context via `MercadoPagoCoreService.createContextVacante()` and preference via `PreferenceVacanteClient.createPreference()`
+  - New `createContextVacante()` and `buildResponseVacante()` methods in `MercadoPagoCoreService`
+- feat(reservaVacante): Added `Campanha campanha` domain field to `ReservaVacante` model for enriched responses
+- feat(reservaVacante): Enhanced `ReservaVacanteResponse` with `initPoint` from MercadoPagoContext and reorganized `estado` field
+  - `ReservaVacanteDtoMapper` injects `MercadoPagoContextService` to resolve `initPoint` for each response
+  - Field order: `estado` moved before `importe`, new `initPoint` field added
+- feat(reservaVacante): `FindReservaVacanteUseCaseImpl` enriches domain model with `Campanha` association and structured `jsonify()` logging
+
+### Changed
+- refactor(mercadopagoContext): Renamed `makeContext()` → `makeContextCuota()` in both `MercadoPagoCoreService` and `MercadoPagoCoreController` for semantic clarity
+  - Updated `MercadoPagoCoreController.makeContext()` caller
+  - Updated `GetDeudaPersonaUseCaseImpl` reference
+- fix(chequeraCuota): Consolidated ISO 8601 date format pattern from `yyyy-MM-dd'T'HH:mm:ssZ` to `yyyy-MM-dd'T'HH:mm:ssXX` across all entities
+  - `ChequeraCuotaEntity`: 3 `@JsonFormat` patterns updated
+  - `MercadoPagoContext`: 4 `@JsonFormat` patterns updated (fechaVencimiento, lastVencimientoUpdated, fechaPago, fechaAcreditacion)
+  - `MercadoPagoContextDto`: 1 `@JsonFormat` pattern updated
+  - `ReservaVacante`, `ReservaVacanteEntity`, `ReservaVacanteResponse`: new `@JsonFormat` with correct pattern
+- fix(mercadopagoContext): Corrected `isCuotaAvailable()` logic from `!=` to `==` comparisons for `pagado`, `baja`, `compensada` fields
+- refactor(reservaVacante): Removed `@Transactional` from `CreateReservaVacanteUseCaseImpl`
+- refactor(dto): `UMPreferenceMPDto` extended with `ReservaVacante` field alongside `ChequeraCuotaEntity`
+- refactor(reservaVacante): `PreferenceClient.createPreference()` method signature simplified to single line
+- chore(logging): Added `@Slf4j` and structured `jsonify()` logging in `ReservaVacanteDtoMapper`
+
+> Basado en análisis profundo de `git diff HEAD` (21 archivos modificados, +166/-19 líneas) y `pom.xml` (versión actual 3.25.0).
+
 ## [3.25.0] - 2026-06-15
 ### Added
 - feat(mercadoPagoContext): New `reservaVacanteId` (UUID) field and domain associations `ChequeraCuota`/`ReservaVacante`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,25 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.25.0**
+**Versión actual (SemVer): 3.26.0**
+
+## Novedades 3.26.0 (verificado en código)
+- feat(mercadopagoContext): Nuevo `FindActiveByReservaVacanteIdUseCase` para recuperar contexto MP activo por `reservaVacanteId` (UUID)
+  - Nuevo puerto de entrada, implementación, método en repositorio (`findByReservaVacanteIdAndActivo`), método JPA y adaptador
+- feat(mercadopagoContext): Nuevo `PreferenceVacanteClient` Feign client para crear preferencias de vacantes
+- feat(mercadopagoContext): `MercadoPagoContext` domain model con `jsonify()` para logging estructurado
+- feat(reservaVacante): Integración con MercadoPago al crear reserva — nuevo `MercadoPagoCoreService.createContextVacante()` y `PreferenceVacanteClient.createPreference()`
+- feat(reservaVacante): Nuevo campo `Campanha campanha` en modelo de dominio `ReservaVacante`
+- feat(reservaVacante): `ReservaVacanteResponse` mejorado con `initPoint` desde MercadoPagoContext
+  - `ReservaVacanteDtoMapper` ahora inyecta `MercadoPagoContextService` para resolver `initPoint`
+- feat(reservaVacante): `FindReservaVacanteUseCaseImpl` ahora enriquece con `Campanha` y logging con `jsonify()`
+- fix(chequeraCuota/mercadopagoContext): Formato de fecha ISO 8601 unificado a `yyyy-MM-dd'T'HH:mm:ssXX` en todas las entidades
+- fix(mercadopagoContext): Corregida lógica `isCuotaAvailable()` — comparación `!=` → `==` para campos `pagado`, `baja`, `compensada`
+- refactor(mercadopagoContext): Renombrado `makeContext()` → `makeContextCuota()` en `MercadoPagoCoreService` y `MercadoPagoCoreController`
+- refactor(reservaVacante): Eliminado `@Transactional` de `CreateReservaVacanteUseCaseImpl`
+- refactor(dto): `UMPreferenceMPDto` extendido con campo `ReservaVacante`
+
+> Basado en análisis profundo de `git diff HEAD` (21 archivos modificados, +166/-19 líneas) y `pom.xml` (versión 3.25.0 → 3.26.0).
 
 ## Novedades 3.25.0 (verificado en código)
 - feat(mercadoPagoContext): New `reservaVacanteId` (UUID) field and domain associations `ChequeraCuota`/`ReservaVacante`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.25.0** (actualizada: 2026-06-15)
+**Versión actual del servicio: 3.26.0** (actualizada: 2026-06-15)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -8,7 +8,8 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `architecture.mmd`: Arquitectura general (controladores, servicios, repositorios, entidades).
 - `hexagonal-architecture.mmd`: Arquitectura hexagonal implementada en el caso de uso Curso Cargo Contratado.
 - `hexagonal-articulo.mmd`: Arquitectura hexagonal del módulo Artículo (gestión de artículos) - v3.13.0.
-- `hexagonal-chequeraCuota.mmd`: Arquitectura hexagonal del caso de uso Chequera Cuota (flujo de pago de cuotas) - v3.25.0.
+- `hexagonal-chequeraCuota.mmd`: Arquitectura hexagonal del caso de uso Chequera Cuota (flujo de pago de cuotas) - v3.26.0.
+- `hexagonal-mercadoPagoContext.mmd`: Arquitectura hexagonal del módulo MercadoPagoContext (contexto de pagos MP) - v3.26.0.
 - `hexagonal-auth.mmd`: Arquitectura hexagonal del módulo Auth (autenticación de usuarios).
 - `hexagonal-geografica.mmd`: Arquitectura hexagonal del módulo Geografica (entidades geográficas).
 - `hexagonal-proveedor.mmd`: Arquitectura hexagonal del módulo Proveedor (gestión de proveedores).
@@ -23,10 +24,10 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-chequeraSerie.mmd`: Arquitectura hexagonal del módulo ChequeraSerie (gestión de series de chequeras) - v3.21.0.
 - `hexagonal-baja.mmd`: Arquitectura hexagonal del módulo Baja (gestión de bajas de chequeras) - v3.21.0.
 - `hexagonal-campanha.mmd`: Arquitectura hexagonal del módulo Campanha (gestión de campañas UM Hub) - v3.24.0.
-- `hexagonal-reservaVacante.mmd`: Arquitectura hexagonal del módulo ReservaVacante (gestión de reservas de vacantes UM Hub) - v3.24.0.
+- `hexagonal-reservaVacante.mmd`: Arquitectura hexagonal del módulo ReservaVacante (gestión de reservas de vacantes UM Hub) - v3.26.0.
 - `hexagonal-domicilio.mmd`: Arquitectura hexagonal del módulo Domicilio (gestión de domicilios) - v3.24.0.
 - `hexagonal-persona.mmd`: Arquitectura hexagonal del módulo Persona (gestión de personas) - v3.24.0.
-- `hexagonal-mercadoPagoContext.mmd`: Arquitectura hexagonal del módulo MercadoPagoContext (contexto de pagos MP) - v3.25.0.
+
 - `deployment.mmd`: Diagrama de despliegue del microservicio.
 
 ## Diagramas de Datos

--- a/docs/entities.mmd
+++ b/docs/entities.mmd
@@ -14,6 +14,7 @@ erDiagram
     Persona ||--o{ Domicilio : "domicilio"
     Persona ||--o{ Legajo : "legajo"
     MercadoPagoContext ||--o{ MercadoPagoContextHistory : "tiene historial"
+    MercadoPagoContext ||--o{ ReservaVacante : "asociado a"
     Facultad ||--o{ Dependencia : "tiene"
     Geografica ||--o{ Dependencia : "ubicada en"
     Cuenta ||--o{ Dependencia : "asociada a"

--- a/docs/hexagonal-mercadoPagoContext.mmd
+++ b/docs/hexagonal-mercadoPagoContext.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo MercadoPagoContext (v3.25.0)
+title: Arquitectura Hexagonal - Módulo MercadoPagoContext (v3.26.0)
 ---
 
 classDiagram
@@ -34,6 +34,7 @@ classDiagram
             <<interface>>
             +findByMercadoPagoContextId(Long) Optional~MercadoPagoContext~
             +findByChequeraCuotaIdAndActivo(Long, Byte) Optional~MercadoPagoContext~
+            +findByReservaVacanteIdAndActivo(UUID, Byte) Optional~MercadoPagoContext~
             +findAllByChequeraCuotaIdAndActivo(Long, Byte) List~MercadoPagoContext~
             +findAllActiveChequeraCuota() List~Long~
             +findAllActiveToChange(OffsetDateTime, OffsetDateTime) List~MercadoPagoContext~
@@ -60,6 +61,7 @@ classDiagram
             +add(MercadoPagoContext) MercadoPagoContext
             +findById(Long) Optional~MercadoPagoContext~
             +findActiveByChequeraCuotaId(Long) Optional~MercadoPagoContext~
+            +findActiveByReservaVacanteId(UUID) MercadoPagoContext
             +findAllActiveChequeraCuota() List~Long~
             +findAllActiveToChange() List~MercadoPagoContext~
             +findAllByChequeraCuotaIdAndActivo(Long, Byte) List~MercadoPagoContext~
@@ -74,6 +76,7 @@ classDiagram
             class AddMercadoPagoContextUseCaseImpl
             class FindByMercadoPagoContextIdUseCaseImpl
             class FindActiveByChequeraCuotaIdUseCaseImpl
+            class FindActiveByReservaVacanteIdUseCaseImpl
             class FindAllActiveChequeraCuotaUseCaseImpl
             class FindAllActiveToChangeUseCaseImpl
             class FindAllByChequeraCuotaIdAndActivoUseCaseImpl
@@ -87,6 +90,7 @@ classDiagram
         class AddMercadoPagoContextUseCase { <<interface>> }
         class FindByMercadoPagoContextIdUseCase { <<interface>> }
         class FindActiveByChequeraCuotaIdUseCase { <<interface>> }
+        class FindActiveByReservaVacanteIdUseCase { <<interface>> }
         class FindAllActiveChequeraCuotaUseCase { <<interface>> }
         class FindAllActiveToChangeUseCase { <<interface>> }
         class FindAllByChequeraCuotaIdAndActivoUseCase { <<interface>> }
@@ -119,6 +123,7 @@ classDiagram
                 <<JpaRepository>>
                 +findByMercadoPagoContextId(Long) Optional~MercadoPagoContextEntity~
                 +findByChequeraCuotaIdAndActivo(Long, Byte) Optional~MercadoPagoContextEntity~
+                +findByReservaVacanteId(UUID) Optional~MercadoPagoContextEntity~
                 +findAllByChequeraCuotaIdAndActivo(Long, Byte) List~MercadoPagoContextEntity~
                 +findAllByActivoAndFechaVencimientoBetween(OffsetDateTime, OffsetDateTime) List~MercadoPagoContextEntity~
                 +findAllByChequeraCuotaIdInAndActivo(List~Long~, Byte) List~MercadoPagoContextEntity~
@@ -131,6 +136,7 @@ classDiagram
                 -MercadoPagoContextMapper mapper
                 +findByMercadoPagoContextId(Long) Optional~MercadoPagoContext~
                 +findByChequeraCuotaIdAndActivo(Long, Byte) Optional~MercadoPagoContext~
+                +findByReservaVacanteIdAndActivo(UUID, Byte) Optional~MercadoPagoContext~
                 +findAllByChequeraCuotaIdAndActivo(Long, Byte) List~MercadoPagoContext~
                 +findAllActiveChequeraCuota() List~Long~
                 +findAllActiveToChange(OffsetDateTime, OffsetDateTime) List~MercadoPagoContext~
@@ -189,6 +195,7 @@ classDiagram
     MercadoPagoContextService --> AddMercadoPagoContextUseCase : uses
     MercadoPagoContextService --> FindByMercadoPagoContextIdUseCase : uses
     MercadoPagoContextService --> FindActiveByChequeraCuotaIdUseCase : uses
+    MercadoPagoContextService --> FindActiveByReservaVacanteIdUseCase : uses
     MercadoPagoContextService --> FindAllActiveChequeraCuotaUseCase : uses
     MercadoPagoContextService --> FindAllActiveToChangeUseCase : uses
     MercadoPagoContextService --> FindAllByChequeraCuotaIdAndActivoUseCase : uses
@@ -201,6 +208,7 @@ classDiagram
     AddMercadoPagoContextUseCaseImpl ..|> AddMercadoPagoContextUseCase : implements
     FindByMercadoPagoContextIdUseCaseImpl ..|> FindByMercadoPagoContextIdUseCase : implements
     FindActiveByChequeraCuotaIdUseCaseImpl ..|> FindActiveByChequeraCuotaIdUseCase : implements
+    FindActiveByReservaVacanteIdUseCaseImpl ..|> FindActiveByReservaVacanteIdUseCase : implements
     FindAllActiveChequeraCuotaUseCaseImpl ..|> FindAllActiveChequeraCuotaUseCase : implements
     FindAllActiveToChangeUseCaseImpl ..|> FindAllActiveToChangeUseCase : implements
     FindAllByChequeraCuotaIdAndActivoUseCaseImpl ..|> FindAllByChequeraCuotaIdAndActivoUseCase : implements
@@ -213,6 +221,7 @@ classDiagram
     AddMercadoPagoContextUseCaseImpl --> MercadoPagoContextRepository : uses
     FindByMercadoPagoContextIdUseCaseImpl --> MercadoPagoContextRepository : uses
     FindActiveByChequeraCuotaIdUseCaseImpl --> MercadoPagoContextRepository : uses
+    FindActiveByReservaVacanteIdUseCaseImpl --> MercadoPagoContextRepository : uses
     FindAllActiveToChangeUseCaseImpl --> MercadoPagoContextRepository : uses
     UpdateMercadoPagoContextUseCaseImpl --> MercadoPagoContextRepository : uses
     ProcessPaymentEventUseCaseImpl --> MercadoPagoContextRepository : uses

--- a/docs/hexagonal-reservaVacante.mmd
+++ b/docs/hexagonal-reservaVacante.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo ReservaVacante (v3.24.0)
+title: Arquitectura Hexagonal - Módulo ReservaVacante (v3.26.0)
 ---
 
 classDiagram
@@ -13,6 +13,7 @@ classDiagram
             +String estado
             +BigDecimal importe
             +OffsetDateTime vencimiento
+            +Campanha campanha
             +Persona persona
             +Domicilio domicilio
             +LocalDateTime created
@@ -41,12 +42,15 @@ classDiagram
                 -PersonaService personaService
                 -DomicilioService domicilioService
                 -CampanhaService campanhaService
+                -MercadoPagoCoreService mercadoPagoCoreService
+                -PreferenceVacanteClient preferenceVacanteClient
                 +createReservaVacante(ReservaVacanteRequest) ReservaVacante
             }
             class FindReservaVacanteUseCaseImpl {
                 -ReservaVacanteRepository repository
                 -PersonaService personaService
                 -DomicilioService domicilioService
+                -CampanhaService campanhaService
                 +findByReservaVacanteId(UUID) ReservaVacante
             }
         }
@@ -117,14 +121,16 @@ classDiagram
                 +String apellido
                 +String email
                 +UUID campanhaId
+                +String estado
                 +BigDecimal importe
                 +OffsetDateTime vencimiento
+                +String initPoint
                 +LocalDateTime created
-                +String estado
                 +LocalDateTime updated
             }
 
             class ReservaVacanteDtoMapper {
+                -MercadoPagoContextService mercadoPagoContextService
                 +toDomain(ReservaVacanteRequest) ReservaVacante
                 +toResponse(ReservaVacante) ReservaVacanteResponse
             }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.25.0</version>
+    <version>3.26.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/client/tesoreria/mercadopago/PreferenceVacanteClient.java
+++ b/src/main/java/um/tesoreria/core/client/tesoreria/mercadopago/PreferenceVacanteClient.java
@@ -3,11 +3,11 @@ package um.tesoreria.core.client.tesoreria.mercadopago;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import um.tesoreria.core.model.dto.UMPreferenceMPDto;
 import um.tesoreria.core.model.dto.MercadoPagoContextDto;
+import um.tesoreria.core.model.dto.UMPreferenceMPDto;
 
-@FeignClient(name = "tesoreria-mercadopago-service", contextId = "preferenceClient", path = "/api/tesoreria/mercadopago/preference")
-public interface PreferenceClient {
+@FeignClient(name = "tesoreria-mercadopago-service", contextId = "preferenceVacanteClient", path = "/api/tesoreria/mercadopago/vacante/preference")
+public interface PreferenceVacanteClient {
 
     @PostMapping("/create")
     MercadoPagoContextDto createPreference(@RequestBody UMPreferenceMPDto umPreferenceMPDto);

--- a/src/main/java/um/tesoreria/core/controller/facade/MercadoPagoCoreController.java
+++ b/src/main/java/um/tesoreria/core/controller/facade/MercadoPagoCoreController.java
@@ -20,7 +20,7 @@ public class MercadoPagoCoreController {
     @GetMapping("/makeContext/{chequeraCuotaId}")
     public ResponseEntity<UMPreferenceMPDto> makeContext(@PathVariable Long chequeraCuotaId) {
         try {
-            return ResponseEntity.ok(service.makeContext(chequeraCuotaId));
+            return ResponseEntity.ok(service.makeContextCuota(chequeraCuotaId));
         } catch (MercadoPagoContextException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequeraCuota/infrastructure/persistence/entity/ChequeraCuotaEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequeraCuota/infrastructure/persistence/entity/ChequeraCuotaEntity.java
@@ -58,7 +58,7 @@ public class ChequeraCuotaEntity extends Auditable {
     private Integer arancelTipoId;
 
     @Column(name = "chc_1er_vencimiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento1;
 
     @Builder.Default
@@ -70,7 +70,7 @@ public class ChequeraCuotaEntity extends Auditable {
     private BigDecimal importe1Original = BigDecimal.ZERO;
 
     @Column(name = "chc_2do_vencimiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento2;
 
     @Builder.Default
@@ -82,7 +82,7 @@ public class ChequeraCuotaEntity extends Auditable {
     private BigDecimal importe2Original = BigDecimal.ZERO;
 
     @Column(name = "chc_3er_vencimiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento3;
 
     @Builder.Default

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/application/service/MercadoPagoContextService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/application/service/MercadoPagoContextService.java
@@ -10,6 +10,7 @@ import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model.MercadoPagoCo
 import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.ports.in.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -18,6 +19,7 @@ public class MercadoPagoContextService {
 
     private final AddMercadoPagoContextUseCase addMercadoPagoContextUseCase;
     private final FindActiveByChequeraCuotaIdUseCase findActiveByChequeraCuotaIdUseCase;
+    private final FindActiveByReservaVacanteIdUseCase findActiveByReservaVacanteIdUseCase;
     private final FindAllActiveChequeraCuotaUseCase findAllActiveChequeraCuotaUseCase;
     private final FindAllActiveToChangeUseCase findAllActiveToChangeUseCase;
     private final FindAllByChequeraCuotaIdAndActivoUseCase findAllByChequeraCuotaIdAndActivoUseCase;
@@ -48,6 +50,18 @@ public class MercadoPagoContextService {
         log.debug("\n\nProcessing MercadoPagoContextService.findActiveByChequeraCuotaId\n\n");
         try {
             return findActiveByChequeraCuotaIdUseCase.findActiveByChequeraCuotaId(chequeraCuotaId);
+        } catch (MercadoPagoContextException e) {
+            log.debug("\n\nNo se encontró contexto activo\n\n");
+            return null;
+        }
+    }
+
+    public MercadoPagoContext findActiveByReservaVacanteId(UUID reservaVacanteId) {
+        log.debug("\n\nProcessing MercadoPagoContextService.findActiveByReservaVacanteId\n\n");
+        try {
+            var context = findActiveByReservaVacanteIdUseCase.findActiveByReservaVacanteId(reservaVacanteId);
+            log.debug("MercadoPagoContext -> {}", context.jsonify());
+            return context;
         } catch (MercadoPagoContextException e) {
             log.debug("\n\nNo se encontró contexto activo\n\n");
             return null;

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/application/usecases/FindActiveByReservaVacanteIdUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/application/usecases/FindActiveByReservaVacanteIdUseCaseImpl.java
@@ -1,0 +1,23 @@
+package um.tesoreria.core.hexagonal.mercadoPagoContext.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.mercadoPagoContext.application.exception.MercadoPagoContextException;
+import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model.MercadoPagoContext;
+import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.ports.in.FindActiveByReservaVacanteIdUseCase;
+import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.ports.out.MercadoPagoContextRepository;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class FindActiveByReservaVacanteIdUseCaseImpl implements FindActiveByReservaVacanteIdUseCase {
+
+    private final MercadoPagoContextRepository repository;
+
+    @Override
+    public MercadoPagoContext findActiveByReservaVacanteId(UUID reservaVacanteId) {
+        return repository.findByReservaVacanteIdAndActivo(reservaVacanteId, (byte) 1)
+                .orElseThrow(() -> new MercadoPagoContextException("No se encontró MPContext para reservaVacanteId " + reservaVacanteId, null));
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/domain/model/MercadoPagoContext.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/domain/model/MercadoPagoContext.java
@@ -1,8 +1,10 @@
 package um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import um.tesoreria.core.hexagonal.chequeraCuota.domain.model.ChequeraCuota;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.model.ReservaVacante;
+import um.tesoreria.core.util.Jsonifier;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -19,6 +21,7 @@ public class MercadoPagoContext {
     private Long chequeraCuotaId;
     private UUID reservaVacanteId;
     private String initPoint;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaVencimiento;
 
     @Builder.Default
@@ -27,6 +30,7 @@ public class MercadoPagoContext {
     @Builder.Default
     private Byte changed = 0;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime lastVencimientoUpdated;
     private String preferenceId;
     private String preference;
@@ -37,7 +41,9 @@ public class MercadoPagoContext {
     private Long chequeraPagoId;
     private String idMercadoPago;
     private String status;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaPago;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaAcreditacion;
 
     @Builder.Default
@@ -48,4 +54,7 @@ public class MercadoPagoContext {
     private ChequeraCuota chequeraCuota;
     private ReservaVacante reservaVacante;
 
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/domain/ports/in/FindActiveByReservaVacanteIdUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/domain/ports/in/FindActiveByReservaVacanteIdUseCase.java
@@ -1,0 +1,9 @@
+package um.tesoreria.core.hexagonal.mercadoPagoContext.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model.MercadoPagoContext;
+
+import java.util.UUID;
+
+public interface FindActiveByReservaVacanteIdUseCase {
+    MercadoPagoContext findActiveByReservaVacanteId(UUID reservaVacanteId);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/domain/ports/out/MercadoPagoContextRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/domain/ports/out/MercadoPagoContextRepository.java
@@ -4,6 +4,7 @@ import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model.MercadoPagoCo
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface MercadoPagoContextRepository {
 
@@ -16,6 +17,8 @@ public interface MercadoPagoContextRepository {
     Optional<MercadoPagoContext> findByMercadoPagoContextId(Long mercadoPagoContextId);
 
     Optional<MercadoPagoContext> findByChequeraCuotaIdAndActivo(Long chequeraCuotaId, Byte activo);
+
+    Optional<MercadoPagoContext> findByReservaVacanteIdAndActivo(UUID reservaVacanteId, Byte activo);
 
     List<MercadoPagoContext> findAllByActivoOrderByMercadoPagoContextIdDesc(Byte activo);
 

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/infrastructure/persistence/repository/JpaMercadoPagoContextRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/infrastructure/persistence/repository/JpaMercadoPagoContextRepository.java
@@ -6,6 +6,7 @@ import um.tesoreria.core.hexagonal.mercadoPagoContext.infrastructure.persistence
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface JpaMercadoPagoContextRepository extends JpaRepository<MercadoPagoContextEntity, Long> {
 
@@ -14,6 +15,8 @@ public interface JpaMercadoPagoContextRepository extends JpaRepository<MercadoPa
     List<MercadoPagoContextEntity> findAllByStatusAndChequeraPagoIdIsNull(String status);
 
     Optional<MercadoPagoContextEntity> findByChequeraCuotaIdAndActivo(Long chequeraCuotaId, Byte activo);
+
+    Optional<MercadoPagoContextEntity> findByReservaVacanteId(UUID reservaVacanteId);
 
     Optional<MercadoPagoContextEntity> findByMercadoPagoContextId(Long mercadoPagoContextId);
 

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/infrastructure/persistence/repository/JpaMercadoPagoContextRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/infrastructure/persistence/repository/JpaMercadoPagoContextRepositoryAdapter.java
@@ -10,6 +10,7 @@ import um.tesoreria.core.hexagonal.mercadoPagoContext.infrastructure.persistence
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Component
@@ -52,6 +53,12 @@ public class JpaMercadoPagoContextRepositoryAdapter implements MercadoPagoContex
     @Override
     public Optional<MercadoPagoContext> findByChequeraCuotaIdAndActivo(Long chequeraCuotaId, Byte activo) {
         return repository.findByChequeraCuotaIdAndActivo(chequeraCuotaId, activo)
+                .map(mapper::toDomainModel);
+    }
+
+    @Override
+    public Optional<MercadoPagoContext> findByReservaVacanteIdAndActivo(UUID reservaVacanteId, Byte activo) {
+        return repository.findByReservaVacanteId(reservaVacanteId)
                 .map(mapper::toDomainModel);
     }
 

--- a/src/main/java/um/tesoreria/core/hexagonal/persona/application/usecases/GetDeudaPersonaUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/persona/application/usecases/GetDeudaPersonaUseCaseImpl.java
@@ -81,8 +81,8 @@ public class GetDeudaPersonaUseCaseImpl implements GetDeudaPersonaUseCase {
             List<ChequeraSerieEntity> groupSeries = entry.getValue();
             if (groupSeries.isEmpty()) continue;
             
-            Integer facultadId = groupSeries.get(0).getFacultadId();
-            Integer tipoChequeraId = groupSeries.get(0).getTipoChequeraId();
+            Integer facultadId = groupSeries.getFirst().getFacultadId();
+            Integer tipoChequeraId = groupSeries.getFirst().getTipoChequeraId();
             List<Long> serieIds = groupSeries.stream().map(ChequeraSerieEntity::getChequeraSerieId).collect(Collectors.toList());
 
             allCuotas.addAll(chequeraCuotaService.findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIds(
@@ -157,7 +157,7 @@ public class GetDeudaPersonaUseCaseImpl implements GetDeudaPersonaUseCase {
                         && chequeraCuota.getImporte1().compareTo(BigDecimal.ZERO) != 0) {
 
                     MercadoPagoContext existingContext = contextsByCuotaId.get(chequeraCuota.getChequeraCuotaId());
-                    var umPreferenceMPDto = mercadoPagoCoreService.makeContext(chequeraCuota, existingContext);
+                    var umPreferenceMPDto = mercadoPagoCoreService.makeContextCuota(chequeraCuota, existingContext);
 
                     if (umPreferenceMPDto != null) {
                         var context = umPreferenceMPDto.getMercadoPagoContext();

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/CreateReservaVacanteUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/CreateReservaVacanteUseCaseImpl.java
@@ -1,13 +1,14 @@
 package um.tesoreria.core.hexagonal.umhub.reservaVacante.application.usecases;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import um.tesoreria.core.client.tesoreria.mercadopago.PreferenceVacanteClient;
 import um.tesoreria.core.exception.PersonaException;
 import um.tesoreria.core.hexagonal.domicilio.application.exception.DomicilioException;
 import um.tesoreria.core.hexagonal.domicilio.application.service.DomicilioService;
 import um.tesoreria.core.hexagonal.domicilio.domain.model.Domicilio;
+import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model.MercadoPagoContext;
 import um.tesoreria.core.hexagonal.persona.application.service.PersonaService;
 import um.tesoreria.core.hexagonal.persona.domain.model.Persona;
 import um.tesoreria.core.hexagonal.umhub.campanha.application.service.CampanhaService;
@@ -17,6 +18,7 @@ import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.model.ReservaVaca
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.ports.in.CreateReservaVacanteUseCase;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.ports.out.ReservaVacanteRepository;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.infrastructure.web.dto.ReservaVacanteRequest;
+import um.tesoreria.core.service.facade.MercadoPagoCoreService;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;
@@ -32,9 +34,10 @@ public class CreateReservaVacanteUseCaseImpl implements CreateReservaVacanteUseC
     private final PersonaService personaService;
     private final DomicilioService domicilioService;
     private final CampanhaService campanhaService;
+    private final MercadoPagoCoreService mercadoPagoCoreService;
+    private final PreferenceVacanteClient preferenceVacanteClient;
 
     @Override
-    @Transactional
     public ReservaVacante createReservaVacante(ReservaVacanteRequest reservaVacanteRequest) {
         log.debug("\n\nProcessing CreateReservaVacanteUseCaseImpl.createReservaVacante\n\n");
         // Verificar persona
@@ -98,7 +101,10 @@ public class CreateReservaVacanteUseCaseImpl implements CreateReservaVacanteUseC
         reservaVacante = repository.create(reservaVacante);
         reservaVacante.setPersona(persona);
         reservaVacante.setDomicilio(domicilio);
+        reservaVacante.setCampanha(campanha);
         log.debug("ReservaVacante -> {}", reservaVacante.jsonify());
+        var umPreferenceMPDto = mercadoPagoCoreService.createContextVacante(reservaVacante);
+        preferenceVacanteClient.createPreference(umPreferenceMPDto);
         return reservaVacante;
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/FindReservaVacanteUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/FindReservaVacanteUseCaseImpl.java
@@ -7,6 +7,8 @@ import um.tesoreria.core.hexagonal.domicilio.application.service.DomicilioServic
 import um.tesoreria.core.hexagonal.domicilio.domain.model.Domicilio;
 import um.tesoreria.core.hexagonal.persona.application.service.PersonaService;
 import um.tesoreria.core.hexagonal.persona.domain.model.Persona;
+import um.tesoreria.core.hexagonal.umhub.campanha.application.service.CampanhaService;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.application.exception.ReservaVacanteException;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.model.ReservaVacante;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.ports.in.FindReservaVacanteUseCase;
@@ -25,13 +27,15 @@ public class FindReservaVacanteUseCaseImpl implements FindReservaVacanteUseCase 
 
     @Override
     public ReservaVacante findByReservaVacanteId(UUID reservaVacanteId) {
-        log.debug("Finding ReservaVacante by ID: {}", reservaVacanteId);
+        log.debug("\n\nFinding ReservaVacante by ID: {}\n\n", reservaVacanteId);
         ReservaVacante reservaVacante = repository.findByReservaVacanteId(reservaVacanteId)
                 .orElseThrow(() -> new ReservaVacanteException(reservaVacanteId));
+        reservaVacante.setCampanha(reservaVacante.getCampanha());
         Persona persona = personaService.findByUniqueId(reservaVacante.getPersonaUniqueId());
         reservaVacante.setPersona(persona);
         Domicilio domicilio = domicilioService.findByUnique(persona.getPersonaId(), persona.getDocumentoId());
         reservaVacante.setDomicilio(domicilio);
+        log.debug("ReservaVacante -> {}", reservaVacante.jsonify());
         return reservaVacante;
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/domain/model/ReservaVacante.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/domain/model/ReservaVacante.java
@@ -1,8 +1,10 @@
 package um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import um.tesoreria.core.hexagonal.domicilio.domain.model.Domicilio;
 import um.tesoreria.core.hexagonal.persona.domain.model.Persona;
+import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
 import um.tesoreria.core.util.Jsonifier;
 
 import java.math.BigDecimal;
@@ -22,7 +24,9 @@ public class ReservaVacante {
     private UUID campanhaId;
     private String estado;
     private BigDecimal importe;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento;
+    private Campanha campanha;
     private Persona persona;
     private Domicilio domicilio;
     private LocalDateTime created;

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/infrastructure/persistence/entity/ReservaVacanteEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/infrastructure/persistence/entity/ReservaVacanteEntity.java
@@ -1,5 +1,6 @@
 package um.tesoreria.core.hexagonal.umhub.reservaVacante.infrastructure.persistence.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,6 +32,8 @@ public class ReservaVacanteEntity extends Auditable {
     private UUID campanhaId;
     private String estado;
     private BigDecimal importe;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento;
 
     @OneToOne(optional = true)

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/infrastructure/web/dto/ReservaVacanteResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/infrastructure/web/dto/ReservaVacanteResponse.java
@@ -1,6 +1,8 @@
 package um.tesoreria.core.hexagonal.umhub.reservaVacante.infrastructure.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
+import um.tesoreria.core.util.Jsonifier;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -20,9 +22,15 @@ public class ReservaVacanteResponse {
     private String apellido;
     private String email;
     private UUID campanhaId;
-    private BigDecimal importe;
-    private OffsetDateTime vencimiento;
-    private LocalDateTime created;
     private String estado;
+    private BigDecimal importe;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
+    private OffsetDateTime vencimiento;
+    private String initPoint;
+    private LocalDateTime created;
     private LocalDateTime updated;
+
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/infrastructure/web/mapper/ReservaVacanteDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/infrastructure/web/mapper/ReservaVacanteDtoMapper.java
@@ -1,12 +1,21 @@
 package um.tesoreria.core.hexagonal.umhub.reservaVacante.infrastructure.web.mapper;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.mercadoPagoContext.application.service.MercadoPagoContextService;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.model.ReservaVacante;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.infrastructure.web.dto.ReservaVacanteRequest;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.infrastructure.web.dto.ReservaVacanteResponse;
 
 @Component
+@Slf4j
 public class ReservaVacanteDtoMapper {
+
+    private final MercadoPagoContextService mercadoPagoContextService;
+
+    public ReservaVacanteDtoMapper(MercadoPagoContextService mercadoPagoContextService) {
+        this.mercadoPagoContextService = mercadoPagoContextService;
+    }
 
     public ReservaVacante toDomain(ReservaVacanteRequest request) {
         if (request == null) return null;
@@ -16,8 +25,9 @@ public class ReservaVacanteDtoMapper {
     }
 
     public ReservaVacanteResponse toResponse(ReservaVacante domain) {
+        log.debug("\n\nProcessing ReservaVacanteDtoMapper\n\n");
         if (domain == null) return null;
-        return ReservaVacanteResponse.builder()
+        var response = ReservaVacanteResponse.builder()
                 .reservaVacanteId(domain.getReservaVacanteId())
                 .tipoDocumento(domain.getPersona().getDocumentoId())
                 .numeroDocumento(domain.getPersona().getPersonaId().toPlainString())
@@ -25,11 +35,14 @@ public class ReservaVacanteDtoMapper {
                 .apellido(domain.getPersona().getApellido())
                 .email(domain.getDomicilio().getEmailPersonal())
                 .campanhaId(domain.getCampanhaId())
+                .estado(domain.getEstado())
                 .importe(domain.getImporte())
                 .vencimiento(domain.getVencimiento())
+                .initPoint(mercadoPagoContextService.findActiveByReservaVacanteId(domain.getReservaVacanteId()).getInitPoint())
                 .created(domain.getCreated())
-                .estado(domain.getEstado())
                 .updated(domain.getUpdated())
                 .build();
+        log.debug("response -> {}", response.jsonify());
+        return response;
     }
 }

--- a/src/main/java/um/tesoreria/core/model/dto/MercadoPagoContextDto.java
+++ b/src/main/java/um/tesoreria/core/model/dto/MercadoPagoContextDto.java
@@ -19,7 +19,7 @@ public class MercadoPagoContextDto {
     private Long chequeraCuotaId;
     private String initPoint;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaVencimiento;
 
     @Builder.Default

--- a/src/main/java/um/tesoreria/core/model/dto/UMPreferenceMPDto.java
+++ b/src/main/java/um/tesoreria/core/model/dto/UMPreferenceMPDto.java
@@ -3,6 +3,7 @@ package um.tesoreria.core.model.dto;
 import lombok.*;
 import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model.MercadoPagoContext;
 import um.tesoreria.core.hexagonal.chequeraCuota.infrastructure.persistence.entity.ChequeraCuotaEntity;
+import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.model.ReservaVacante;
 import um.tesoreria.core.util.Jsonifier;
 
 @Getter
@@ -14,6 +15,7 @@ public class UMPreferenceMPDto {
 
     private MercadoPagoContext mercadoPagoContext;
     private ChequeraCuotaEntity chequeraCuota;
+    private ReservaVacante reservaVacante;
 
     public String jsonify() {
         return Jsonifier.builder(this).build();

--- a/src/main/java/um/tesoreria/core/service/facade/MercadoPagoCoreService.java
+++ b/src/main/java/um/tesoreria/core/service/facade/MercadoPagoCoreService.java
@@ -8,6 +8,7 @@ import um.tesoreria.core.exception.ChequeraCuotaException;
 import um.tesoreria.core.exception.MercadoPagoContextException;
 import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model.MercadoPagoContext;
 import um.tesoreria.core.hexagonal.chequeraCuota.infrastructure.persistence.entity.ChequeraCuotaEntity;
+import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.model.ReservaVacante;
 import um.tesoreria.core.model.dto.UMPreferenceMPDto;
 import um.tesoreria.core.service.ChequeraCuotaService;
 import um.tesoreria.core.hexagonal.mercadoPagoContext.application.service.MercadoPagoContextService;
@@ -32,7 +33,7 @@ public class MercadoPagoCoreService {
     }
 
     @Transactional
-    public UMPreferenceMPDto makeContext(Long chequeraCuotaId) {
+    public UMPreferenceMPDto makeContextCuota(Long chequeraCuotaId) {
         log.debug("\n\nProcessing MercadoPagoCoreService.makeContext\n\n");
 
         var today = LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC);
@@ -53,7 +54,7 @@ public class MercadoPagoCoreService {
     }
 
     @Transactional
-    public UMPreferenceMPDto makeContext(ChequeraCuotaEntity chequeraCuota, MercadoPagoContext existingContext) {
+    public UMPreferenceMPDto makeContextCuota(ChequeraCuotaEntity chequeraCuota, MercadoPagoContext existingContext) {
         var today = LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC);
         if (chequeraCuota == null || !isCuotaAvailable(chequeraCuota)) return null;
 
@@ -67,7 +68,7 @@ public class MercadoPagoCoreService {
 
     private boolean isCuotaAvailable(ChequeraCuotaEntity chequeraCuota) {
         log.debug("\n\nProcessing MercadoPagoCoreService.isCuotaAvailable\n\n");
-        var result = chequeraCuota.getPagado() != 1 && chequeraCuota.getBaja() != 1 && chequeraCuota.getCompensada() != 1;
+        var result = chequeraCuota.getPagado() == 0 && chequeraCuota.getBaja() == 0 && chequeraCuota.getCompensada() == 0;
         log.debug("ChequeraCuota available result -> {}", result);
         return result;
     }
@@ -156,6 +157,30 @@ public class MercadoPagoCoreService {
     public MercadoPagoContext findContextByMercadoPagoContextId(Long mercadoPagoContextId) {
         log.debug("Processing MercadoPagoCoreService.findContextByMercadoPagoContextId");
         return mercadoPagoContextService.findByMercadoPagoContextId(mercadoPagoContextId);
+    }
+
+    @Transactional
+    public UMPreferenceMPDto createContextVacante(ReservaVacante reservaVacante) {
+        log.debug("\n\nProcessing MercadoPagoCoreService.makeContextVacante\n\n");
+        MercadoPagoContext mercadoPagoContext = MercadoPagoContext.builder()
+                .reservaVacanteId(reservaVacante.getReservaVacanteId())
+                .fechaVencimiento(reservaVacante.getVencimiento())
+                .importe(reservaVacante.getImporte())
+                .changed((byte) 0)
+                .activo((byte) 1)
+                .build();
+        mercadoPagoContext = mercadoPagoContextService.add(mercadoPagoContext);
+        var response = buildResponseVacante(mercadoPagoContext, reservaVacante);
+        log.debug("\n\nUMPreferenceMPDto -> {}\n\n", response.jsonify());
+        return response;
+    }
+
+    private UMPreferenceMPDto buildResponseVacante(MercadoPagoContext context, ReservaVacante reservaVacante) {
+        log.debug("\n\nProcessing MercadoPagoCoreService.buildResponseVacante\n\n");
+        return UMPreferenceMPDto.builder()
+                .mercadoPagoContext(context)
+                .reservaVacante(reservaVacante)
+                .build();
     }
 
 }


### PR DESCRIPTION
## Descripción

Integración completa de MercadoPago con el flujo de ReservaVacante. Se añaden casos de uso, clientes Feign, mejoras en el modelo de dominio y correcciones de formato ISO 8601.

## Cambios Realizados

- **feat(mercadopagoContext):** Nuevo `FindActiveByReservaVacanteIdUseCase` para recuperar contexto MP activo por `reservaVacanteId` (UUID)
  - Puerto de entrada, implementación, método en repositorio, método JPA y adaptador
- **feat(mercadopagoContext):** Nuevo `PreferenceVacanteClient` Feign client para crear preferencias de vacantes
- **feat(mercadopagoContext):** Método `jsonify()` en `MercadoPagoContext` para logging estructurado
- **feat(reservaVacante):** Integración MP al crear reserva — `createContextVacante()` y preference via `PreferenceVacanteClient`
- **feat(reservaVacante):** Nuevo campo `Campanha campanha` en modelo `ReservaVacante`
- **feat(reservaVacante):** `ReservaVacanteResponse` enriquecido con `initPoint` desde MercadoPagoContext
- **feat(reservaVacante):** `FindReservaVacanteUseCaseImpl` enriquece con `Campanha` y logging `jsonify()`
- **fix(chequeraCuota/mercadopagoContext):** Formato ISO 8601 unificado a `yyyy-MM-dd'T'HH:mm:ssXX` en todas las entidades (8 campos)
- **fix(mercadopagoContext):** Corregida lógica `isCuotaAvailable()` — comparación `!=` → `==` para `pagado`, `baja`, `compensada`
- **refactor(mercadopagoContext):** Renombrado `makeContext()` → `makeContextCuota()`
- **refactor(reservaVacante):** Eliminado `@Transactional` de `CreateReservaVacanteUseCaseImpl`
- **refactor(dto):** `UMPreferenceMPDto` extendido con campo `ReservaVacante`
- **chore:** Bump version a `3.26.0`, documentación y CHANGELOG actualizados

## Verificación

- [ ] Build: `mvn clean compile` sin errores
- [ ] Análisis: `mvn verify` pasa checks de calidad
- [ ] ISO 8601: Validar formato `XX` en respuestas JSON de ChequeraCuota y MercadoPagoContext
- [ ] Integración: Flujo de creación de reserva vacante genera contexto MP y preferencia correctamente
- [ ] Regresión: Flujo de cuotas existentes (chequera) no se ve afectado por refactor `makeContextCuota()`
