### PR TITLE
fix(domicilio): Null-safety en campos email de JpaDomicilioRepositoryAdapter y DomicilioMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.32.2] - 2026-07-05
+### Fixed
+- fix(domicilio): Null-safety en campos email de `JpaDomicilioRepositoryAdapter` y `DomicilioMapper`
+  - `JpaDomicilioRepositoryAdapter.update()`: Asigna string vacío si `emailPersonal` o `emailInstitucional` es null al actualizar domicilio
+  - `DomicilioMapper.toEntity()`: Asigna string vacío si `emailPersonal` o `emailInstitucional` es null en el mapeo a entidad
+  - Previene `NullPointerException` en persistencia de domicilios cuando los campos email no están informados
+
+> Basado en análisis profundo de `git diff HEAD` (2 archivos modificados, +8/-8 líneas) y `pom.xml` (versión 3.32.1 → 3.32.2).
+
 ## [3.32.1] - 2026-07-05
 ### Fixed
 - fix(preuniversitario): Null-safety en creación de persona/domicilio y envío de chequera preuniversitaria

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.32.1**
+**Versión actual (SemVer): 3.32.2**
 
 ## Novedades 3.32.0 (verificado en código)
 - feat(mercadopagoContext): Integración de pago MercadoPago con ReservaVacante en `ProcessPaymentEventUseCaseImpl`
@@ -17,6 +17,14 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0
 - feat(docs): Diagrama hexagonal-reservaVacante.mmd actualizado con UpdateReservaVacanteUseCase
 
 > Basado en análisis profundo de `git diff HEAD` (8 archivos modificados, +68/-15 líneas) y `pom.xml` (versión 3.31.0 → 3.32.0).
+
+## Novedades 3.32.2 (verificado en código)
+- fix(domicilio): Null-safety en campos email de `JpaDomicilioRepositoryAdapter` y `DomicilioMapper`
+  - `JpaDomicilioRepositoryAdapter.update()`: Asigna string vacío si `emailPersonal` o `emailInstitucional` es null al actualizar domicilio en BD
+  - `DomicilioMapper.toEntity()`: Asigna string vacío si `emailPersonal` o `emailInstitucional` es null en el mapeo dominio → entidad
+  - Previene `NullPointerException` en persistencia de domicilios cuando los campos email no están informados
+
+> Basado en análisis profundo de `git diff HEAD` (2 archivos modificados, +8/-8 líneas) y `pom.xml` (versión 3.32.1 → 3.32.2).
 
 ## Novedades 3.32.1 (verificado en código)
 - fix(preuniversitario): Null-safety en creación de persona/domicilio y envío de chequera preuniversitaria

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.32.1** (actualizada: 2026-07-05)
+**Versión actual del servicio: 3.32.2** (actualizada: 2026-07-05)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/docs/hexagonal-articulo.mmd
+++ b/docs/hexagonal-articulo.mmd
@@ -260,8 +260,6 @@ classDiagram
                 +toResponse(Articulo) ArticuloResponse
                 +toSearchResponse(ArticuloSearch) ArticuloSearchResponse
             }
-
-            ArticuloController --> CuentaService : calls
         }
     }
 
@@ -302,6 +300,7 @@ classDiagram
 
     ArticuloController --> ArticuloService : calls
     ArticuloController --> ArticuloDtoMapper : uses
+    ArticuloController --> CuentaService : calls
     ArticuloDtoMapper --> Articulo : maps
     ArticuloDtoMapper --> ArticuloResponse : maps
     ArticuloDtoMapper --> ArticuloSearchResponse : maps

--- a/docs/hexagonal-chequeraCuota.mmd
+++ b/docs/hexagonal-chequeraCuota.mmd
@@ -84,9 +84,6 @@ classDiagram
         class UpdateChequeraCuotaUseCase { <<interface>> }
     }
 
-    domain_namespace_uses "domain" : Producto
-    domain_namespace_uses "domain" : ChequeraSerie
-
     namespace application {
         class ChequeraCuotaService {
             -20+ use cases inyectados

--- a/docs/hexagonal-chequeraSerie.mmd
+++ b/docs/hexagonal-chequeraSerie.mmd
@@ -142,21 +142,21 @@ classDiagram
         }
     }
 
