### PR TITLE
feat(reservaVacante): extiende vencimiento, importe personalizable y fix ISO 8601 en Domicilio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.27.0] - 2026-06-19
+### Added
+- feat(reservaVacante): Extended `vencimiento` from 2 to 60 days in `CreateReservaVacanteUseCaseImpl.createReservaVacante()`
+  - `plusDays(2)` → `plusDays(60)` for more flexible reservation window
+- feat(reservaVacante): Custom `importe` override from `ReservaVacanteRequest`
+  - If `importe` is non-null and non-zero in the request, it overrides `Campanha.getValorReserva()`
+  - New `BigDecimal importe` field in `ReservaVacanteRequest` DTO
+  - Enables manual importe specification per reservation
+- feat(reservaVacante): Added `jsonify()` structured logging method to `ReservaVacanteRequest` DTO
+- chore(logging): Added `jsonify()` debug log of `ReservaVacanteRequest` in `CreateReservaVacanteUseCaseImpl`
+
+### Fixed
+- fix(domicilio): Added missing `@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXX")` annotation to `fecha` field in `Domicilio`, `DomicilioRequest`, and `DomicilioResponse`
+  - Completes ISO 8601 compliance for Domicilio module (was missed in v3.26.1)
+
+> Basado en análisis profundo de `git diff HEAD --cached` (5 archivos modificados, +15/-2 líneas) y `pom.xml` (versión 3.26.1 → 3.27.0).
+
 ## [3.26.1] - 2026-06-18
 ### Fixed
 - fix(core): Extendida corrección ISO 8601 a todas las entidades del proyecto (61 archivos)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,21 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.26.1**
+**Versión actual (SemVer): 3.27.0**
+
+## Novedades 3.27.0 (verificado en código)
+- feat(reservaVacante): Extendido `vencimiento` de 2 a 60 días en la creación de reserva de vacante
+  - Cambio de `plusDays(2)` a `plusDays(60)` en `CreateReservaVacanteUseCaseImpl.createReservaVacante()`
+  - Proporciona ventana más flexible para completar el pago de la reserva
+- feat(reservaVacante): `importe` personalizable desde `ReservaVacanteRequest`
+  - Nuevo campo `BigDecimal importe` en `ReservaVacanteRequest`
+  - Si se especifica y es distinto de cero, sobreescribe `Campanha.getValorReserva()`
+- feat(reservaVacante): Nuevo método `jsonify()` en `ReservaVacanteRequest` para logging estructurado
+- feat(reservaVacante): Nuevo log debug con `jsonify()` de `ReservaVacanteRequest` en `CreateReservaVacanteUseCaseImpl`
+- fix(domicilio): Agregado `@JsonFormat` faltante en campo `fecha` de `Domicilio`, `DomicilioRequest` y `DomicilioResponse`
+  - Completa la corrección ISO 8601 iniciada en v3.26.1 para el módulo Domicilio
+
+> Basado en análisis profundo de `git diff HEAD --cached` (5 archivos modificados) y `pom.xml` (versión 3.26.1 → 3.27.0).
 
 ## Novedades 3.26.1 (verificado en código)
 - fix(core): Extendida corrección ISO 8601 a todas las entidades del proyecto (61 archivos)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.26.1** (actualizada: 2026-06-18)
