### PR TITLE
feat(tool): update proposal-to-facultad mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
-## [3.29.0] - 2026-06-25
+## [3.29.0] - 2026-06-26
 ### Added
+- feat(Tool): Nuevos mappings de propuesta a facultadId en `Tool.convert2Tesium()`
+  - Nuevas propuestas: 70, 111, 125-134 → facultad 1; 72, 121-123 → facultad 2; 74, 120 → facultad 3; 75, 112-118 → facultad 4; 68, 124 → facultad 5
+  - Eliminados mappings legacy: propuestas 109, 73, 108 reemplazados por valores actualizados
+  - Amplía compatibilidad con nuevas sedes/carreras del sistema Guarani
 - feat(chequeraSerie): Nuevo `PreuniversitarioChequeraService` en `hexagonal/chequeraSerie/application/service/`
   - Lógica de creación de chequera preuniversitaria extraída de `CreatePreuniversitarioUseCaseImpl`
 
@@ -46,7 +50,7 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 - Eliminación de servicio legacy: `ArancelPorcentajeService.java`
 - Eliminación de controladores legacy: `ArancelPorcentajeController.java`
 
-> Basado en análisis profundo de `git diff HEAD` (63 archivos modificados, +688/-1070 líneas) y `pom.xml` (versión 3.28.0).
+> Basado en análisis profundo de `git diff HEAD` (64 archivos modificados, +693/-1075 líneas, incluyendo cambios locales en Tool.java) y `pom.xml` (versión 3.28.0 → 3.29.0).
 
 ## [3.28.0] - 2026-06-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0
 **Versión actual (SemVer): 3.29.0**
 
 ## Novedades 3.29.0 (verificado en código)
+- feat(Tool): Actualizados mappings de propuesta a facultadId en `Tool.convert2Tesium()`
+  - Nuevas propuestas: 70, 111, 125-134 → facultad 1; 72, 121-123 → facultad 2; 74, 120 → facultad 3; 75, 112-118 → facultad 4; 68, 124 → facultad 5
+  - Eliminados mappings legacy (109, 73, 108) reemplazados por valores actualizados
+  - Amplía cobertura de carreras/sedes del sistema Guarani
 - refactor(arancelTipo): Migración completa del módulo ArancelTipo a arquitectura hexagonal
   - Eliminación de `ArancelTipo.kt` (Kotlin) y creación de `ArancelTipoEntity.java` con Lombok
   - `ArancelTipoService` y `ArancelTipoController` movidos a `hexagonal/arancelTipo/`
@@ -26,7 +30,7 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0
 - refactor(chequeraSerie): `ChequeraSerieMapper` movido a `hexagonal/chequeraSerie/infrastructure/web/mapper/`
 - chore(docs): Nuevos diagramas Mermaid para módulos ArancelTipo, ArancelPorcentaje y Asiento
 
-> Basado en análisis profundo de `git diff HEAD` (63 archivos modificados, +688/-1070 líneas) y `pom.xml` (versión 3.28.0).
+> Basado en análisis profundo de `git diff HEAD` (64 archivos modificados, +693/-1075 líneas, incluyendo cambios locales en Tool.java) y `pom.xml` (versión 3.28.0 → 3.29.0).
 
 ## Novedades 3.28.0 (verificado en código)
 - feat(guarani): Nuevo módulo `alumnoGuarani` con arquitectura hexagonal para integración con sistema Guarani
@@ -926,6 +930,9 @@ src/
 │   ├── java/
 │   │   └── um/tesoreria/core/
 │   │       ├── hexagonal/
+│   │       │   ├── arancelPorcentaje/        # Módulo ArancelPorcentaje (v3.29.0)
+│   │       │   ├── arancelTipo/              # Módulo ArancelTipo (v3.29.0)
+│   │       │   ├── asiento/                  # Módulo Asiento (v3.29.0)
 │   │       │   ├── auth/                     # Módulo Auth (v3.6.0)
 │   │       │   ├── baja/                     # Módulo Baja (v3.21.0)
 │   │       │   ├── chequeraCuota/            # Módulo ChequeraCuota (v3.2.0)
@@ -937,7 +944,7 @@ src/
 │   │       │   ├── facultad/                 # Módulo Facultad (v3.18.0)
 │   │       │   ├── facturaPendiente/         # Módulo FacturaPendiente (v3.15.0)
 │   │       │   ├── geografica/               # Módulo Geografica (v3.6.0)
-│   │       │   ├── guarani/alumnoGuarani/    # Módulo AlumnoGuarani (v3.28.0)
+│   │       │   ├── guarani/alumnoGuarani/    # Módulo AlumnoGuarani (v3.29.0)
 │   │       │   ├── mercadoPagoContext/       # Módulo MercadoPagoContext (v3.24.0)
 │   │       │   ├── persona/                  # Módulo Persona (v3.24.0)
 │   │       │   ├── proveedor/                # Módulo Proveedor (v3.9.0)
@@ -989,7 +996,7 @@ Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](ht
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-brightgreen.svg)](https://spring.io/projects/spring-cloud)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.28.0-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.29.0-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.29.0** (actualizada: 2026-06-25)
+**Versión actual del servicio: 3.29.0** (actualizada: 2026-06-26)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.28.0</version>
+    <version>3.29.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/util/Tool.java
+++ b/src/main/java/um/tesoreria/core/util/Tool.java
@@ -256,12 +256,12 @@ public class Tool {
             default -> 0;
         };
         int facultadId = switch (propuesta) {
+            case 70, 111, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134 -> 1;
+            case 72, 121, 122, 123 -> 2;
+            case 74, 120 -> 3;
+            case 75, 112, 113, 114, 115, 116, 117, 118 -> 4;
+            case 68, 124 -> 5;
             case 69 -> 14;
-            case 70, 109 -> 1;
-            case 72, 73 -> 2;
-            case 74 -> 3;
-            case 75 -> 4;
-            case 108 -> 5;
             default -> 0;
         };
         int tipoChequeraId = switch (geograficaId) {


### PR DESCRIPTION
Closes #263

## Descripción

Actualización de los mappings de propuesta a facultadId en `Tool.convert2Tesium()` para ampliar la compatibilidad con nuevas sedes/carreras del sistema Guarani. Se actualizaron las propuestas 111, 125-134 → Facultad 1; 121-123 → Facultad 2; 120 → Facultad 3; 112-118 → Facultad 4; 68, 124 → Facultad 5. Se eliminaron mappings legacy obsoletos (109, 73, 108). Bump de versión a 3.29.0.

## Cambios Realizados

- **feat(Tool):** Nuevos mappings de propuesta a facultadId en `Tool.java` — +5/-5 líneas en el switch de facultadId
- **chore(version):** Bump de `pom.xml` de 3.28.0 → 3.29.0
- **chore(docs):** Actualización de `CHANGELOG.md`, `README.md` y `docs/README.md`

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `src/main/java/um/tesoreria/core/util/Tool.java` | +5 / -5 líneas |
| `pom.xml` | Versión 3.28.0 → 3.29.0 |
| `CHANGELOG.md` | Registro del cambio agregado |
| `README.md` | Badge y novedades actualizados |
| `docs/README.md` | Fecha corregida |

## Verificación

- [ ] Compilación exitosa: `mvn compile`
- [ ] Tests unitarios: `mvn test`