-    ChequeraSerieService --> CreateChequeraSerieUseCaseImpl : uses
-    ChequeraSerieService --> DeleteChequeraSerieUseCaseImpl : uses
-    ChequeraSerieService --> GetChequeraSerieAltasUseCaseImpl : uses
-    ChequeraSerieService --> GetChequeraSerieByCbuOrVisaUseCaseImpl : uses
-    ChequeraSerieService --> GetChequeraSerieByFacultadUseCaseImpl : uses
-    ChequeraSerieService --> GetChequeraSerieByIdUseCaseImpl : uses
-    ChequeraSerieService --> GetChequeraSerieByNumberUseCaseImpl : uses
-    ChequeraSerieService --> GetChequeraSerieByPersonaUseCaseImpl : uses
-    ChequeraSerieService --> GetChequeraSerieByUniqueUseCaseImpl : uses
-    ChequeraSerieService --> GetChequeraSerieIncompletasUseCaseImpl : uses
-    ChequeraSerieService --> GetChequeraSerieSpecialQueriesUseCaseImpl : uses
-    ChequeraSerieService --> GetResumenLectivoUseCaseImpl : uses
-    ChequeraSerieService --> MarkSentUseCaseImpl : uses
-    ChequeraSerieService --> SetPayPerTicUseCaseImpl : uses
-    ChequeraSerieService --> UpdateChequeraSerieUseCaseImpl : uses
+    ChequeraSerieService --> CreateChequeraSerieUseCase : uses
+    ChequeraSerieService --> DeleteChequeraSerieUseCase : uses
+    ChequeraSerieService --> GetChequeraSerieAltasUseCase : uses
+    ChequeraSerieService --> GetChequeraSerieByCbuOrVisaUseCase : uses
+    ChequeraSerieService --> GetChequeraSerieByFacultadUseCase : uses
+    ChequeraSerieService --> GetChequeraSerieByIdUseCase : uses
+    ChequeraSerieService --> GetChequeraSerieByNumberUseCase : uses
+    ChequeraSerieService --> GetChequeraSerieByPersonaUseCase : uses
+    ChequeraSerieService --> GetChequeraSerieByUniqueUseCase : uses
+    ChequeraSerieService --> GetChequeraSerieIncompletasUseCase : uses
+    ChequeraSerieService --> GetChequeraSerieSpecialQueriesUseCase : uses
+    ChequeraSerieService --> GetResumenLectivoUseCase : uses
+    ChequeraSerieService --> MarkSentUseCase : uses
+    ChequeraSerieService --> SetPayPerTicUseCase : uses
+    ChequeraSerieService --> UpdateChequeraSerieUseCase : uses
 
     CreateChequeraSerieUseCaseImpl ..|> CreateChequeraSerieUseCase
     DeleteChequeraSerieUseCaseImpl ..|> DeleteChequeraSerieUseCase

--- a/docs/hexagonal-chequeraTipoChequera.mmd
+++ b/docs/hexagonal-chequeraTipoChequera.mmd
@@ -156,17 +156,17 @@ classDiagram
         }
     }
 
-    TipoChequeraService --> GetAllTipoChequeraUseCaseImpl : uses
-    TipoChequeraService --> GetAllTipoChequeraAsignableUseCaseImpl : uses
-    TipoChequeraService --> GetAllTipoChequeraByFacultadAndGeograficaUseCaseImpl : uses
-    TipoChequeraService --> GetAllTipoChequeraByClaseChequeraUseCaseImpl : uses
-    TipoChequeraService --> GetTipoChequeraByIdUseCaseImpl : uses
-    TipoChequeraService --> GetLastTipoChequeraUseCaseImpl : uses
-    TipoChequeraService --> CreateTipoChequeraUseCaseImpl : uses
-    TipoChequeraService --> UpdateTipoChequeraUseCaseImpl : uses
-    TipoChequeraService --> DeleteTipoChequeraUseCaseImpl : uses
-    TipoChequeraService --> MarkTipoChequeraUseCaseImpl : uses
-    TipoChequeraService --> UnmarkTipoChequeraUseCaseImpl : uses
+    TipoChequeraService --> GetAllTipoChequeraUseCase : uses
+    TipoChequeraService --> GetAllTipoChequeraAsignableUseCase : uses
+    TipoChequeraService --> GetAllTipoChequeraByFacultadAndGeograficaUseCase : uses
+    TipoChequeraService --> GetAllTipoChequeraByClaseChequeraUseCase : uses
+    TipoChequeraService --> GetTipoChequeraByIdUseCase : uses
+    TipoChequeraService --> GetLastTipoChequeraUseCase : uses
+    TipoChequeraService --> CreateTipoChequeraUseCase : uses
+    TipoChequeraService --> UpdateTipoChequeraUseCase : uses
+    TipoChequeraService --> DeleteTipoChequeraUseCase : uses
+    TipoChequeraService --> MarkTipoChequeraUseCase : uses
+    TipoChequeraService --> UnmarkTipoChequeraUseCase : uses
 
     GetAllTipoChequeraUseCaseImpl ..|> GetAllTipoChequeraUseCase : implements
     GetAllTipoChequeraAsignableUseCaseImpl ..|> GetAllTipoChequeraAsignableUseCase : implements

--- a/docs/hexagonal-domicilio.mmd
+++ b/docs/hexagonal-domicilio.mmd
@@ -33,10 +33,10 @@ classDiagram
             <<interface>>
             +create(Domicilio) Domicilio
             +findById(Long) Optional~Domicilio~
