### PR TITLE
fix(model): correct ISO 8601 date format pattern from Z to XX across all model classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.26.1] - 2026-06-18
+### Fixed
+- fix(core): Extendida corrección ISO 8601 a todas las entidades del proyecto (61 archivos)
+  - Migración del patrón `@JsonFormat` de `yyyy-MM-dd'T'HH:mm:ssZ` a `yyyy-MM-dd'T'HH:mm:ssXX` en todos los modelos Java y Kotlin del proyecto
+  - Afecta modelos de dominio, entidades JPA, DTOs y vistas en los paquetes `model/`, `kotlin/model/` y `hexagonal/*/entity/`
+  - Garantiza cumplimiento completo con el estándar ISO 8601 (incluye el separador `:` en el offset de zona horaria)
+
+### Changed
+- refactor(core): Unificado formato de fecha ISO 8601 en modelos restantes no cubiertos en v3.26.0
+  - `model/`: ChequeraClase, ChequeraCuotaPersona, ChequeraIncompleta, ChequeraKey, ChequeraPagoReemplazo, ContratoFactura, CuentaMovimientoAsiento, CuentaSearch, CuotaDeuda, CuotaDeudaPayPerTic, Debito, DomicilioHistorico, DomicilioKey, FacturacionElectronica, IngresoAsiento, LegajoKey, LectivoCuota, PayPerTic, TipoPagoFechaAcreditacion, TipoPagoFechaPago
+  - `kotlin/model/`: Asiento, BancoMovimiento, ChequeraCuotaReemplazo, ChequeraEliminada, ChequeraImpresionCabecera, ChequeraImpresionDetalle, ChequeraPago, ChequeraPagoAsiento, ChequeraSerieReemplazo, CuentaMovimiento, Ejercicio, Entrega, Lectivo, Legajo, Plan, ProveedorMovimiento, ProveedorPago, Usuario, ValorMovimiento, ChequeraCuotaDto, ChequeraSerieDto, LectivoDto, AsientoInternal, ClickPagosEntity, ChequeraCuotaDeuda, ChequeraSerieAlta, ChequeraSerieAltaFull
+  - `kotlin/model/dto/`: ChequeraCuotaDto, ChequeraSerieDto, LectivoDto
+  - `extern/model/dto/`: InscripcionDto
+  - Entidades hexagonales: BajaEntity, ChequeraSerieEntity, ContratoEntity, CuentaEntity, DomicilioEntity, MercadoPagoContextEntity
+
+> Basado en análisis profundo de `git diff HEAD` (61 archivos modificados, +115/-115 líneas) y `pom.xml` (versión 3.26.0 → 3.26.1).
+
 ## [3.26.0] - 2026-06-15
 ### Added
 - feat(mercadopagoContext): New `FindActiveByReservaVacanteIdUseCase` for retrieving active MP context by `reservaVacanteId` (UUID)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.26.0**
+**Versión actual (SemVer): 3.26.1**
+
+## Novedades 3.26.1 (verificado en código)
+- fix(core): Extendida corrección ISO 8601 a todas las entidades del proyecto (61 archivos)
+  - Migración del patrón `@JsonFormat` de `yyyy-MM-dd'T'HH:mm:ssZ` a `yyyy-MM-dd'T'HH:mm:ssXX` en todos los modelos Java y Kotlin
+  - Afecta modelos de dominio, entidades JPA, DTOs y vistas en `model/`, `kotlin/model/` y `hexagonal/*/entity/`
+  - Garantiza cumplimiento completo con el estándar ISO 8601 en todas las fechas serializadas
+
+> Basado en análisis profundo de `git diff HEAD` (61 archivos modificados, +115/-115 líneas) y `pom.xml` (versión 3.26.0 → 3.26.1).
 
 ## Novedades 3.26.0 (verificado en código)
 - feat(mercadopagoContext): Nuevo `FindActiveByReservaVacanteIdUseCase` para recuperar contexto MP activo por `reservaVacanteId` (UUID)
