### PR TITLE
feat(lectivo-total-imputacion): agregar endpoint findAllByLectivo, refactor controller y tests completos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.31.0] - 2026-07-03
+### Added
+- feat(lectivoTotalImputacion): Nuevo caso de uso `FindAllByLectivoUseCase` y endpoint `GET /lectivo/{lectivoId}`
+  - Nuevo puerto de entrada: `FindAllByLectivoUseCase` con método `findAllByLectivo(Integer lectivoId)`
+  - Nueva implementación: `FindAllByLectivoUseCaseImpl`
+  - Nuevo método `findAllByLectivo(Integer)` en `LectivoTotalImputacionRepository`
+  - Nuevo endpoint: `GET /api/tesoreria/core/lectivototalimputacion/lectivo/{lectivoId}`
+  - Nueva ruta alternativa: `/api/tesoreria/core/lectivototalimputacion` como base path
+- feat(lectivoTotalImputacion): Enriquecimiento del modelo de dominio con asociaciones a `Facultad`, `Lectivo`, `TipoChequera`, `Producto` y `Cuenta`
+  - `LectivoTotalImputacion` domain model: nuevos campos `facultad`, `lectivo`, `tipoChequera`, `producto`, `cuenta`
+  - `LectivoTotalImputacionEntity`: corregida anotación `@JoinColumn` de `columnDefinition` a `name` (fix)
+  - `LectivoTotalImputacionResponse`: expone objetos completos de asociaciones en respuestas REST
+  - `LectivoTotalImputacionDtoMapper.toResponse()`: mapea nuevas asociaciones del dominio al DTO
+  - `LectivoTotalImputacionMapper`: ahora con `@RequiredArgsConstructor` e inyección de 5 mappers de dominio
+  - Refactorizado `toDomain()` para mapear asociaciones desde entidades JPA a modelos de dominio
+- feat(lectivoTotalImputacion): Refactorización de `ResponseEntity` API en controller
+  - Migración de `new ResponseEntity<>(..., HttpStatus.OK)` a `ResponseEntity.ok(...)`
+  - Migración de `new ResponseEntity<>(HttpStatus.NOT_FOUND)` a `ResponseEntity.notFound().build()`
+- feat(tests): Nuevos tests unitarios y de integración para el módulo LectivoTotalImputacion (8 tests)
+  - `LectivoTotalImputacionControllerTest`: controller REST con MockMvc
+  - `LectivoTotalImputacionServiceTest`: service con mocking de casos de uso
+  - `FindAllByLectivoUseCaseImplTest`, `AddLectivoTotalImputacionUseCaseImplTest`, `FindAllByTipoUseCaseImplTest`, `FindByProductoUseCaseImplTest`, `UpdateLectivoTotalImputacionUseCaseImplTest`: casos de uso individuales
+  - `JpaLectivoTotalImputacionRepositoryAdapterTest`, `JpaLectivoTotalImputacionRepositoryTest`: integración con BBDD H2
+  - `LectivoTotalImputacionMapperTest`, `LectivoTotalImputacionDtoMapperTest`: mappers
+- feat(deps): Nuevas dependencias de test `spring-boot-starter-data-jpa-test` y `spring-boot-starter-webmvc-test`
+- fix(test): Agregado `INIT=SET REFERENTIAL_INTEGRITY FALSE` en H2 test URL para evitar violaciones de FK
+
+> Basado en análisis profundo de `git diff HEAD` (25 archivos modificados, +1071/-14 líneas) y `pom.xml` (versión 3.30.0 → 3.31.0).
+
 ## [3.30.0] - 2026-07-01
 ### Added
 - feat(producto): Nuevo módulo Producto con arquitectura hexagonal completa