-            +findByUnique(Integer, Integer) Optional~Domicilio~
-            +findFirstByPersonaId(Integer) Optional~Domicilio~
+            +findByUnique(BigDecimal, Integer) Optional~Domicilio~
+            +findFirstByPersonaId(BigDecimal) Optional~Domicilio~
             +update(Long, Domicilio) Optional~Domicilio~
-            +deleteById(Long) void
+            +deleteById(Long) boolean
         }
     }
 
@@ -92,12 +92,24 @@ classDiagram
         namespace persistence {
             class DomicilioEntity {
                 +Long domicilioId
-                +Integer personaId
+                +BigDecimal personaId
                 +Integer documentoId
                 +OffsetDateTime fecha
                 +String calle
+                +String puerta
+                +String piso
+                +String dpto
+                +String telefono
+                +String movil
+                +String observaciones
+                +String codigoPostal
+                +Integer facultadId
+                +Integer provinciaId
+                +Integer localidadId
                 +String emailPersonal
                 +String emailInstitucional
+                +String laboral
+                +String emailPagador
             }
 
             class JpaDomicilioRepository {
@@ -112,15 +124,15 @@ classDiagram
                 -DomicilioMapper mapper
                 +create(Domicilio) Domicilio
                 +findById(Long) Optional~Domicilio~
-                +findByUnique(Integer, Integer) Optional~Domicilio~
-                +findFirstByPersonaId(Integer) Optional~Domicilio~
-                +update(Long, Domicilio) Optional~Domicilio~
-                +deleteById(Long) void
+            +findByUnique(BigDecimal, Integer) Optional~Domicilio~
+            +findFirstByPersonaId(BigDecimal) Optional~Domicilio~
+            +update(Long, Domicilio) Optional~Domicilio~
+            +deleteById(Long) boolean
             }
 
             class DomicilioMapper {
                 +toEntity(Domicilio) DomicilioEntity
-                +toDomain(DomicilioEntity) Domicilio
+                +toDomainModel(DomicilioEntity) Domicilio
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.32.1</version>
+    <version>3.32.2</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/persistence/adapter/JpaDomicilioRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/persistence/adapter/JpaDomicilioRepositoryAdapter.java
@@ -61,8 +61,8 @@ public class JpaDomicilioRepositoryAdapter implements DomicilioRepository {
             entity.setFacultadId(domicilio.getFacultadId());
             entity.setProvinciaId(domicilio.getProvinciaId());
             entity.setLocalidadId(domicilio.getLocalidadId());
-            entity.setEmailPersonal(domicilio.getEmailPersonal());
-            entity.setEmailInstitucional(domicilio.getEmailInstitucional());
+            entity.setEmailPersonal(domicilio.getEmailPersonal() != null ? domicilio.getEmailPersonal() : "");
+            entity.setEmailInstitucional(domicilio.getEmailInstitucional() != null ? domicilio.getEmailInstitucional() : "");
             entity.setLaboral(domicilio.getLaboral());
             DomicilioEntity updated = jpaDomicilioRepository.save(entity);
             return domicilioMapper.toDomainModel(updated);

--- a/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/persistence/mapper/DomicilioMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/persistence/mapper/DomicilioMapper.java
@@ -50,8 +50,8 @@ public class DomicilioMapper {
                 .facultadId(domain.getFacultadId())
                 .provinciaId(domain.getProvinciaId())
                 .localidadId(domain.getLocalidadId())
-                .emailPersonal(domain.getEmailPersonal())
-                .emailInstitucional(domain.getEmailInstitucional())
+                .emailPersonal(domain.getEmailPersonal() != null ? domain.getEmailPersonal() : "")
+                .emailInstitucional(domain.getEmailInstitucional() != null ? domain.getEmailInstitucional() : "")
                 .laboral(domain.getLaboral())
                 .build();
     }


### PR DESCRIPTION
Closes #275

## Descripción
Se implementa null-safety en los campos de email (`emailPersonal` y `emailInstitucional`) en la capa de persistencia de domicilios para prevenir `NullPointerException` cuando estos campos no están informados.

## Cambios Realizados
- **JpaDomicilioRepositoryAdapter.update()**: guarda null → string vacío para `emailPersonal` y `emailInstitucional`
- **DomicilioMapper.toEntity()**: guarda null → string vacío para `emailPersonal` y `emailInstitucional`
- **pom.xml**: bump 3.32.1 → 3.32.2
- Actualización de CHANGELOG.md, README.md, docs/README.md y diagramas `.mmd`

## Commits
- `f3a529a` fix(domicilio): add null-safety for email fields in persistence
- `cf4be44` docs(diagrams): correct service-to-useCase relationships and entity signatures