+**Versión actual del servicio: 3.27.0** (actualizada: 2026-06-19)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -24,7 +24,7 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-chequeraSerie.mmd`: Arquitectura hexagonal del módulo ChequeraSerie (gestión de series de chequeras) - v3.21.0.
 - `hexagonal-baja.mmd`: Arquitectura hexagonal del módulo Baja (gestión de bajas de chequeras) - v3.21.0.
 - `hexagonal-campanha.mmd`: Arquitectura hexagonal del módulo Campanha (gestión de campañas UM Hub) - v3.24.0.
-- `hexagonal-reservaVacante.mmd`: Arquitectura hexagonal del módulo ReservaVacante (gestión de reservas de vacantes UM Hub) - v3.26.0.
+- `hexagonal-reservaVacante.mmd`: Arquitectura hexagonal del módulo ReservaVacante (gestión de reservas de vacantes UM Hub) - v3.27.0.
 - `hexagonal-domicilio.mmd`: Arquitectura hexagonal del módulo Domicilio (gestión de domicilios) - v3.24.0.
 - `hexagonal-persona.mmd`: Arquitectura hexagonal del módulo Persona (gestión de personas) - v3.24.0.
 

--- a/docs/hexagonal-reservaVacante.mmd
+++ b/docs/hexagonal-reservaVacante.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo ReservaVacante (v3.26.0)
+title: Arquitectura Hexagonal - Módulo ReservaVacante (v3.27.0)
 ---
 
 classDiagram
@@ -111,6 +111,7 @@ classDiagram
                 +String apellido
                 +String email
                 +UUID campanhaId
+                +BigDecimal importe
             }
 
             class ReservaVacanteResponse {

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.26.1</version>
+    <version>3.27.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/hexagonal/domicilio/domain/model/Domicilio.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/domicilio/domain/model/Domicilio.java
@@ -1,5 +1,6 @@
 package um.tesoreria.core.hexagonal.domicilio.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,6 +18,7 @@ public class Domicilio {
     private Long domicilioId;
     private BigDecimal personaId;
     private Integer documentoId;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
     private String calle;
     private String puerta;

--- a/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/web/dto/DomicilioRequest.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/web/dto/DomicilioRequest.java
@@ -1,5 +1,6 @@
 package um.tesoreria.core.hexagonal.domicilio.infrastructure.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -10,6 +11,7 @@ public class DomicilioRequest {
     private Long domicilioId;
     private BigDecimal personaId;
     private Integer documentoId;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
     private String calle;
     private String puerta;

--- a/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/web/dto/DomicilioResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/web/dto/DomicilioResponse.java
@@ -1,5 +1,6 @@
 package um.tesoreria.core.hexagonal.domicilio.infrastructure.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,6 +17,7 @@ public class DomicilioResponse {
     private Long domicilioId;
     private BigDecimal personaId;
     private Integer documentoId;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fecha;
     private String calle;
     private String puerta;

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/CreateReservaVacanteUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/CreateReservaVacanteUseCaseImpl.java
@@ -40,6 +40,7 @@ public class CreateReservaVacanteUseCaseImpl implements CreateReservaVacanteUseC
     @Override
     public ReservaVacante createReservaVacante(ReservaVacanteRequest reservaVacanteRequest) {
         log.debug("\n\nProcessing CreateReservaVacanteUseCaseImpl.createReservaVacante\n\n");
+        log.debug("ReservaVacanteRequest : {}", reservaVacanteRequest.jsonify());
         // Verificar persona
         Persona persona;
         var personaId = new BigDecimal(reservaVacanteRequest.getNumeroDocumento().replaceAll("\\D+", ""));
@@ -89,13 +90,13 @@ public class CreateReservaVacanteUseCaseImpl implements CreateReservaVacanteUseC
                 .orElseThrow(() -> new ReservaVacanteException(reservaVacanteRequest.getCampanhaId()));
         // Crea reservaVacante
         OffsetDateTime vencimiento = OffsetDateTime.now(ZoneOffset.ofHours(-3))
-                .plusDays(2)
+                .plusDays(60)
                 .with(LocalTime.MAX);
         ReservaVacante reservaVacante = ReservaVacante.builder()
                 .personaUniqueId(persona.getUniqueId())
                 .campanhaId(reservaVacanteRequest.getCampanhaId())
                 .estado("pendiente")
-                .importe(campanha.getValorReserva())
+                .importe(reservaVacanteRequest.getImporte() != null && reservaVacanteRequest.getImporte().compareTo(BigDecimal.ZERO) != 0 ? reservaVacanteRequest.getImporte() : campanha.getValorReserva())
                 .vencimiento(vencimiento)
                 .build();
         reservaVacante = repository.create(reservaVacante);

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/infrastructure/web/dto/ReservaVacanteRequest.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/infrastructure/web/dto/ReservaVacanteRequest.java
@@ -2,7 +2,9 @@ package um.tesoreria.core.hexagonal.umhub.reservaVacante.infrastructure.web.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import um.tesoreria.core.util.Jsonifier;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
@@ -15,5 +17,9 @@ public class ReservaVacanteRequest {
     private String apellido;
     private String email;
     private UUID campanhaId;
+    private BigDecimal importe;
 
+    public String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
 }


### PR DESCRIPTION
Closes #257

## Descripción

Se prepara la versión **v3.27.0** con dos cambios principales: extensión del vencimiento de reserva de vacante a 60 días con importe personalizable, y corrección ISO 8601 pendiente en el módulo Domicilio.

## Cambios Realizados

- **feat(reservaVacante):** Extiende `vencimiento` de 2 a 60 días en `CreateReservaVacanteUseCaseImpl`
- **feat(reservaVacante):** Agrega campo `importe` personalizable en `ReservaVacanteRequest` que sobreescribe `Campanha.getValorReserva()` cuando se especifica
- **feat(reservaVacante):** Agrega método `jsonify()` para logging estructurado del request
- **fix(domicilio):** Agrega anotación `@JsonFormat` faltante en campo `fecha` de `Domicilio`, `DomicilioRequest` y `DomicilioResponse`
- **docs:** Actualiza versión a 3.27.0 en `pom.xml`, `CHANGELOG.md`, `README.md` y diagramas

## Verificación

- [ ] Compilación exitosa con `mvn clean compile`
- [ ] Pruebas unitarias pasan correctamente
- [ ] Validar que el campo `importe` en `ReservaVacanteRequest` sea opcional (backward compatible)
- [ ] Verificar que la respuesta JSON de Domicilio use formato ISO 8601 (`yyyy-MM-dd'T'HH:mm:ssXX`)