--- a/README.md
+++ b/README.md
@@ -4,7 +4,26 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.30.0**
+**Versión actual (SemVer): 3.31.0**
+
+## Novedades 3.31.0 (verificado en código)
+- feat(lectivoTotalImputacion): Nuevo caso de uso `FindAllByLectivoUseCase` y endpoint `GET /lectivo/{lectivoId}`
+  - Nuevo puerto de entrada: `FindAllByLectivoUseCase` con método `findAllByLectivo(Integer lectivoId)`
+  - Nueva implementación: `FindAllByLectivoUseCaseImpl`
+  - Nuevo método `findAllByLectivo(Integer)` en `LectivoTotalImputacionRepository` y adaptador JPA
+  - Nuevo endpoint: `GET /api/tesoreria/core/lectivototalimputacion/lectivo/{lectivoId}`
+  - Nueva ruta base alternativa: `/api/tesoreria/core/lectivototalimputacion`
+- feat(lectivoTotalImputacion): Enriquecimiento del modelo de dominio con asociaciones a `Facultad`, `Lectivo`, `TipoChequera`, `Producto` y `Cuenta`
+  - `LectivoTotalImputacion` domain model: nuevos campos `facultad`, `lectivo`, `tipoChequera`, `producto`, `cuenta`
+  - `LectivoTotalImputacionEntity`: corregido `@JoinColumn` de `columnDefinition` a `name` (fix JPA)
+  - `LectivoTotalImputacionResponse`: expone objetos completos de asociaciones en respuestas REST
+  - `LectivoTotalImputacionMapper`: inyecta 5 mappers de dominio para mapear asociaciones
+- feat(lectivoTotalImputacion): Refactorización de controller con `ResponseEntity.ok()` y `ResponseEntity.notFound().build()`
+- feat(tests): 8 nuevos tests unitarios y de integración para el módulo LectivoTotalImputacion (controller, service, use cases, mappers, repository)
+- feat(deps): Nuevas dependencias `spring-boot-starter-data-jpa-test` y `spring-boot-starter-webmvc-test`
+- fix(test): Agregado parámetro H2 `INIT=SET REFERENTIAL_INTEGRITY FALSE` en test application.yml
+
+> Basado en análisis profundo de `git diff HEAD` (25 archivos modificados, +1071/-14 líneas) y `pom.xml` (versión 3.30.0 → 3.31.0).
 
 ## Novedades 3.30.0 (verificado en código)
 - feat(producto): Nuevo módulo Producto con arquitectura hexagonal completa

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.30.0** (actualizada: 2026-07-01)
+**Versión actual del servicio: 3.31.0** (actualizada: 2026-07-03)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -20,7 +20,7 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-dependencia.mmd`: Arquitectura hexagonal del módulo Dependencia (gestión de dependencias) - v3.17.0.
 - `hexagonal-facturaPendiente.mmd`: Arquitectura hexagonal del módulo FacturaPendiente (gestión de facturas pendientes) - v3.15.0.
 - `hexagonal-facultad.mmd`: Arquitectura hexagonal del módulo Facultad (gestión de facultades) - v3.18.0.
-- `hexagonal-lectivoTotalImputacion.mmd`: Arquitectura hexagonal del módulo LectivoTotalImputacion (imputaciones contables por lectivo) - v3.30.0.
+- `hexagonal-lectivoTotalImputacion.mmd`: Arquitectura hexagonal del módulo LectivoTotalImputacion (imputaciones contables por lectivo) - v3.31.0 (nuevo caso de uso FindAllByLectivo + enriquecimiento con asociaciones a Facultad/Lectivo/TipoChequera/Producto/Cuenta).
 - `hexagonal-contrato.mmd`: Arquitectura hexagonal del módulo Contrato (gestión de contratos) - v3.19.0.
 - `hexagonal-chequeraSerie.mmd`: Arquitectura hexagonal del módulo ChequeraSerie (15+ casos de uso individuales) - v3.30.0 (refactorización masiva a casos de uso).
 - `hexagonal-baja.mmd`: Arquitectura hexagonal del módulo Baja (gestión de bajas de chequeras) - v3.21.0.

--- a/docs/hexagonal-lectivoTotalImputacion.mmd
+++ b/docs/hexagonal-lectivoTotalImputacion.mmd
@@ -12,12 +12,48 @@ classDiagram
             +Integer lectivoId
             +Integer tipoChequeraId
             +Integer productoId
-            +BigDecimal cuenta
+            +BigDecimal numeroCuenta
+            +Facultad facultad
+            +Lectivo lectivo
+            +TipoChequera tipoChequera
+            +Producto producto
+            +Cuenta cuenta
+        }
+
+        class Facultad {
+            <<domain>>
+            +Integer facultadId
+            +String nombre
+        }
+
+        class Lectivo {
+            <<domain>>
+            +Integer lectivoId
+            +String nombre
+        }
+
+        class TipoChequera {
+            <<domain>>
+            +Integer tipoChequeraId
+            +String nombre
+        }
+
+        class Producto {
+            <<domain>>
+            +Integer productoId
+            +String nombre
+        }
+
+        class Cuenta {
+            <<domain>>
+            +String numeroCuenta
+            +String nombre
         }
 
         class LectivoTotalImputacionRepository {
             <<interface>>
             +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
+            +findAllByLectivo(Integer) List~LectivoTotalImputacion~
             +findByProducto(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacion~
             +add(LectivoTotalImputacion) LectivoTotalImputacion
             +update(Long, LectivoTotalImputacion) Optional~LectivoTotalImputacion~
@@ -28,10 +64,12 @@ classDiagram
     namespace application {
         class LectivoTotalImputacionService {
             -FindAllByTipoUseCase findAllByTipoUseCase
+            -FindAllByLectivoUseCase findAllByLectivoUseCase
             -FindByProductoUseCase findByProductoUseCase
             -AddLectivoTotalImputacionUseCase addLectivoTotalImputacionUseCase
             -UpdateLectivoTotalImputacionUseCase updateLectivoTotalImputacionUseCase
             +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
+            +findAllByLectivo(Integer) List~LectivoTotalImputacion~
             +findByProducto(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacion~
             +add(LectivoTotalImputacion) LectivoTotalImputacion
             +update(Long, LectivoTotalImputacion) Optional~LectivoTotalImputacion~
@@ -41,6 +79,11 @@ classDiagram
             class FindAllByTipoUseCaseImpl {
                 -LectivoTotalImputacionRepository repository
                 +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
+            }
+
+            class FindAllByLectivoUseCaseImpl {
+                -LectivoTotalImputacionRepository repository
+                +findAllByLectivo(Integer) List~LectivoTotalImputacion~
             }
 
             class FindByProductoUseCaseImpl {
@@ -62,6 +105,11 @@ classDiagram
         class FindAllByTipoUseCase {
             <<interface>>
             +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
+        }
+
+        class FindAllByLectivoUseCase {
+            <<interface>>
+            +findAllByLectivo(Integer) List~LectivoTotalImputacion~
         }
 
         class FindByProductoUseCase {
@@ -88,12 +136,18 @@ classDiagram
                 +Integer lectivoId
                 +Integer tipoChequeraId
                 +Integer productoId
-                +BigDecimal cuenta
+                +BigDecimal numeroCuenta
+                +FacultadEntity facultad
+                +LectivoEntity lectivo
+                +TipoChequeraEntity tipoChequera
+                +ProductoEntity producto
+                +CuentaEntity cuenta
             }
 
             class JpaLectivoTotalImputacionRepository {
                 <<JpaRepository>>
                 +findAllByFacultadIdAndLectivoIdAndTipoChequeraId(Integer, Integer, Integer) List~LectivoTotalImputacionEntity~
+                +findAllByLectivoId(Integer) List~LectivoTotalImputacionEntity~
                 +findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoId(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacionEntity~
                 +findByLectivoTotalImputacionId(Long) Optional~LectivoTotalImputacionEntity~
             }
@@ -102,6 +156,7 @@ classDiagram
                 -JpaLectivoTotalImputacionRepository jpaLectivoTotalImputacionRepository
                 -LectivoTotalImputacionMapper mapper
                 +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
+                +findAllByLectivo(Integer) List~LectivoTotalImputacion~
                 +findByProducto(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacion~
                 +add(LectivoTotalImputacion) LectivoTotalImputacion
                 +update(Long, LectivoTotalImputacion) Optional~LectivoTotalImputacion~
@@ -109,6 +164,11 @@ classDiagram
             }
 
             class LectivoTotalImputacionMapper {
+                -FacultadMapper facultadMapper
+                -LectivoMapper lectivoMapper
+                -TipoChequeraMapper tipoChequeraMapper
+                -ProductoMapper productoMapper
+                -CuentaMapper cuentaMapper
                 +toDomain(LectivoTotalImputacionEntity) LectivoTotalImputacion
                 +toEntity(LectivoTotalImputacion) LectivoTotalImputacionEntity
             }
@@ -118,6 +178,7 @@ classDiagram
             class LectivoTotalImputacionController {
                 -LectivoTotalImputacionService service
                 -LectivoTotalImputacionDtoMapper mapper
+                +findAllByLectivo(Integer) ResponseEntity~List~LectivoTotalImputacionResponse~~
                 +findAllByTipo(Integer, Integer, Integer) ResponseEntity~List~LectivoTotalImputacionResponse~~
                 +findByProducto(Integer, Integer, Integer, Integer) ResponseEntity~LectivoTotalImputacionResponse~
                 +add(LectivoTotalImputacionRequest) ResponseEntity~LectivoTotalImputacionResponse~
@@ -130,7 +191,7 @@ classDiagram
                 +Integer lectivoId
                 +Integer tipoChequeraId
                 +Integer productoId
-                +BigDecimal cuenta
+                +BigDecimal numeroCuenta
             }
 
             class LectivoTotalImputacionResponse {
@@ -139,7 +200,12 @@ classDiagram
                 +Integer lectivoId
                 +Integer tipoChequeraId
                 +Integer productoId
-                +BigDecimal cuenta
+                +BigDecimal numeroCuenta
+                +Facultad facultad
+                +Lectivo lectivo
+                +TipoChequera tipoChequera
+                +Producto producto
+                +Cuenta cuenta
             }
 
             class LectivoTotalImputacionDtoMapper {
@@ -149,17 +215,26 @@ classDiagram
         }
     }
 
+    LectivoTotalImputacion --> Facultad : has
+    LectivoTotalImputacion --> Lectivo : has
+    LectivoTotalImputacion --> TipoChequera : has
+    LectivoTotalImputacion --> Producto : has
+    LectivoTotalImputacion --> Cuenta : has
+
     LectivoTotalImputacionService --> FindAllByTipoUseCase : uses
+    LectivoTotalImputacionService --> FindAllByLectivoUseCase : uses
     LectivoTotalImputacionService --> FindByProductoUseCase : uses
     LectivoTotalImputacionService --> AddLectivoTotalImputacionUseCase : uses
     LectivoTotalImputacionService --> UpdateLectivoTotalImputacionUseCase : uses
 
     FindAllByTipoUseCaseImpl ..|> FindAllByTipoUseCase : implements
+    FindAllByLectivoUseCaseImpl ..|> FindAllByLectivoUseCase : implements
     FindByProductoUseCaseImpl ..|> FindByProductoUseCase : implements
     AddLectivoTotalImputacionUseCaseImpl ..|> AddLectivoTotalImputacionUseCase : implements
     UpdateLectivoTotalImputacionUseCaseImpl ..|> UpdateLectivoTotalImputacionUseCase : implements
 
     FindAllByTipoUseCaseImpl --> LectivoTotalImputacionRepository : uses
+    FindAllByLectivoUseCaseImpl --> LectivoTotalImputacionRepository : uses
     FindByProductoUseCaseImpl --> LectivoTotalImputacionRepository : uses
     AddLectivoTotalImputacionUseCaseImpl --> LectivoTotalImputacionRepository : uses
     UpdateLectivoTotalImputacionUseCaseImpl --> LectivoTotalImputacionRepository : uses
@@ -171,6 +246,12 @@ classDiagram
     LectivoTotalImputacionMapper --> LectivoTotalImputacion : maps
     LectivoTotalImputacionMapper --> LectivoTotalImputacionEntity : maps
     JpaLectivoTotalImputacionRepository --> LectivoTotalImputacionEntity : persists
+
+    LectivoTotalImputacionEntity --> FacultadEntity : references (via FacultadMapper)
+    LectivoTotalImputacionEntity --> LectivoEntity : references (via LectivoMapper)
+    LectivoTotalImputacionEntity --> TipoChequeraEntity : references (via TipoChequeraMapper)
+    LectivoTotalImputacionEntity --> ProductoEntity : references (via ProductoMapper)
+    LectivoTotalImputacionEntity --> CuentaEntity : references (via CuentaMapper)
 
     LectivoTotalImputacionController --> LectivoTotalImputacionService : calls
     LectivoTotalImputacionController --> LectivoTotalImputacionDtoMapper : uses

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.30.0</version>
+    <version>3.31.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>
@@ -67,6 +67,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/service/LectivoTotalImputacionService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/service/LectivoTotalImputacionService.java
@@ -13,12 +13,17 @@ import java.util.Optional;
 public class LectivoTotalImputacionService {
 
     private final FindAllByTipoUseCase findAllByTipoUseCase;
+    private final FindAllByLectivoUseCase findAllByLectivoUseCase;
     private final FindByProductoUseCase findByProductoUseCase;
     private final AddLectivoTotalImputacionUseCase addLectivoTotalImputacionUseCase;
     private final UpdateLectivoTotalImputacionUseCase updateLectivoTotalImputacionUseCase;
 
     public List<LectivoTotalImputacion> findAllByTipo(Integer facultadId, Integer lectivoId, Integer tipoChequeraId) {
         return findAllByTipoUseCase.findAllByTipo(facultadId, lectivoId, tipoChequeraId);
+    }
+
+    public List<LectivoTotalImputacion> findAllByLectivo(Integer lectivoId) {
+        return findAllByLectivoUseCase.findAllByLectivo(lectivoId);
     }
 
     public Optional<LectivoTotalImputacion> findByProducto(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId) {

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/FindAllByLectivoUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/FindAllByLectivoUseCaseImpl.java
@@ -1,0 +1,22 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.ports.in.FindAllByLectivoUseCase;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.ports.out.LectivoTotalImputacionRepository;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class FindAllByLectivoUseCaseImpl implements FindAllByLectivoUseCase {
+
+    private final LectivoTotalImputacionRepository repository;
+
+    @Override
+    public List<LectivoTotalImputacion> findAllByLectivo(Integer lectivoId) {
+        return repository.findAllByLectivo(lectivoId);
+    }
+
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/domain/model/LectivoTotalImputacion.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/domain/model/LectivoTotalImputacion.java
@@ -1,6 +1,12 @@
 package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model;
 
 import lombok.*;
+import um.tesoreria.core.hexagonal.contable.cuenta.domain.model.Cuenta;
+import um.tesoreria.core.hexagonal.facultad.domain.model.Facultad;
+import um.tesoreria.core.hexagonal.lectivo.domain.model.Lectivo;
+import um.tesoreria.core.hexagonal.chequera.producto.domain.model.Producto;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
+
 import java.math.BigDecimal;
 
 @Getter
@@ -15,4 +21,10 @@ public class LectivoTotalImputacion {
     private Integer tipoChequeraId;
     private Integer productoId;
     private BigDecimal numeroCuenta;
+
+    private Facultad facultad;
+    private Lectivo lectivo;
+    private TipoChequera tipoChequera;
+    private Producto producto;
+    private Cuenta cuenta;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/domain/ports/in/FindAllByLectivoUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/domain/ports/in/FindAllByLectivoUseCase.java
@@ -1,0 +1,9 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+
+import java.util.List;
+
+public interface FindAllByLectivoUseCase {
+    List<LectivoTotalImputacion> findAllByLectivo(Integer lectivoId);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/domain/ports/out/LectivoTotalImputacionRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/domain/ports/out/LectivoTotalImputacionRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 public interface LectivoTotalImputacionRepository {
     List<LectivoTotalImputacion> findAllByTipo(Integer facultadId, Integer lectivoId, Integer tipoChequeraId);
+    List<LectivoTotalImputacion> findAllByLectivo(Integer lectivoId);
     Optional<LectivoTotalImputacion> findByProducto(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId);
     LectivoTotalImputacion add(LectivoTotalImputacion lectivoTotalImputacion);
     Optional<LectivoTotalImputacion> update(Long id, LectivoTotalImputacion lectivoTotalImputacion);

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/adapter/JpaLectivoTotalImputacionRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/adapter/JpaLectivoTotalImputacionRepositoryAdapter.java
@@ -26,6 +26,12 @@ public class JpaLectivoTotalImputacionRepositoryAdapter implements LectivoTotalI
     }
 
     @Override
+    public List<LectivoTotalImputacion> findAllByLectivo(Integer lectivoId) {
+        return jpaLectivoTotalImputacionRepository.findAllByLectivoId(lectivoId)
+                .stream().map(mapper::toDomain).collect(Collectors.toList());
+    }
+
+    @Override
     public Optional<LectivoTotalImputacion> findByProducto(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId) {
         return jpaLectivoTotalImputacionRepository
                 .findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoId(facultadId, lectivoId, tipoChequeraId, productoId)

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/entity/LectivoTotalImputacionEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/entity/LectivoTotalImputacionEntity.java
@@ -34,23 +34,23 @@ public class LectivoTotalImputacionEntity extends Auditable {
     private BigDecimal numeroCuenta;
 
 	@OneToOne(optional = true)
-	@JoinColumn(columnDefinition = "facultadId", insertable = false, updatable = false)
+	@JoinColumn(name = "facultadId", insertable = false, updatable = false)
 	private FacultadEntity facultad;
 
 	@OneToOne(optional = true)
-	@JoinColumn(columnDefinition = "lectivoId", insertable = false, updatable = false)
+	@JoinColumn(name = "lectivoId", insertable = false, updatable = false)
 	private LectivoEntity lectivo;
 
 	@OneToOne(optional = true)
-	@JoinColumn(columnDefinition = "tipoChequeraId", insertable = false, updatable = false)
+	@JoinColumn(name = "tipoChequeraId", insertable = false, updatable = false)
 	private TipoChequeraEntity tipoChequera;
 
 	@OneToOne(optional = true)
-	@JoinColumn(columnDefinition = "productoId", insertable = false, updatable = false)
+	@JoinColumn(name = "productoId", insertable = false, updatable = false)
 	private ProductoEntity producto;
 
 	@OneToOne(optional = true)
-	@JoinColumn(columnDefinition = "numeroCuenta", insertable = false, updatable = false)
+	@JoinColumn(name = "cuenta", insertable = false, updatable = false)
 	private CuentaEntity cuenta;
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/mapper/LectivoTotalImputacionMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/mapper/LectivoTotalImputacionMapper.java
@@ -1,11 +1,24 @@
 package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.mapper;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.contable.cuenta.infrastructure.persistence.mapper.CuentaMapper;
 import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
 import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.entity.LectivoTotalImputacionEntity;
+import um.tesoreria.core.hexagonal.chequera.producto.infrastructure.persistence.mapper.ProductoMapper;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.mapper.TipoChequeraMapper;
+import um.tesoreria.core.hexagonal.facultad.infrastructure.persistence.mapper.FacultadMapper;
+import um.tesoreria.core.hexagonal.lectivo.infrastructure.persistence.mapper.LectivoMapper;
 
 @Component
+@RequiredArgsConstructor
 public class LectivoTotalImputacionMapper {
+
+    private final FacultadMapper facultadMapper;
+    private final LectivoMapper lectivoMapper;
+    private final TipoChequeraMapper tipoChequeraMapper;
+    private final ProductoMapper productoMapper;
+    private final CuentaMapper cuentaMapper;
 
     public LectivoTotalImputacion toDomain(LectivoTotalImputacionEntity entity) {
         if (entity == null) return null;
@@ -16,6 +29,11 @@ public class LectivoTotalImputacionMapper {
                 .tipoChequeraId(entity.getTipoChequeraId())
                 .productoId(entity.getProductoId())
                 .numeroCuenta(entity.getNumeroCuenta())
+                .facultad(facultadMapper.toDomain(entity.getFacultad()))
+                .lectivo(lectivoMapper.toDomainModel(entity.getLectivo()))
+                .tipoChequera(tipoChequeraMapper.toDomainModel(entity.getTipoChequera()))
+                .producto(productoMapper.toDomainModel(entity.getProducto()))
+                .cuenta(cuentaMapper.toDomain(entity.getCuenta()))
                 .build();
     }
 

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/repository/JpaLectivoTotalImputacionRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/repository/JpaLectivoTotalImputacionRepository.java
@@ -21,6 +21,8 @@ public interface JpaLectivoTotalImputacionRepository extends JpaRepository<Lecti
 	List<LectivoTotalImputacionEntity> findAllByFacultadIdAndLectivoIdAndTipoChequeraId(Integer facultadId,
 	                                                                                           Integer lectivoId, Integer tipoChequeraId);
 
+	List<LectivoTotalImputacionEntity> findAllByLectivoId(Integer lectivoId);
+
 	Optional<LectivoTotalImputacionEntity> findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoId(
 			Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId);
 

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/controller/LectivoTotalImputacionController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/controller/LectivoTotalImputacionController.java
@@ -1,7 +1,6 @@
 package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.web.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.application.service.LectivoTotalImputacionService;
@@ -13,12 +12,20 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/lectivototalimputacion")
+@RequestMapping({"/lectivototalimputacion", "/api/tesoreria/core/lectivototalimputacion"})
 @RequiredArgsConstructor
 public class LectivoTotalImputacionController {
 
     private final LectivoTotalImputacionService service;
     private final LectivoTotalImputacionDtoMapper mapper;
+
+    @GetMapping("/lectivo/{lectivoId}")
+    public ResponseEntity<List<LectivoTotalImputacionResponse>> findAllByLectivo(
+            @PathVariable Integer lectivoId) {
+        List<LectivoTotalImputacionResponse> responses = service.findAllByLectivo(lectivoId)
+                .stream().map(mapper::toResponse).collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
 
     @GetMapping("/tipo/{facultadId}/{lectivoId}/{tipochequeraId}")
     public ResponseEntity<List<LectivoTotalImputacionResponse>> findAllByTipo(
@@ -27,7 +34,7 @@ public class LectivoTotalImputacionController {
             @PathVariable Integer tipochequeraId) {
         List<LectivoTotalImputacionResponse> responses = service.findAllByTipo(facultadId, lectivoId, tipochequeraId)
                 .stream().map(mapper::toResponse).collect(Collectors.toList());
-        return new ResponseEntity<>(responses, HttpStatus.OK);
+        return ResponseEntity.ok(responses);
     }
 
     @GetMapping("/producto/{facultadId}/{lectivoId}/{tipochequeraId}/{productoId}")
@@ -37,14 +44,14 @@ public class LectivoTotalImputacionController {
             @PathVariable Integer tipochequeraId,
             @PathVariable Integer productoId) {
         return service.findByProducto(facultadId, lectivoId, tipochequeraId, productoId)
-                .map(domain -> new ResponseEntity<>(mapper.toResponse(domain), HttpStatus.OK))
-                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+                .map(domain -> ResponseEntity.ok(mapper.toResponse(domain)))
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @PostMapping("/")
     public ResponseEntity<LectivoTotalImputacionResponse> add(@RequestBody LectivoTotalImputacionRequest request) {
         LectivoTotalImputacionResponse response = mapper.toResponse(service.add(mapper.toDomain(request)));
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping("/{lectivoTotalImputacionId}")
@@ -52,8 +59,8 @@ public class LectivoTotalImputacionController {
             @RequestBody LectivoTotalImputacionRequest request,
             @PathVariable Long lectivoTotalImputacionId) {
         return service.update(lectivoTotalImputacionId, mapper.toDomain(request))
-                .map(domain -> new ResponseEntity<>(mapper.toResponse(domain), HttpStatus.OK))
-                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+                .map(domain -> ResponseEntity.ok(mapper.toResponse(domain)))
+                .orElse(ResponseEntity.notFound().build());
     }
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/dto/LectivoTotalImputacionResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/dto/LectivoTotalImputacionResponse.java
@@ -4,6 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import um.tesoreria.core.hexagonal.contable.cuenta.domain.model.Cuenta;
+import um.tesoreria.core.hexagonal.facultad.domain.model.Facultad;
+import um.tesoreria.core.hexagonal.lectivo.domain.model.Lectivo;
+import um.tesoreria.core.hexagonal.chequera.producto.domain.model.Producto;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
+
 import java.math.BigDecimal;
 
 @Data
@@ -17,4 +23,10 @@ public class LectivoTotalImputacionResponse {
     private Integer tipoChequeraId;
     private Integer productoId;
     private BigDecimal numeroCuenta;
+
+    private Facultad facultad;
+    private Lectivo lectivo;
+    private TipoChequera tipoChequera;
+    private Producto producto;
+    private Cuenta cuenta;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/mapper/LectivoTotalImputacionDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/mapper/LectivoTotalImputacionDtoMapper.java
@@ -29,6 +29,11 @@ public class LectivoTotalImputacionDtoMapper {
                 .tipoChequeraId(domain.getTipoChequeraId())
                 .productoId(domain.getProductoId())
                 .numeroCuenta(domain.getNumeroCuenta())
+                .facultad(domain.getFacultad())
+                .lectivo(domain.getLectivo())
+                .tipoChequera(domain.getTipoChequera())
+                .producto(domain.getProducto())
+                .cuenta(domain.getCuenta())
                 .build();
     }
 

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/service/LectivoTotalImputacionServiceTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/service/LectivoTotalImputacionServiceTest.java
@@ -1,0 +1,79 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.application.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.ports.in.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LectivoTotalImputacionServiceTest {
+
+    @Mock
+    private FindAllByTipoUseCase findAllByTipoUseCase;
+    @Mock
+    private FindAllByLectivoUseCase findAllByLectivoUseCase;
+    @Mock
+    private FindByProductoUseCase findByProductoUseCase;
+    @Mock
+    private AddLectivoTotalImputacionUseCase addLectivoTotalImputacionUseCase;
+    @Mock
+    private UpdateLectivoTotalImputacionUseCase updateLectivoTotalImputacionUseCase;
+
+    @InjectMocks
+    private LectivoTotalImputacionService service;
+
+    @Test
+    void findAllByTipo_delegatesToUseCase() {
+        var results = List.of(LectivoTotalImputacion.builder().build());
+        when(findAllByTipoUseCase.findAllByTipo(1, 2, 3)).thenReturn(results);
+
+        assertThat(service.findAllByTipo(1, 2, 3)).isEqualTo(results);
+        verify(findAllByTipoUseCase).findAllByTipo(1, 2, 3);
+    }
+
+    @Test
+    void findAllByLectivo_delegatesToUseCase() {
+        var results = List.of(LectivoTotalImputacion.builder().build());
+        when(findAllByLectivoUseCase.findAllByLectivo(1)).thenReturn(results);
+
+        assertThat(service.findAllByLectivo(1)).isEqualTo(results);
+        verify(findAllByLectivoUseCase).findAllByLectivo(1);
+    }
+
+    @Test
+    void findByProducto_delegatesToUseCase() {
+        var domain = LectivoTotalImputacion.builder().build();
+        when(findByProductoUseCase.findByProducto(1, 2, 3, 4)).thenReturn(Optional.of(domain));
+
+        assertThat(service.findByProducto(1, 2, 3, 4)).contains(domain);
+        verify(findByProductoUseCase).findByProducto(1, 2, 3, 4);
+    }
+
+    @Test
+    void add_delegatesToUseCase() {
+        var domain = LectivoTotalImputacion.builder().build();
+        when(addLectivoTotalImputacionUseCase.add(domain)).thenReturn(domain);
+
+        assertThat(service.add(domain)).isEqualTo(domain);
+        verify(addLectivoTotalImputacionUseCase).add(domain);
+    }
+
+    @Test
+    void update_delegatesToUseCase() {
+        var domain = LectivoTotalImputacion.builder().build();
+        when(updateLectivoTotalImputacionUseCase.update(1L, domain)).thenReturn(Optional.of(domain));
+
+        assertThat(service.update(1L, domain)).contains(domain);
+        verify(updateLectivoTotalImputacionUseCase).update(1L, domain);
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/AddLectivoTotalImputacionUseCaseImplTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/AddLectivoTotalImputacionUseCaseImplTest.java
@@ -1,0 +1,36 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.application.usecases;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.ports.out.LectivoTotalImputacionRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AddLectivoTotalImputacionUseCaseImplTest {
+
+    @Mock
+    private LectivoTotalImputacionRepository repository;
+
+    @InjectMocks
+    private AddLectivoTotalImputacionUseCaseImpl useCase;
+
+    @Test
+    void add_delegatesToRepository() {
+        var domain = LectivoTotalImputacion.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4).build();
+
+        when(repository.add(domain)).thenReturn(domain);
+
+        var result = useCase.add(domain);
+
+        assertThat(result).isEqualTo(domain);
+        verify(repository).add(domain);
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/FindAllByLectivoUseCaseImplTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/FindAllByLectivoUseCaseImplTest.java
@@ -1,0 +1,36 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.application.usecases;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.ports.out.LectivoTotalImputacionRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FindAllByLectivoUseCaseImplTest {
+
+    @Mock
+    private LectivoTotalImputacionRepository repository;
+
+    @InjectMocks
+    private FindAllByLectivoUseCaseImpl useCase;
+
+    @Test
+    void findAllByLectivo_delegatesToRepository() {
+        var results = List.of(LectivoTotalImputacion.builder().build());
+        when(repository.findAllByLectivo(1)).thenReturn(results);
+
+        var actual = useCase.findAllByLectivo(1);
+
+        assertThat(actual).isEqualTo(results);
+        verify(repository).findAllByLectivo(1);
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/FindAllByTipoUseCaseImplTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/FindAllByTipoUseCaseImplTest.java
@@ -1,0 +1,36 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.application.usecases;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.ports.out.LectivoTotalImputacionRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FindAllByTipoUseCaseImplTest {
+
+    @Mock
+    private LectivoTotalImputacionRepository repository;
+
+    @InjectMocks
+    private FindAllByTipoUseCaseImpl useCase;
+
+    @Test
+    void findAllByTipo_delegatesToRepository() {
+        var results = List.of(LectivoTotalImputacion.builder().build());
+        when(repository.findAllByTipo(1, 2, 3)).thenReturn(results);
+
+        var actual = useCase.findAllByTipo(1, 2, 3);
+
+        assertThat(actual).isEqualTo(results);
+        verify(repository).findAllByTipo(1, 2, 3);
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/FindByProductoUseCaseImplTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/FindByProductoUseCaseImplTest.java
@@ -1,0 +1,46 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.application.usecases;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.ports.out.LectivoTotalImputacionRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FindByProductoUseCaseImplTest {
+
+    @Mock
+    private LectivoTotalImputacionRepository repository;
+
+    @InjectMocks
+    private FindByProductoUseCaseImpl useCase;
+
+    @Test
+    void findByProducto_delegatesToRepository() {
+        var domain = LectivoTotalImputacion.builder().build();
+        when(repository.findByProducto(1, 2, 3, 4)).thenReturn(Optional.of(domain));
+
+        var result = useCase.findByProducto(1, 2, 3, 4);
+
+        assertThat(result).contains(domain);
+        verify(repository).findByProducto(1, 2, 3, 4);
+    }
+
+    @Test
+    void findByProducto_whenNotFound_returnsEmpty() {
+        when(repository.findByProducto(1, 2, 3, 4)).thenReturn(Optional.empty());
+
+        var result = useCase.findByProducto(1, 2, 3, 4);
+
+        assertThat(result).isEmpty();
+        verify(repository).findByProducto(1, 2, 3, 4);
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/UpdateLectivoTotalImputacionUseCaseImplTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/application/usecases/UpdateLectivoTotalImputacionUseCaseImplTest.java
@@ -1,0 +1,47 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.application.usecases;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.ports.out.LectivoTotalImputacionRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateLectivoTotalImputacionUseCaseImplTest {
+
+    @Mock
+    private LectivoTotalImputacionRepository repository;
+
+    @InjectMocks
+    private UpdateLectivoTotalImputacionUseCaseImpl useCase;
+
+    @Test
+    void update_delegatesToRepository() {
+        var domain = LectivoTotalImputacion.builder().build();
+        when(repository.update(1L, domain)).thenReturn(Optional.of(domain));
+
+        var result = useCase.update(1L, domain);
+
+        assertThat(result).contains(domain);
+        verify(repository).update(1L, domain);
+    }
+
+    @Test
+    void update_whenNotFound_returnsEmpty() {
+        var domain = LectivoTotalImputacion.builder().build();
+        when(repository.update(1L, domain)).thenReturn(Optional.empty());
+
+        var result = useCase.update(1L, domain);
+
+        assertThat(result).isEmpty();
+        verify(repository).update(1L, domain);
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/adapter/JpaLectivoTotalImputacionRepositoryAdapterTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/adapter/JpaLectivoTotalImputacionRepositoryAdapterTest.java
@@ -1,0 +1,176 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.adapter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.entity.LectivoTotalImputacionEntity;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.mapper.LectivoTotalImputacionMapper;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.repository.JpaLectivoTotalImputacionRepository;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaLectivoTotalImputacionRepositoryAdapter.class, JpaLectivoTotalImputacionRepositoryAdapterTest.TestAuditingConfig.class})
+class JpaLectivoTotalImputacionRepositoryAdapterTest {
+
+    @EnableJpaAuditing
+    static class TestAuditingConfig {}
+
+    @Autowired
+    private JpaLectivoTotalImputacionRepositoryAdapter adapter;
+
+    @Autowired
+    private JpaLectivoTotalImputacionRepository jpaRepository;
+
+    @MockitoBean
+    private LectivoTotalImputacionMapper mapper;
+
+    @Test
+    void add_savesAndMaps() {
+        var domain = LectivoTotalImputacion.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("100.50")).build();
+
+        var entityWithoutId = LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("100.50")).build();
+
+        var expectedDomain = LectivoTotalImputacion.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("100.50")).build();
+
+        when(mapper.toEntity(domain)).thenReturn(entityWithoutId);
+        when(mapper.toDomain(any(LectivoTotalImputacionEntity.class))).thenReturn(expectedDomain);
+
+        var result = adapter.add(domain);
+
+        assertThat(result).isEqualTo(expectedDomain);
+        verify(mapper).toEntity(domain);
+        verify(mapper).toDomain(any(LectivoTotalImputacionEntity.class));
+    }
+
+    @Test
+    void findById_whenFound_mapsAndReturns() {
+        var saved = jpaRepository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("100.50")).build());
+
+        var expected = LectivoTotalImputacion.builder()
+                .lectivoTotalImputacionId(saved.getLectivoTotalImputacionId())
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("100.50")).build();
+
+        when(mapper.toDomain(any(LectivoTotalImputacionEntity.class))).thenReturn(expected);
+
+        Optional<LectivoTotalImputacion> result = adapter.findById(saved.getLectivoTotalImputacionId());
+
+        assertThat(result).contains(expected);
+    }
+
+    @Test
+    void findById_whenNotFound_returnsEmpty() {
+        var result = adapter.findById(999L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findAllByTipo_returnsMappedList() {
+        jpaRepository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("10.00")).build());
+        jpaRepository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(5)
+                .numeroCuenta(new BigDecimal("20.00")).build());
+
+        when(mapper.toDomain(any(LectivoTotalImputacionEntity.class)))
+                .thenReturn(LectivoTotalImputacion.builder().build())
+                .thenReturn(LectivoTotalImputacion.builder().build());
+
+        var results = adapter.findAllByTipo(1, 2, 3);
+
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    void findAllByLectivo_returnsMappedList() {
+        jpaRepository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("10.00")).build());
+
+        when(mapper.toDomain(any(LectivoTotalImputacionEntity.class)))
+                .thenReturn(LectivoTotalImputacion.builder().build());
+
+        var results = adapter.findAllByLectivo(2);
+
+        assertThat(results).hasSize(1);
+    }
+
+    @Test
+    void findByProducto_whenFound_mapsAndReturns() {
+        jpaRepository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("10.00")).build());
+
+        when(mapper.toDomain(any(LectivoTotalImputacionEntity.class)))
+                .thenReturn(LectivoTotalImputacion.builder().lectivoTotalImputacionId(1L).build());
+
+        var result = adapter.findByProducto(1, 2, 3, 4);
+
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    void findByProducto_whenNotFound_returnsEmpty() {
+        var result = adapter.findByProducto(1, 2, 3, 999);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void update_whenFound_updatesAndMaps() {
+        var saved = jpaRepository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("10.00")).build());
+        jpaRepository.flush();
+        var id = saved.getLectivoTotalImputacionId();
+
+        var updateDomain = LectivoTotalImputacion.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("99.99")).build();
+
+        var updateEntity = LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("99.99")).build();
+
+        when(mapper.toEntity(updateDomain)).thenReturn(updateEntity);
+        when(mapper.toDomain(any(LectivoTotalImputacionEntity.class)))
+                .thenReturn(LectivoTotalImputacion.builder().lectivoTotalImputacionId(id).build());
+
+        var result = adapter.update(id, updateDomain);
+
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    void update_whenNotFound_returnsEmpty() {
+        var domain = LectivoTotalImputacion.builder().build();
+
+        var result = adapter.update(999L, domain);
+
+        assertThat(result).isEmpty();
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/mapper/LectivoTotalImputacionMapperTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/mapper/LectivoTotalImputacionMapperTest.java
@@ -1,0 +1,165 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.mapper;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.contable.cuenta.domain.model.Cuenta;
+import um.tesoreria.core.hexagonal.contable.cuenta.infrastructure.persistence.entity.CuentaEntity;
+import um.tesoreria.core.hexagonal.contable.cuenta.infrastructure.persistence.mapper.CuentaMapper;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.entity.LectivoTotalImputacionEntity;
+import um.tesoreria.core.hexagonal.chequera.producto.domain.model.Producto;
+import um.tesoreria.core.hexagonal.chequera.producto.infrastructure.persistence.entity.ProductoEntity;
+import um.tesoreria.core.hexagonal.chequera.producto.infrastructure.persistence.mapper.ProductoMapper;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.entity.TipoChequeraEntity;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.mapper.TipoChequeraMapper;
+import um.tesoreria.core.hexagonal.facultad.domain.model.Facultad;
+import um.tesoreria.core.hexagonal.facultad.infrastructure.persistence.entity.FacultadEntity;
+import um.tesoreria.core.hexagonal.facultad.infrastructure.persistence.mapper.FacultadMapper;
+import um.tesoreria.core.hexagonal.lectivo.domain.model.Lectivo;
+import um.tesoreria.core.hexagonal.lectivo.infrastructure.persistence.entity.LectivoEntity;
+import um.tesoreria.core.hexagonal.lectivo.infrastructure.persistence.mapper.LectivoMapper;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LectivoTotalImputacionMapperTest {
+
+    @Mock
+    private FacultadMapper facultadMapper;
+    @Mock
+    private LectivoMapper lectivoMapper;
+    @Mock
+    private TipoChequeraMapper tipoChequeraMapper;
+    @Mock
+    private ProductoMapper productoMapper;
+    @Mock
+    private CuentaMapper cuentaMapper;
+
+    @InjectMocks
+    private LectivoTotalImputacionMapper mapper;
+
+    @Test
+    void toDomain_whenEntityIsNull_returnsNull() {
+        assertThat(mapper.toDomain(null)).isNull();
+    }
+
+    @Test
+    void toDomain_mapsScalarFields() {
+        var entity = LectivoTotalImputacionEntity.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultadId(100)
+                .lectivoId(200)
+                .tipoChequeraId(300)
+                .productoId(400)
+                .numeroCuenta(new BigDecimal("123.45"))
+                .build();
+
+        var domain = mapper.toDomain(entity);
+
+        assertThat(domain.getLectivoTotalImputacionId()).isEqualTo(1L);
+        assertThat(domain.getFacultadId()).isEqualTo(100);
+        assertThat(domain.getLectivoId()).isEqualTo(200);
+        assertThat(domain.getTipoChequeraId()).isEqualTo(300);
+        assertThat(domain.getProductoId()).isEqualTo(400);
+        assertThat(domain.getNumeroCuenta()).isEqualByComparingTo(new BigDecimal("123.45"));
+    }
+
+    @Test
+    void toDomain_mapsRelatedEntities() {
+        var facultadEntity = new FacultadEntity();
+        var lectivoEntity = new LectivoEntity();
+        var tipoChequeraEntity = new TipoChequeraEntity();
+        var productoEntity = new ProductoEntity();
+        var cuentaEntity = new CuentaEntity();
+
+        var entity = LectivoTotalImputacionEntity.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultad(facultadEntity)
+                .lectivo(lectivoEntity)
+                .tipoChequera(tipoChequeraEntity)
+                .producto(productoEntity)
+                .cuenta(cuentaEntity)
+                .build();
+
+        var facultad = new Facultad();
+        var lectivo = new Lectivo();
+        var tipoChequera = new TipoChequera();
+        var producto = new Producto();
+        var cuenta = new Cuenta();
+
+        when(facultadMapper.toDomain(facultadEntity)).thenReturn(facultad);
+        when(lectivoMapper.toDomainModel(lectivoEntity)).thenReturn(lectivo);
+        when(tipoChequeraMapper.toDomainModel(tipoChequeraEntity)).thenReturn(tipoChequera);
+        when(productoMapper.toDomainModel(productoEntity)).thenReturn(producto);
+        when(cuentaMapper.toDomain(cuentaEntity)).thenReturn(cuenta);
+
+        var domain = mapper.toDomain(entity);
+
+        assertThat(domain.getFacultad()).isEqualTo(facultad);
+        assertThat(domain.getLectivo()).isEqualTo(lectivo);
+        assertThat(domain.getTipoChequera()).isEqualTo(tipoChequera);
+        assertThat(domain.getProducto()).isEqualTo(producto);
+        assertThat(domain.getCuenta()).isEqualTo(cuenta);
+    }
+
+    @Test
+    void toDomain_whenRelatedEntitiesAreNull_doesNotThrow() {
+        var entity = LectivoTotalImputacionEntity.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultadId(100)
+                .lectivoId(200)
+                .build();
+
+        var domain = mapper.toDomain(entity);
+
+        assertThat(domain.getFacultadId()).isEqualTo(100);
+        assertThat(domain.getFacultad()).isNull();
+    }
+
+    @Test
+    void toEntity_whenDomainIsNull_returnsNull() {
+        assertThat(mapper.toEntity(null)).isNull();
+    }
+
+    @Test
+    void toEntity_mapsAllFields() {
+        var domain = LectivoTotalImputacion.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultadId(100)
+                .lectivoId(200)
+                .tipoChequeraId(300)
+                .productoId(400)
+                .numeroCuenta(new BigDecimal("123.45"))
+                .build();
+
+        var entity = mapper.toEntity(domain);
+
+        assertThat(entity.getLectivoTotalImputacionId()).isEqualTo(1L);
+        assertThat(entity.getFacultadId()).isEqualTo(100);
+        assertThat(entity.getLectivoId()).isEqualTo(200);
+        assertThat(entity.getTipoChequeraId()).isEqualTo(300);
+        assertThat(entity.getProductoId()).isEqualTo(400);
+        assertThat(entity.getNumeroCuenta()).isEqualByComparingTo(new BigDecimal("123.45"));
+    }
+
+    @Test
+    void toEntity_doesNotMapRelatedEntities() {
+        var facultad = new Facultad();
+        var domain = LectivoTotalImputacion.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultad(facultad)
+                .build();
+
+        var entity = mapper.toEntity(domain);
+
+        assertThat(entity.getFacultad()).isNull();
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/repository/JpaLectivoTotalImputacionRepositoryTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/persistence/repository/JpaLectivoTotalImputacionRepositoryTest.java
@@ -1,0 +1,92 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.persistence.entity.LectivoTotalImputacionEntity;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaLectivoTotalImputacionRepositoryTest.TestAuditingConfig.class)
+class JpaLectivoTotalImputacionRepositoryTest {
+
+    @EnableJpaAuditing
+    static class TestAuditingConfig {}
+
+    @Autowired
+    private JpaLectivoTotalImputacionRepository repository;
+
+    @Test
+    void saveAndFindById() {
+        var saved = repository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("100.50")).build());
+
+        assertThat(saved.getLectivoTotalImputacionId()).isNotNull();
+
+        var found = repository.findById(saved.getLectivoTotalImputacionId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getFacultadId()).isEqualTo(1);
+    }
+
+    @Test
+    void findAllByFacultadIdAndLectivoIdAndTipoChequeraId() {
+        repository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("10.00")).build());
+        repository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(5)
+                .numeroCuenta(new BigDecimal("20.00")).build());
+        repository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(4).productoId(6)
+                .numeroCuenta(new BigDecimal("30.00")).build());
+
+        var results = repository.findAllByFacultadIdAndLectivoIdAndTipoChequeraId(1, 2, 3);
+
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    void findAllByLectivoId() {
+        repository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4).build());
+        repository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(4).productoId(5).build());
+        repository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(3).tipoChequeraId(3).productoId(6).build());
+
+        var results = repository.findAllByLectivoId(2);
+
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    void findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoId() {
+        repository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("50.00")).build());
+        repository.save(LectivoTotalImputacionEntity.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(5)
+                .numeroCuenta(new BigDecimal("75.00")).build());
+
+        var result = repository.findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoId(1, 2, 3, 4);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getNumeroCuenta()).isEqualByComparingTo(new BigDecimal("50.00"));
+    }
+
+    @Test
+    void findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoId_whenNotFound() {
+        var result = repository.findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoId(999, 999, 999, 999);
+
+        assertThat(result).isEmpty();
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/controller/LectivoTotalImputacionControllerTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/controller/LectivoTotalImputacionControllerTest.java
@@ -1,0 +1,168 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.web.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.application.service.LectivoTotalImputacionService;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.web.dto.LectivoTotalImputacionRequest;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.web.dto.LectivoTotalImputacionResponse;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.web.mapper.LectivoTotalImputacionDtoMapper;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(LectivoTotalImputacionController.class)
+class LectivoTotalImputacionControllerTest {
+
+    @Autowired
+    private MockMvcTester mockMvc;
+
+    @MockitoBean
+    private LectivoTotalImputacionService service;
+
+    @MockitoBean
+    private LectivoTotalImputacionDtoMapper mapper;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void findAllByLectivo_returnsList() {
+        var domain = LectivoTotalImputacion.builder().lectivoTotalImputacionId(1L).build();
+        var response = LectivoTotalImputacionResponse.builder().lectivoTotalImputacionId(1L).build();
+
+        when(service.findAllByLectivo(1)).thenReturn(List.of(domain));
+        when(mapper.toResponse(domain)).thenReturn(response);
+
+        mockMvc.get().uri("/lectivototalimputacion/lectivo/1")
+                .accept(MediaType.APPLICATION_JSON)
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson().extractingPath("$").asArray().hasSize(1);
+    }
+
+    @Test
+    void findAllByTipo_returnsList() {
+        var domain = LectivoTotalImputacion.builder().lectivoTotalImputacionId(1L).build();
+        var response = LectivoTotalImputacionResponse.builder().lectivoTotalImputacionId(1L).build();
+
+        when(service.findAllByTipo(1, 2, 3)).thenReturn(List.of(domain));
+        when(mapper.toResponse(domain)).thenReturn(response);
+
+        mockMvc.get().uri("/lectivototalimputacion/tipo/1/2/3")
+                .accept(MediaType.APPLICATION_JSON)
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson().extractingPath("$").asArray().hasSize(1);
+    }
+
+    @Test
+    void findByProducto_whenFound_returnsOk() {
+        var domain = LectivoTotalImputacion.builder().lectivoTotalImputacionId(1L).build();
+        var response = LectivoTotalImputacionResponse.builder().lectivoTotalImputacionId(1L).build();
+
+        when(service.findByProducto(1, 2, 3, 4)).thenReturn(Optional.of(domain));
+        when(mapper.toResponse(domain)).thenReturn(response);
+
+        mockMvc.get().uri("/lectivototalimputacion/producto/1/2/3/4")
+                .accept(MediaType.APPLICATION_JSON)
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson().extractingPath("$.lectivoTotalImputacionId").isEqualTo(1);
+    }
+
+    @Test
+    void findByProducto_whenNotFound_returnsNotFound() {
+        when(service.findByProducto(1, 2, 3, 4)).thenReturn(Optional.empty());
+
+        mockMvc.get().uri("/lectivototalimputacion/producto/1/2/3/4")
+                .accept(MediaType.APPLICATION_JSON)
+                .assertThat()
+                .hasStatus(404);
+    }
+
+    @Test
+    void add_returnsOk() throws Exception {
+        var request = new LectivoTotalImputacionRequest();
+        request.setFacultadId(1);
+        request.setLectivoId(2);
+        request.setTipoChequeraId(3);
+        request.setProductoId(4);
+        request.setNumeroCuenta(new BigDecimal("100.50"));
+
+        var domain = LectivoTotalImputacion.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("100.50")).build();
+
+        var response = LectivoTotalImputacionResponse.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultadId(1).lectivoId(2).tipoChequeraId(3).productoId(4)
+                .numeroCuenta(new BigDecimal("100.50")).build();
+
+        when(mapper.toDomain(request)).thenReturn(domain);
+        when(service.add(domain)).thenReturn(domain);
+        when(mapper.toResponse(domain)).thenReturn(response);
+
+        mockMvc.post().uri("/lectivototalimputacion/")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson().extractingPath("$.lectivoTotalImputacionId").isEqualTo(1);
+    }
+
+    @Test
+    void update_whenFound_returnsOk() throws Exception {
+        var request = new LectivoTotalImputacionRequest();
+        request.setFacultadId(1);
+        request.setLectivoId(2);
+
+        var domain = LectivoTotalImputacion.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultadId(1).lectivoId(2).build();
+
+        var response = LectivoTotalImputacionResponse.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultadId(1).lectivoId(2).build();
+
+        when(mapper.toDomain(request)).thenReturn(domain);
+        when(service.update(1L, domain)).thenReturn(Optional.of(domain));
+        when(mapper.toResponse(domain)).thenReturn(response);
+
+        mockMvc.put().uri("/lectivototalimputacion/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson().extractingPath("$.lectivoTotalImputacionId").isEqualTo(1);
+    }
+
+    @Test
+    void update_whenNotFound_returnsNotFound() throws Exception {
+        var domain = LectivoTotalImputacion.builder().build();
+        when(mapper.toDomain(any())).thenReturn(domain);
+        when(service.update(1L, domain)).thenReturn(Optional.empty());
+
+        mockMvc.put().uri("/lectivototalimputacion/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new LectivoTotalImputacionRequest()))
+                .assertThat()
+                .hasStatus(404);
+    }
+
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/mapper/LectivoTotalImputacionDtoMapperTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/contable/lectivoTotalImputacion/infrastructure/web/mapper/LectivoTotalImputacionDtoMapperTest.java
@@ -1,0 +1,67 @@
+package um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.web.mapper;
+
+import org.junit.jupiter.api.Test;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.domain.model.LectivoTotalImputacion;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.web.dto.LectivoTotalImputacionRequest;
+import um.tesoreria.core.hexagonal.contable.lectivoTotalImputacion.infrastructure.web.dto.LectivoTotalImputacionResponse;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LectivoTotalImputacionDtoMapperTest {
+
+    private final LectivoTotalImputacionDtoMapper mapper = new LectivoTotalImputacionDtoMapper();
+
+    @Test
+    void toDomain_whenRequestIsNull_returnsNull() {
+        assertThat(mapper.toDomain(null)).isNull();
+    }
+
+    @Test
+    void toDomain_mapsAllFields() {
+        var request = new LectivoTotalImputacionRequest();
+        request.setLectivoTotalImputacionId(1L);
+        request.setFacultadId(100);
+        request.setLectivoId(200);
+        request.setTipoChequeraId(300);
+        request.setProductoId(400);
+        request.setNumeroCuenta(new BigDecimal("123.45"));
+
+        var domain = mapper.toDomain(request);
+
+        assertThat(domain.getLectivoTotalImputacionId()).isEqualTo(1L);
+        assertThat(domain.getFacultadId()).isEqualTo(100);
+        assertThat(domain.getLectivoId()).isEqualTo(200);
+        assertThat(domain.getTipoChequeraId()).isEqualTo(300);
+        assertThat(domain.getProductoId()).isEqualTo(400);
+        assertThat(domain.getNumeroCuenta()).isEqualByComparingTo(new BigDecimal("123.45"));
+    }
+
+    @Test
+    void toResponse_whenDomainIsNull_returnsNull() {
+        assertThat(mapper.toResponse(null)).isNull();
+    }
+
+    @Test
+    void toResponse_mapsAllFields() {
+        var domain = LectivoTotalImputacion.builder()
+                .lectivoTotalImputacionId(1L)
+                .facultadId(100)
+                .lectivoId(200)
+                .tipoChequeraId(300)
+                .productoId(400)
+                .numeroCuenta(new BigDecimal("123.45"))
+                .build();
+
+        var response = mapper.toResponse(domain);
+
+        assertThat(response.getLectivoTotalImputacionId()).isEqualTo(1L);
+        assertThat(response.getFacultadId()).isEqualTo(100);
+        assertThat(response.getLectivoId()).isEqualTo(200);
+        assertThat(response.getTipoChequeraId()).isEqualTo(300);
+        assertThat(response.getProductoId()).isEqualTo(400);
+        assertThat(response.getNumeroCuenta()).isEqualByComparingTo(new BigDecimal("123.45"));
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   main:
     allow-circular-references: true
   datasource:
-    url: jdbc:h2:mem:tesium_test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:tesium_test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;INIT=SET REFERENTIAL_INTEGRITY FALSE
     username: sa
     password: sa
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
Closes #267

## Descripción

Se agrega el endpoint `findAllByLectivo` en el módulo `LectivoTotalImputacion`, se refactoriza el controlador para usar `ResponseEntity` fluido y se completa la suite de tests unitarios y de integración para todas las capas del módulo hexagonal.

## Cambios Realizados

- **Nuevo endpoint:** `GET /lectivototalimputacion/lectivo/{lectivoId}` + ruta alternativa `/api/tesoreria/core/lectivototalimputacion`
- **Refactor controller:** `ResponseEntity.ok()` / `.notFound().build()` en lugar de `new ResponseEntity<>`
- **Nuevos campos en response:** `facultad`, `lectivo`, `tipoChequera`, `producto`, `cuenta`
- **Tests:** 11 nuevos archivos de test cubriendo service, use cases, repository, controller y mappers
- **Config H2:** `INIT=SET REFERENTIAL_INTEGRITY FALSE` para tests

## Verificación

- `mvn test` pasa correctamente con los nuevos tests
- Los endpoints anteriores siguen funcionando (no breaking)
