### PR TITLE
refactor(reservaVacante): use domain ports over services

### DIFF
--- a/docs/hexagonal-reservaVacante.mmd
+++ b/docs/hexagonal-reservaVacante.mmd
@@ -42,7 +42,8 @@ classDiagram
         namespace usecases {
             class CreateReservaVacanteUseCaseImpl {
                 -ReservaVacanteRepository repository
-                -PersonaService personaService
+                -GetPersonaByUniqueUseCase getPersonaByUniqueUseCase
+                -SavePersonaUseCase savePersonaUseCase
                 -DomicilioService domicilioService
                 -CampanhaService campanhaService
                 -MercadoPagoCoreService mercadoPagoCoreService
@@ -53,7 +54,6 @@ classDiagram
                 -ReservaVacanteRepository repository
                 -PersonaService personaService
                 -DomicilioService domicilioService
-                -CampanhaService campanhaService
                 +findByReservaVacanteId(UUID) ReservaVacante
             }
             class UpdateReservaVacanteUseCaseImpl {

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.31.0</version>
+    <version>3.32.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/application/usecases/ProcessPaymentEventUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/application/usecases/ProcessPaymentEventUseCaseImpl.java
@@ -8,7 +8,8 @@ import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model.MercadoPagoCo
 import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.ports.in.FindByMercadoPagoContextIdUseCase;
 import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.ports.in.ProcessPaymentEventUseCase;
 import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.ports.in.UpdateMercadoPagoContextUseCase;
-import um.tesoreria.core.hexagonal.umhub.reservaVacante.application.service.ReservaVacanteService;
+import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.ports.in.FindReservaVacanteUseCase;
+import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.ports.in.UpdateReservaVacanteUseCase;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.domain.model.ReservaVacante;
 import um.tesoreria.core.service.facade.PagoService;
 
@@ -21,17 +22,20 @@ public class ProcessPaymentEventUseCaseImpl implements ProcessPaymentEventUseCas
     private final FindByMercadoPagoContextIdUseCase findByMercadoPagoContextIdUseCase;
     private final UpdateMercadoPagoContextUseCase updateMercadoPagoContextUseCase;
     private final PagoService pagoService;
-    private final ReservaVacanteService reservaVacanteService;
+    private final FindReservaVacanteUseCase findReservaVacanteUseCase;
+    private final UpdateReservaVacanteUseCase updateReservaVacanteUseCase;
 
     public ProcessPaymentEventUseCaseImpl(
             FindByMercadoPagoContextIdUseCase findByMercadoPagoContextIdUseCase,
             UpdateMercadoPagoContextUseCase updateMercadoPagoContextUseCase,
             @Lazy PagoService pagoService,
-            ReservaVacanteService reservaVacanteService) {
+            FindReservaVacanteUseCase findReservaVacanteUseCase,
+            UpdateReservaVacanteUseCase updateReservaVacanteUseCase) {
         this.findByMercadoPagoContextIdUseCase = findByMercadoPagoContextIdUseCase;
         this.updateMercadoPagoContextUseCase = updateMercadoPagoContextUseCase;
         this.pagoService = pagoService;
-        this.reservaVacanteService = reservaVacanteService;
+        this.findReservaVacanteUseCase = findReservaVacanteUseCase;
+        this.updateReservaVacanteUseCase = updateReservaVacanteUseCase;
     }
 
     @Override
@@ -57,9 +61,9 @@ public class ProcessPaymentEventUseCaseImpl implements ProcessPaymentEventUseCas
             context = updateMercadoPagoContextUseCase.update(context, context.getMercadoPagoContextId());
 
             if ("approved".equals(context.getStatus())) {
-                ReservaVacante reservaVacante = reservaVacanteService.findReservaVacante(context.getReservaVacanteId());
+                ReservaVacante reservaVacante = findReservaVacanteUseCase.findByReservaVacanteId(context.getReservaVacanteId());
                 reservaVacante.setEstado("pagado");
-                reservaVacanteService.updateReservaVacante(reservaVacante, context.getReservaVacanteId());
+                updateReservaVacanteUseCase.update(reservaVacante, context.getReservaVacanteId());
                 log.info("ReservaVacante {} marked as paid.", context.getReservaVacanteId());
             }
         } else {

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/CreateReservaVacanteUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/CreateReservaVacanteUseCaseImpl.java
@@ -9,8 +9,9 @@ import um.tesoreria.core.hexagonal.domicilio.application.exception.DomicilioExce
 import um.tesoreria.core.hexagonal.domicilio.application.service.DomicilioService;
 import um.tesoreria.core.hexagonal.domicilio.domain.model.Domicilio;
 import um.tesoreria.core.hexagonal.mercadoPagoContext.domain.model.MercadoPagoContext;
-import um.tesoreria.core.hexagonal.persona.application.service.PersonaService;
 import um.tesoreria.core.hexagonal.persona.domain.model.Persona;
+import um.tesoreria.core.hexagonal.persona.domain.ports.in.GetPersonaByUniqueUseCase;
+import um.tesoreria.core.hexagonal.persona.domain.ports.in.SavePersonaUseCase;
 import um.tesoreria.core.hexagonal.umhub.campanha.application.service.CampanhaService;
 import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.application.exception.ReservaVacanteException;
@@ -31,7 +32,8 @@ import java.time.ZoneOffset;
 public class CreateReservaVacanteUseCaseImpl implements CreateReservaVacanteUseCase {
 
     private final ReservaVacanteRepository repository;
-    private final PersonaService personaService;
+    private final GetPersonaByUniqueUseCase getPersonaByUniqueUseCase;
+    private final SavePersonaUseCase savePersonaUseCase;
     private final DomicilioService domicilioService;
     private final CampanhaService campanhaService;
     private final MercadoPagoCoreService mercadoPagoCoreService;
@@ -45,7 +47,7 @@ public class CreateReservaVacanteUseCaseImpl implements CreateReservaVacanteUseC
         Persona persona;
         var personaId = new BigDecimal(reservaVacanteRequest.getNumeroDocumento().replaceAll("\\D+", ""));
         try {
-            persona = personaService.findByUnique(personaId, reservaVacanteRequest.getTipoDocumento());
+            persona = getPersonaByUniqueUseCase.findByUnique(personaId, reservaVacanteRequest.getTipoDocumento());
         } catch (PersonaException e) {
             persona = Persona.builder()
                     .personaId(personaId)
@@ -58,7 +60,7 @@ public class CreateReservaVacanteUseCaseImpl implements CreateReservaVacanteUseC
                     .primero((byte) 0)
                     .sexo("")
                     .build();
-            persona = personaService.create(persona);
+            persona = savePersonaUseCase.create(persona);
         }
         log.debug("Persona -> {}", persona.jsonify());
         // Verificar domicilio

--- a/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/FindReservaVacanteUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/umhub/reservaVacante/application/usecases/FindReservaVacanteUseCaseImpl.java
@@ -3,10 +3,10 @@ package um.tesoreria.core.hexagonal.umhub.reservaVacante.application.usecases;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import um.tesoreria.core.hexagonal.domicilio.application.service.DomicilioService;
 import um.tesoreria.core.hexagonal.domicilio.domain.model.Domicilio;
-import um.tesoreria.core.hexagonal.persona.application.service.PersonaService;
+import um.tesoreria.core.hexagonal.domicilio.domain.ports.in.GetDomicilioByUniqueUseCase;
 import um.tesoreria.core.hexagonal.persona.domain.model.Persona;
+import um.tesoreria.core.hexagonal.persona.domain.ports.in.GetPersonaByUniqueIdUseCase;
 import um.tesoreria.core.hexagonal.umhub.campanha.application.service.CampanhaService;
 import um.tesoreria.core.hexagonal.umhub.campanha.domain.model.Campanha;
 import um.tesoreria.core.hexagonal.umhub.reservaVacante.application.exception.ReservaVacanteException;
@@ -22,8 +22,8 @@ import java.util.UUID;
 public class FindReservaVacanteUseCaseImpl implements FindReservaVacanteUseCase {
 
     private final ReservaVacanteRepository repository;
-    private final PersonaService personaService;
-    private final DomicilioService domicilioService;
+    private final GetPersonaByUniqueIdUseCase getPersonaByUniqueIdUseCase;
+    private final GetDomicilioByUniqueUseCase getDomicilioByUniqueUseCase;
 
     @Override
     public ReservaVacante findByReservaVacanteId(UUID reservaVacanteId) {
@@ -31,9 +31,9 @@ public class FindReservaVacanteUseCaseImpl implements FindReservaVacanteUseCase 
         ReservaVacante reservaVacante = repository.findByReservaVacanteId(reservaVacanteId)
                 .orElseThrow(() -> new ReservaVacanteException(reservaVacanteId));
         reservaVacante.setCampanha(reservaVacante.getCampanha());
-        Persona persona = personaService.findByUniqueId(reservaVacante.getPersonaUniqueId());
+        Persona persona = getPersonaByUniqueIdUseCase.findByUniqueId(reservaVacante.getPersonaUniqueId());
         reservaVacante.setPersona(persona);
-        Domicilio domicilio = domicilioService.findByUnique(persona.getPersonaId(), persona.getDocumentoId());
+        Domicilio domicilio = getDomicilioByUniqueUseCase.getDomicilioByUnique(persona.getPersonaId(), persona.getDocumentoId());
         reservaVacante.setDomicilio(domicilio);
         log.debug("ReservaVacante -> {}", reservaVacante.jsonify());
         return reservaVacante;


### PR DESCRIPTION
Closes #271

## Descripción

Migración de dependencias de servicios de aplicación a puertos/use cases de dominio en el módulo `reservaVacante`, alineando la implementación con los principios de arquitectura hexagonal.

## Cambios Realizados

- [x] **ProcessPaymentEventUseCaseImpl**: Reemplazo de `ReservaVacanteService` por `FindReservaVacanteUseCase` y `UpdateReservaVacanteUseCase` (domain ports).
- [x] **CreateReservaVacanteUseCaseImpl**: Reemplazo de `PersonaService` por `GetPersonaByUniqueUseCase` y `SavePersonaUseCase`.
- [x] **FindReservaVacanteUseCaseImpl**: Reemplazo de `PersonaService` por `GetPersonaByUniqueIdUseCase` y `DomicilioService` por `GetDomicilioByUniqueUseCase`. Eliminación de dependencia `CampanhaService` no utilizada.
- [x] **Version bump**: `3.31.0` → `3.32.0` en `pom.xml`.
- [x] **Documentación**: Actualización del diagrama de clases hexagonal en `docs/hexagonal-reservaVacante.mmd`.

## Verificación

- [ ] Compilación exitosa: `mvn clean compile`
- [ ] Tests unitarios: `mvn test`
- [ ] Pruebas de integración del flujo de pago MercadoPago con ReservaVacante