@@ -930,7 +938,7 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-brightgreen.svg)](https://spring.io/projects/spring-cloud)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.25.0-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.26.1-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.26.0** (actualizada: 2026-06-15)
+**Versión actual del servicio: 3.26.1** (actualizada: 2026-06-18)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.26.0</version>
+    <version>3.26.1</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/extern/model/dto/InscripcionDto.java
+++ b/src/main/java/um/tesoreria/core/extern/model/dto/InscripcionDto.java
@@ -21,7 +21,7 @@ public class InscripcionDto {
     private Integer lectivoId;
     private Long inscripcionId;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
 
     @Builder.Default

--- a/src/main/java/um/tesoreria/core/hexagonal/baja/infrastructure/persistence/entity/BajaEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/baja/infrastructure/persistence/entity/BajaEntity.java
@@ -47,7 +47,7 @@ public class BajaEntity extends Auditable {
     private Integer documentoId;
 
     @Column(name = "baj_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
 
     @Column(name = "baj_observaciones")

--- a/src/main/java/um/tesoreria/core/hexagonal/chequeraSerie/infrastructure/persistence/entity/ChequeraSerieEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequeraSerie/infrastructure/persistence/entity/ChequeraSerieEntity.java
@@ -61,7 +61,7 @@ public class ChequeraSerieEntity extends Auditable {
     private Integer geograficaId;
 
     @Column(name = "chs_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
 
     @Column(name = "chs_cuotasp")
@@ -101,7 +101,7 @@ public class ChequeraSerieEntity extends Auditable {
 
     private String becaResolucion;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime becaFecha;
 
     private Long becaUserId;
@@ -115,7 +115,7 @@ public class ChequeraSerieEntity extends Auditable {
     private BigDecimal importeDeuda = BigDecimal.ZERO;
 
     @Transient
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime ultimoEnvio;
 
     @OneToOne(optional = true)

--- a/src/main/java/um/tesoreria/core/hexagonal/contrato/infrastructure/persistence/entity/ContratoEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contrato/infrastructure/persistence/entity/ContratoEntity.java
@@ -49,7 +49,7 @@ public class ContratoEntity extends Auditable implements Serializable {
 	private Integer documentoId;
 
 	@Column(name = "con_desde")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime desde;
 
 	@Column(name = "con_fac_id")
@@ -68,7 +68,7 @@ public class ContratoEntity extends Auditable implements Serializable {
 	private Integer cargoMateriaId;
 
 	@Column(name = "con_primervenc")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime primerVencimiento;
 
 	@Builder.Default
@@ -87,7 +87,7 @@ public class ContratoEntity extends Auditable implements Serializable {
 	private BigDecimal canonMensualSinAjuste = BigDecimal.ZERO;
 
 	@Column(name = "con_hasta")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime hasta;
 
 	@Builder.Default

--- a/src/main/java/um/tesoreria/core/hexagonal/cuenta/infrastructure/persistence/entity/CuentaEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/cuenta/infrastructure/persistence/entity/CuentaEntity.java
@@ -48,7 +48,7 @@ public class CuentaEntity extends Auditable {
     @Column(name = "geograficaId")
     private Integer geograficaId;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaBloqueo;
 
     @Builder.Default

--- a/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/persistence/entity/DomicilioEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/persistence/entity/DomicilioEntity.java
@@ -41,7 +41,7 @@ public class DomicilioEntity extends Auditable {
     private Integer documentoId;
 
     @Column(name = "dom_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     @Builder.Default
     private OffsetDateTime fecha = OffsetDateTime.now();
 

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/infrastructure/persistence/entity/MercadoPagoContextEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/infrastructure/persistence/entity/MercadoPagoContextEntity.java
@@ -29,7 +29,7 @@ public class MercadoPagoContextEntity extends Auditable {
     private UUID reservaVacanteId;
     private String initPoint;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaVencimiento;
 
     @Builder.Default
@@ -38,7 +38,7 @@ public class MercadoPagoContextEntity extends Auditable {
     @Builder.Default
     private Byte changed = 0;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime lastVencimientoUpdated;
 
     private String preferenceId;
@@ -51,10 +51,10 @@ public class MercadoPagoContextEntity extends Auditable {
     private String idMercadoPago;
     private String status;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaPago;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaAcreditacion;
 
     @Builder.Default

--- a/src/main/java/um/tesoreria/core/kotlin/model/Asiento.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/Asiento.kt
@@ -25,13 +25,13 @@ data class Asiento(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var asientoId: Long? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     var orden: Int = 0,
     var vinculo: String = "",
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaContra: OffsetDateTime? = null,
 
     var ordenContra: Int? = null,

--- a/src/main/java/um/tesoreria/core/kotlin/model/BancoMovimiento.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/BancoMovimiento.kt
@@ -20,7 +20,7 @@ data class BancoMovimiento(
     var bancariaId: Long? = null,
 
     @Column(name = "lib_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     @Column(name = "lib_orden")
@@ -45,14 +45,14 @@ data class BancoMovimiento(
     var debita: Byte = 0,
 
     @Column(name = "lib_fechaconciliacion")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaConciliacion: OffsetDateTime? = null,
 
     @Column(name = "lib_anulado")
     var anulado: Byte = 0,
 
     @Column(name = "lib_fechaasiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaContable: OffsetDateTime? = null,
 
     @Column(name = "lib_numeroasiento")

--- a/src/main/java/um/tesoreria/core/kotlin/model/ChequeraCuotaReemplazo.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ChequeraCuotaReemplazo.kt
@@ -45,7 +45,7 @@ data class ChequeraCuotaReemplazo(
     var arancelTipoId: Int? = null,
 
     @Column(name = "ccr_1er_Vencimiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var vencimiento1: OffsetDateTime? = null,
 
     @Column(name = "ccr_1er_Importe")
@@ -55,7 +55,7 @@ data class ChequeraCuotaReemplazo(
     var importe1Original: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "ccr_2do_Vencimiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var vencimiento2: OffsetDateTime? = null,
 
     @Column(name = "ccr_2do_Importe")
@@ -65,7 +65,7 @@ data class ChequeraCuotaReemplazo(
     var importe2Original: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "ccr_3er_Vencimiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var vencimiento3: OffsetDateTime? = null,
 
     @Column(name = "ccr_3er_Importe")

--- a/src/main/java/um/tesoreria/core/kotlin/model/ChequeraEliminada.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ChequeraEliminada.kt
@@ -30,7 +30,7 @@ data class ChequeraEliminada(
     var asentado: Byte = 0,
     var geograficaId: Int? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     var cuotasPagadas: Int = 0,

--- a/src/main/java/um/tesoreria/core/kotlin/model/ChequeraImpresionCabecera.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ChequeraImpresionCabecera.kt
@@ -27,7 +27,7 @@ data class ChequeraImpresionCabecera(
     @Column(name = "chequeraserie_id")
     var chequeraSerieId: Long? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     var personaId: BigDecimal? = null,
@@ -45,7 +45,7 @@ data class ChequeraImpresionCabecera(
     var becaPorcentaje: BigDecimal = BigDecimal.ZERO,
     var becaResolucion: String? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var becaFecha: OffsetDateTime? = null,
 
     var becaUserId: Long? = null

--- a/src/main/java/um/tesoreria/core/kotlin/model/ChequeraImpresionDetalle.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ChequeraImpresionDetalle.kt
@@ -33,21 +33,21 @@ data class ChequeraImpresionDetalle(
     var arancelTipoId: Int? = null,
 
     @Column(name = "vencimiento_1")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var vencimiento1: OffsetDateTime? = null,
 
     @Column(name = "importe_1")
     var importe1: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "vencimiento_2")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var vencimiento2: OffsetDateTime? = null,
 
     @Column(name = "importe_2")
     var importe2: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "vencimiento_3")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var vencimiento3: OffsetDateTime? = null,
 
     @Column(name = "importe_3")

--- a/src/main/java/um/tesoreria/core/kotlin/model/ChequeraPago.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ChequeraPago.kt
@@ -46,11 +46,11 @@ data class ChequeraPago(
     var anho: Int = 0,
 
     @Column(name = "chp_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     @Column(name = "chp_acred")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var acreditacion: OffsetDateTime? = null,
 
     @Column(name = "chp_importe")

--- a/src/main/java/um/tesoreria/core/kotlin/model/ChequeraPagoAsiento.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ChequeraPagoAsiento.kt
@@ -24,7 +24,7 @@ data class ChequeraPagoAsiento(
     var chequeraPagoReemplazoId: Long? = null,
     var tipoPagoId: Int? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     @Column(name = "cpa_fac_id")

--- a/src/main/java/um/tesoreria/core/kotlin/model/ChequeraSerieReemplazo.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ChequeraSerieReemplazo.kt
@@ -50,7 +50,7 @@ data class ChequeraSerieReemplazo(
     var geograficaId: Int? = 1,
 
     @Column(name = "CSR_Fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime,
 
     @Column(name = "CSR_CuotasP")

--- a/src/main/java/um/tesoreria/core/kotlin/model/CuentaMovimiento.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/CuentaMovimiento.kt
@@ -32,7 +32,7 @@ data class  CuentaMovimiento(
     var cuentaMovimientoId: Long? = null,
 
     @Column(name = "mco_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaContable: OffsetDateTime? = null,
 
     @Column(name = "mco_nrocomp")

--- a/src/main/java/um/tesoreria/core/kotlin/model/Ejercicio.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/Ejercicio.kt
@@ -22,11 +22,11 @@ data class Ejercicio(
     var nombre: String? = null,
 
     @Column(name = "eje_fechainicio")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaInicio: OffsetDateTime? = Tool.dateAbsoluteArgentina(),
 
     @Column(name = "eje_fechafin")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaFinal: OffsetDateTime? = Tool.dateAbsoluteArgentina(),
 
     @Column(name = "eje_bloqueado")

--- a/src/main/java/um/tesoreria/core/kotlin/model/Entrega.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/Entrega.kt
@@ -22,7 +22,7 @@ data class Entrega (
 	var entregaId: Long? = null,
 
 	@Column(name = "noe_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	var fecha: OffsetDateTime? = null,
 
 	@Column(name = "noe_ubi_id")
@@ -35,7 +35,7 @@ data class Entrega (
 	var observacion: String = "",
 
 	@Column(name = "noe_mco_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	var fechaContable: OffsetDateTime? = null,
 
 	@Column(name = "noe_mco_nrocomp")

--- a/src/main/java/um/tesoreria/core/kotlin/model/Lectivo.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/Lectivo.kt
@@ -20,11 +20,11 @@ data class Lectivo(
     var nombre: String = "",
 
     @Column(name = "lec_inicio")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaInicio: OffsetDateTime? = null,
 
     @Column(name = "lec_fin")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaFinal: OffsetDateTime? = null
 
 ) : Auditable() {

--- a/src/main/java/um/tesoreria/core/kotlin/model/Legajo.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/Legajo.kt
@@ -41,7 +41,7 @@ data class Legajo(
     var numeroLegajo: Long = 0L,
 
     @Column(name = "ale_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     @Column(name = "ale_lec_id")

--- a/src/main/java/um/tesoreria/core/kotlin/model/Plan.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/Plan.kt
@@ -24,7 +24,7 @@ data class Plan(
     var nombre: String = "",
 
     @Column(name = "pla_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime,
 
     @Column(name = "pla_publicar")

--- a/src/main/java/um/tesoreria/core/kotlin/model/ProveedorMovimiento.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ProveedorMovimiento.kt
@@ -36,11 +36,11 @@ data class ProveedorMovimiento @JvmOverloads constructor(
     var comprobanteId: Int? = null,
 
     @Column(name = "mvp_fechacomprob")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaComprobante: OffsetDateTime? = null,
 
     @Column(name = "mvp_fechavenc")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaVencimiento: OffsetDateTime? = null,
 
     @Column(name = "mvp_prefijo")
@@ -65,7 +65,7 @@ data class ProveedorMovimiento @JvmOverloads constructor(
     var cancelado: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "mvp_fechareg")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaContable: OffsetDateTime? = null,
 
     @Column(name = "mvp_nrocomp")
@@ -75,7 +75,7 @@ data class ProveedorMovimiento @JvmOverloads constructor(
     var concepto: String? = null,
 
     @Column(name = "mvp_anulado")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaAnulacion: OffsetDateTime? = null,
 
     @Column(name = "mvp_concargo")

--- a/src/main/java/um/tesoreria/core/kotlin/model/ProveedorPago.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ProveedorPago.kt
@@ -27,7 +27,7 @@ data class ProveedorPago(
     @Column(name = "opc_importe")
     var importeAplicado: BigDecimal = BigDecimal.ZERO,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaPago: OffsetDateTime? = null,
 
     var trazaContable: Byte = 0,

--- a/src/main/java/um/tesoreria/core/kotlin/model/Usuario.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/Usuario.kt
@@ -24,7 +24,7 @@ data class Usuario(
     var habilitaOpEliminacion: Byte? = 0,
     var eliminaChequera: Byte? = 0,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var lastLog: OffsetDateTime? = null,
 
     var googleMail: String? = null,

--- a/src/main/java/um/tesoreria/core/kotlin/model/ValorMovimiento.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/ValorMovimiento.kt
@@ -19,7 +19,7 @@ data class ValorMovimiento(
     var valorId: Int? = null,
 
     @Column(name = "val_fechaemision")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaEmision: OffsetDateTime? = null,
 
     @Column(name = "val_numero")
@@ -29,7 +29,7 @@ data class ValorMovimiento(
     var bancariaIdOrigen: Long? = null,
 
     @Column(name = "val_fechaefectivizacion")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaEfectivizacion: OffsetDateTime? = null,
 
     @Column(name = "val_importe")
@@ -48,13 +48,13 @@ data class ValorMovimiento(
     var reemplazo: Long = 0L,
 
     @Column(name = "val_fechaasiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaContable: OffsetDateTime? = null,
 
     @Column(name = "val_numeroasiento")
     var ordenContable: Int? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaContableAnulacion: OffsetDateTime? = null,
 
     var ordenContableAnulacion: Int? = null,

--- a/src/main/java/um/tesoreria/core/kotlin/model/dto/ChequeraCuotaDto.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/dto/ChequeraCuotaDto.kt
@@ -12,13 +12,13 @@ data class ChequeraCuotaDto(
 	var cuotaId: Int = 0,
 	var mes: Int = 0,
 	var anho: Int = 0,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	var vencimiento1: OffsetDateTime? = null,
 	var importe1: BigDecimal = BigDecimal.ZERO,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	var vencimiento2: OffsetDateTime? = null,
 	var importe2: BigDecimal = BigDecimal.ZERO,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	var vencimiento3: OffsetDateTime? = null,
 	var importe3: BigDecimal = BigDecimal.ZERO,
 	var pagado: Byte = 0,

--- a/src/main/java/um/tesoreria/core/kotlin/model/dto/ChequeraSerieDto.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/dto/ChequeraSerieDto.kt
@@ -7,7 +7,7 @@ import um.tesoreria.core.util.Jsonifier
 data class ChequeraSerieDto(
 
     var chequeraSerieId: Long? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	var fecha: OffsetDateTime? = null,
     var observaciones: String = "",
     var alternativaId: Int = 0,

--- a/src/main/java/um/tesoreria/core/kotlin/model/dto/LectivoDto.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/dto/LectivoDto.kt
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.annotation.JsonFormat
 data class LectivoDto(
 
 	var nombre: String = "",
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	var fechaInicio: OffsetDateTime? = null,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	var fechaFinal: OffsetDateTime? = null
 
 )

--- a/src/main/java/um/tesoreria/core/kotlin/model/internal/AsientoInternal.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/internal/AsientoInternal.kt
@@ -7,7 +7,7 @@ import java.math.BigDecimal
 
 data class AsientoInternal(
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	var fechaContable: OffsetDateTime? = null,
 
 	var ordenContable: Int,

--- a/src/main/java/um/tesoreria/core/kotlin/model/internal/ClickPagosEntity.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/internal/ClickPagosEntity.kt
@@ -12,9 +12,9 @@ data class ClickPagosEntity(
 
     // Header
     var codigoBoton: Int = 0,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaProceso: OffsetDateTime? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaEnvio: OffsetDateTime? = null,
     var numeroLote: Int = 0,
 
@@ -48,12 +48,12 @@ data class ClickPagosEntity(
     var relleno6: Int = 0,
     var relleno7: Int = 0,
     var relleno8: Int = 0,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaLiquidacion: OffsetDateTime? = null,
     var adicional6: Long = 0,
     var relleno9: Int = 0,
     var codigoBarra: String = "",
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fechaPago: OffsetDateTime? = null,
     var modoPago: String = "",
     var adicional7: Long = 0,

--- a/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraCuotaDeuda.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraCuotaDeuda.kt
@@ -51,7 +51,7 @@ data class ChequeraCuotaDeuda(
     var arancelTipoId: Long? = null,
 
     @Column(name = "chc_1er_vencimiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var vencimiento1: OffsetDateTime? = null,
 
     @Column(name = "chc_1er_importe")
@@ -61,7 +61,7 @@ data class ChequeraCuotaDeuda(
     var importe1Original: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "chc_2do_vencimiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var vencimiento2: OffsetDateTime? = null,
 
     @Column(name = "chc_2do_importe")
@@ -71,7 +71,7 @@ data class ChequeraCuotaDeuda(
     var importe2Original: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "chc_3er_vencimiento")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var vencimiento3: OffsetDateTime? = null,
 
     @Column(name = "chc_3er_importe")

--- a/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraSerieAlta.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraSerieAlta.kt
@@ -55,7 +55,7 @@ data class ChequeraSerieAlta(
     var geograficaId: Int? = null,
 
     @Column(name = "chs_fecha")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
 
     @Column(name = "chs_cuotasp")

--- a/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraSerieAltaFull.kt
+++ b/src/main/java/um/tesoreria/core/kotlin/model/view/ChequeraSerieAltaFull.kt
@@ -33,7 +33,7 @@ data class ChequeraSerieAltaFull(
     var asentado: Int? = null,
     var geograficaId: Int? = null,
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     var fecha: OffsetDateTime? = null,
     var cuotasPagadas: Int? = null,
     var observaciones: String? = null,

--- a/src/main/java/um/tesoreria/core/model/ChequeraPagoReemplazo.java
+++ b/src/main/java/um/tesoreria/core/model/ChequeraPagoReemplazo.java
@@ -75,11 +75,11 @@ public class ChequeraPagoReemplazo extends Auditable implements Serializable {
 	private Integer anho = 0;
 	
 	@Column(name = "cpr_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 	
 	@Column(name = "cpr_acred")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime acreditacion;
 
     @Builder.Default

--- a/src/main/java/um/tesoreria/core/model/ContratoFactura.java
+++ b/src/main/java/um/tesoreria/core/model/ContratoFactura.java
@@ -57,7 +57,7 @@ public class ContratoFactura extends Auditable implements Serializable {
 	private Long numerocomprobante;
 
 	@Column(name = "cfa_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	@Column(name = "cfa_importe")
@@ -70,7 +70,7 @@ public class ContratoFactura extends Auditable implements Serializable {
 	private Byte excluido = 0;
 
 	@Column(name = "cfa_acreditacion")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime acreditacion;
 
 	@Column(name = "cfa_envio")

--- a/src/main/java/um/tesoreria/core/model/Debito.java
+++ b/src/main/java/um/tesoreria/core/model/Debito.java
@@ -56,10 +56,10 @@ public class Debito extends Auditable implements Serializable {
 	private Integer alternativaId;
 	private Integer cuotaId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaVencimiento;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaBaja;
 
 	private Integer debitoTipoId;
@@ -67,7 +67,7 @@ public class Debito extends Auditable implements Serializable {
 	private String numeroTarjeta;
 	private String observaciones = "";
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaEnvio;
 
 	private Byte rechazado = 0;

--- a/src/main/java/um/tesoreria/core/model/DomicilioHistorico.java
+++ b/src/main/java/um/tesoreria/core/model/DomicilioHistorico.java
@@ -43,7 +43,7 @@ public class DomicilioHistorico extends Auditable implements Serializable {
 	private BigDecimal personaId;
 	private Integer documentoId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	private String calle = "";

--- a/src/main/java/um/tesoreria/core/model/FacturacionElectronica.java
+++ b/src/main/java/um/tesoreria/core/model/FacturacionElectronica.java
@@ -39,10 +39,10 @@ public class FacturacionElectronica extends Auditable {
     private BigDecimal importe;
     private String cae;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaRecibo;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaVencimientoCae;
     private Byte enviada;
     private Integer retries;

--- a/src/main/java/um/tesoreria/core/model/IngresoAsiento.java
+++ b/src/main/java/um/tesoreria/core/model/IngresoAsiento.java
@@ -46,7 +46,7 @@ public class IngresoAsiento extends Auditable implements Serializable {
 	private Integer tipoPagoId;
 
 	@Column(name = "ina_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaContable;
 	
 	@Column(name = "ina_nrocomp")

--- a/src/main/java/um/tesoreria/core/model/LectivoCuota.java
+++ b/src/main/java/um/tesoreria/core/model/LectivoCuota.java
@@ -69,21 +69,21 @@ public class LectivoCuota extends Auditable implements Serializable {
 	private Integer anho;
 
 	@Column(name = "lec_1er_vencimiento")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento1;
 
 	@Column(name = "lec_1er_importe")
 	private BigDecimal importe1;
 
 	@Column(name = "lec_2do_vencimiento")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento2;
 
 	@Column(name = "lec_2do_importe")
 	private BigDecimal importe2;
 
 	@Column(name = "lec_3er_vencimiento")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento3;
 
 	@Column(name = "lec_3er_importe")

--- a/src/main/java/um/tesoreria/core/model/PayPerTic.java
+++ b/src/main/java/um/tesoreria/core/model/PayPerTic.java
@@ -57,19 +57,19 @@ public class PayPerTic extends Auditable implements Serializable {
 	private String payernumberId;
 
 	@Column(name = "upload_date")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime uploaddate;
 
 	@Column(name = "due_date")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime duedate;
 
 	@Column(name = "payment_date")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime paymentdate;
 
 	@Column(name = "accreditation_date")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime accreditationdate;
 
 	private BigDecimal amount = new BigDecimal(0);

--- a/src/main/java/um/tesoreria/core/model/dto/ChequeraCuotaPagosDto.java
+++ b/src/main/java/um/tesoreria/core/model/dto/ChequeraCuotaPagosDto.java
@@ -29,17 +29,17 @@ public class ChequeraCuotaPagosDto {
     private Integer anho;
     private Integer arancelTipoId;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento1;
     private BigDecimal importe1;
     private BigDecimal importe1Original;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento2;
     private BigDecimal importe2;
     private BigDecimal importe2Original;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento3;
     private BigDecimal importe3;
     private BigDecimal importe3Original;

--- a/src/main/java/um/tesoreria/core/model/dto/ChequeraPagoDto.java
+++ b/src/main/java/um/tesoreria/core/model/dto/ChequeraPagoDto.java
@@ -27,10 +27,10 @@ public class ChequeraPagoDto {
     private Integer mes;
     private Integer anho;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime acreditacion;
 
     private BigDecimal importe;

--- a/src/main/java/um/tesoreria/core/model/dto/DeudaChequeraDto.java
+++ b/src/main/java/um/tesoreria/core/model/dto/DeudaChequeraDto.java
@@ -44,7 +44,7 @@ public class DeudaChequeraDto implements Serializable {
 	private Integer cuotas;
 	private Long chequeraId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento1;
 
 	private BigDecimal importe1;

--- a/src/main/java/um/tesoreria/core/model/dto/ItemAsientoDto.java
+++ b/src/main/java/um/tesoreria/core/model/dto/ItemAsientoDto.java
@@ -11,7 +11,7 @@ import java.time.OffsetDateTime;
 @Builder
 public class ItemAsientoDto {
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
 
     private BigDecimal numeroCuenta;

--- a/src/main/java/um/tesoreria/core/model/dto/PagoDto.java
+++ b/src/main/java/um/tesoreria/core/model/dto/PagoDto.java
@@ -19,7 +19,7 @@ public class PagoDto {
     private Integer cuotaId;
     private Integer orden;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
 
     private BigDecimal importePagado;

--- a/src/main/java/um/tesoreria/core/model/dto/PlantillaArancelDto.java
+++ b/src/main/java/um/tesoreria/core/model/dto/PlantillaArancelDto.java
@@ -36,15 +36,15 @@ public class PlantillaArancelDto implements Serializable {
 	private Integer mes;
 	private Integer anho;
 	private BigDecimal porcentaje;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento1;
 	private BigDecimal importe1;
 	private BigDecimal importe1original;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento2;
 	private BigDecimal importe2;
 	private BigDecimal importe2original;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento3;
 	private BigDecimal importe3;
 	private BigDecimal importe3original;

--- a/src/main/java/um/tesoreria/core/model/dto/TipoPagoFechaDto.java
+++ b/src/main/java/um/tesoreria/core/model/dto/TipoPagoFechaDto.java
@@ -13,7 +13,7 @@ public class TipoPagoFechaDto {
     private String uniqueId;
     private Integer tipoPagoId;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
 
 }

--- a/src/main/java/um/tesoreria/core/model/view/ChequeraClase.java
+++ b/src/main/java/um/tesoreria/core/model/view/ChequeraClase.java
@@ -79,7 +79,7 @@ public class ChequeraClase extends Auditable implements Serializable {
 	private Integer geograficaId;
 
 	@Column(name = "chs_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	@Column(name = "chs_cuotasp")

--- a/src/main/java/um/tesoreria/core/model/view/ChequeraCuotaPersona.java
+++ b/src/main/java/um/tesoreria/core/model/view/ChequeraCuotaPersona.java
@@ -76,7 +76,7 @@ public class ChequeraCuotaPersona extends Auditable implements Serializable {
 	private Integer anho = 0;
 
 	@Column(name = "chc_1er_vencimiento")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento1;
 
 	@Column(name = "chc_1er_importe")
@@ -86,7 +86,7 @@ public class ChequeraCuotaPersona extends Auditable implements Serializable {
 	private BigDecimal importe1Original = BigDecimal.ZERO;
 
 	@Column(name = "chc_2do_vencimiento")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento2;
 
 	@Column(name = "chc_2do_importe")
@@ -96,7 +96,7 @@ public class ChequeraCuotaPersona extends Auditable implements Serializable {
 	private BigDecimal importe2Original;
 
 	@Column(name = "chc_3er_vencimiento")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento3;
 
 	@Column(name = "chc_3er_importe")

--- a/src/main/java/um/tesoreria/core/model/view/ChequeraIncompleta.java
+++ b/src/main/java/um/tesoreria/core/model/view/ChequeraIncompleta.java
@@ -59,7 +59,7 @@ public class ChequeraIncompleta implements Serializable {
 	private Integer asentado;
 	private Integer geograficaId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	private Integer cuotasPagadas;

--- a/src/main/java/um/tesoreria/core/model/view/ChequeraKey.java
+++ b/src/main/java/um/tesoreria/core/model/view/ChequeraKey.java
@@ -64,7 +64,7 @@ public class ChequeraKey extends Auditable implements Serializable {
 	private Integer asentado;
 	private Integer geograficaId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	private Integer cuotasPagadas;

--- a/src/main/java/um/tesoreria/core/model/view/CuentaMovimientoAsiento.java
+++ b/src/main/java/um/tesoreria/core/model/view/CuentaMovimientoAsiento.java
@@ -47,7 +47,7 @@ public class CuentaMovimientoAsiento extends Auditable implements Serializable {
 	@Id
 	private Long cuentaMovimientoId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaContable;
 
 	private Integer ordenContable;

--- a/src/main/java/um/tesoreria/core/model/view/CuentaSearch.java
+++ b/src/main/java/um/tesoreria/core/model/view/CuentaSearch.java
@@ -49,7 +49,7 @@ public class CuentaSearch implements Serializable {
 	private BigDecimal grado4;
 	private Integer geograficaId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaBloqueo;
 	
 	private Long cuentaContableId;

--- a/src/main/java/um/tesoreria/core/model/view/CuotaDeuda.java
+++ b/src/main/java/um/tesoreria/core/model/view/CuotaDeuda.java
@@ -50,19 +50,19 @@ public class CuotaDeuda implements Serializable {
 	private Integer mes;
 	private Integer anho;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento1;
 
 	private BigDecimal importe1 = BigDecimal.ZERO;
 	private BigDecimal importe1Original = BigDecimal.ZERO;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento2;
 
 	private BigDecimal importe2 = BigDecimal.ZERO;
 	private BigDecimal importe2Original;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento3;
 
 	private BigDecimal importe3 = BigDecimal.ZERO;

--- a/src/main/java/um/tesoreria/core/model/view/CuotaDeudaPayPerTic.java
+++ b/src/main/java/um/tesoreria/core/model/view/CuotaDeudaPayPerTic.java
@@ -45,7 +45,7 @@ public class CuotaDeudaPayPerTic implements Serializable {
 	private Integer mes;
 	private Integer anho;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento1;
 
 	private BigDecimal importe1 = BigDecimal.ZERO;
@@ -53,7 +53,7 @@ public class CuotaDeudaPayPerTic implements Serializable {
 	@Column(name = "importe1_original")
 	private BigDecimal importe1Original = BigDecimal.ZERO;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento2;
 
 	private BigDecimal importe2 = BigDecimal.ZERO;
@@ -61,7 +61,7 @@ public class CuotaDeudaPayPerTic implements Serializable {
 	@Column(name = "importe2_original")
 	private BigDecimal importe2Original;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime vencimiento3;
 
 	private BigDecimal importe3 = BigDecimal.ZERO;

--- a/src/main/java/um/tesoreria/core/model/view/DomicilioKey.java
+++ b/src/main/java/um/tesoreria/core/model/view/DomicilioKey.java
@@ -52,7 +52,7 @@ public class DomicilioKey extends Auditable implements Serializable {
 	private Integer documentoId;
 
 	@Column(name = "dom_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha = OffsetDateTime.now();
 
 	@Column(name = "dom_calle")

--- a/src/main/java/um/tesoreria/core/model/view/LegajoKey.java
+++ b/src/main/java/um/tesoreria/core/model/view/LegajoKey.java
@@ -58,7 +58,7 @@ public class LegajoKey extends Auditable implements Serializable {
 	private Long numerolegajo;
 
 	@Column(name = "ale_fecha")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fecha;
 
 	@Column(name = "ale_lec_id")

--- a/src/main/java/um/tesoreria/core/model/view/TipoPagoFechaAcreditacion.java
+++ b/src/main/java/um/tesoreria/core/model/view/TipoPagoFechaAcreditacion.java
@@ -32,7 +32,7 @@ public class TipoPagoFechaAcreditacion implements Serializable {
 
 	private Integer tipoPagoId;
 
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
 	private OffsetDateTime fechaAcreditacion;
 
 }

--- a/src/main/java/um/tesoreria/core/model/view/TipoPagoFechaPago.java
+++ b/src/main/java/um/tesoreria/core/model/view/TipoPagoFechaPago.java
@@ -20,7 +20,7 @@ public class TipoPagoFechaPago {
 
     private Integer tipoPagoId;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaPago;
 
 }


### PR DESCRIPTION
Closes #255

## Descripción

Corrige el patrón de formato ISO 8601 en las anotaciones `@JsonFormat` de todas las clases del modelo que serializan campos `OffsetDateTime`, reemplazando `Z` por `XX` para cumplir correctamente con el estándar ISO 8601 (genera `-03:00` en lugar de `-0300`).

## Cambios Realizados

- Reemplazo masivo del patrón `yyyy-MM-dd'T'HH:mm:ssZ` por `yyyy-MM-dd'T'HH:mm:ssXX` en 65 archivos (144 inserciones, 119 eliminaciones)
- Afecta entidades, DTOs, vistas y clases internas tanto en Kotlin como en Java
- Incluye también clases del paquete `infrastructure/persistence/entity` y `extern/model/dto`

## Verificación

- [ ] Compilación exitosa con `mvn compile`
- [ ] Tests unitarios pasan correctamente
- [ ] Verificar que la serialización JSON de fechas produzca el offset con separador `:` (ej: `2026-06-18T10:30:00-03:00`)
