### PR TITLE
docs(mermaid): corregir sintaxis de genéricos en diagramas de arquitectura hexagonal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.33.1] - 2026-07-06
+### Fixed
+- fix(docs): Corregida sintaxis de genéricos en 20 diagramas Mermaid de arquitectura hexagonal y secuencia
+  - Cambio de `~` (tilde) a `<>` (angle brackets) para tipos genéricos: `List~Documento~` → `List<Documento>`, `Optional~Facultad~` → `Optional<Facultad>`, `ResponseEntity~List~Foo~~` → `ResponseEntity<List<Foo>>`
+  - Afecta a todos los diagramas `hexagonal-*.mmd` y `sequence-consulta-articulos.mmd`
+  - Sincroniza la sintaxis con la especificación estándar Mermaid (v10+), mejorando la compatibilidad con parsers y herramientas de renderizado
+
+> Basado en `git diff HEAD` (20 archivos modificados, +431/-431 líneas, corrección únicamente sintáctica en diagramas de documentación). Sin cambios en código de aplicación.
+
 ## [3.33.0] - 2026-07-06
 ### Added
 - feat(documento): Nuevo módulo Documento con arquitectura hexagonal completa

--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.33.0**
+**Versión actual (SemVer): 3.33.1**
+
+## Novedades 3.33.1 (verificado en código)
+- fix(docs): Corregida sintaxis de genéricos Mermaid en 20 diagramas
+  - Cambio de `~` (tilde) a `<>` (angle brackets) en todos los diagramas `hexagonal-*.mmd` y `sequence-consulta-articulos.mmd`
+  - Sincroniza con sintaxis estándar Mermaid v10+, mejorando compatibilidad con parsers
+
+> Basado en `git diff HEAD` (20 archivos modificados, +431/-431 líneas, cambios puramente sintácticos en documentación).
 
 ## Novedades 3.33.0 (verificado en código)
 - feat(documento): Nuevo módulo Documento con arquitectura hexagonal completa
@@ -1031,21 +1038,30 @@ src/
 │   ├── java/
 │   │   └── um/tesoreria/core/
 │   │       ├── hexagonal/
-│   │       │   ├── arancelPorcentaje/        # Módulo ArancelPorcentaje (v3.29.0)
-│   │       │   ├── arancelTipo/              # Módulo ArancelTipo (v3.29.0)
+│   │       │   ├── articulo/                 # Módulo Artículo (v3.13.0)
 │   │       │   ├── asiento/                  # Módulo Asiento (v3.29.0)
 │   │       │   ├── auth/                     # Módulo Auth (v3.6.0)
 │   │       │   ├── baja/                     # Módulo Baja (v3.21.0)
-│   │       │   ├── chequeraCuota/            # Módulo ChequeraCuota (v3.2.0)
-│   │       │   ├── chequeraSerie/            # Módulo ChequeraSerie (v3.21.0)
+│   │       │   ├── chequera/                 # Módulos agrupados de chequera (v3.30.0)
+│   │       │   │   ├── arancelPorcentaje/    # Módulo ArancelPorcentaje (v3.29.0)
+│   │       │   │   ├── arancelTipo/          # Módulo ArancelTipo (v3.29.0)
+│   │       │   │   ├── chequeraCuota/        # Módulo ChequeraCuota (v3.2.0)
+│   │       │   │   ├── chequeraSerie/        # Módulo ChequeraSerie (v3.21.0)
+│   │       │   │   ├── claseChequera/        # Módulo ClaseChequera (v3.30.0)
+│   │       │   │   ├── producto/             # Módulo Producto (v3.30.0)
+│   │       │   │   └── tipoChequera/         # Módulo TipoChequera (v3.30.0)
+│   │       │   ├── contable/                 # Módulos contables (v3.30.0)
+│   │       │   │   └── cuenta/               # Módulo Cuenta (v3.8.0)
 │   │       │   ├── contrato/                 # Módulo Contrato (v3.19.0)
-│   │       │   ├── cuenta/                   # Módulo Cuenta (v3.8.0)
 │   │       │   ├── dependencia/              # Módulo Dependencia (v3.17.0)
+│   │       │   ├── documento/                # Módulo Documento (v3.33.0)
 │   │       │   ├── domicilio/                # Módulo Domicilio (v3.24.0)
 │   │       │   ├── facultad/                 # Módulo Facultad (v3.18.0)
 │   │       │   ├── facturaPendiente/         # Módulo FacturaPendiente (v3.15.0)
 │   │       │   ├── geografica/               # Módulo Geografica (v3.6.0)
 │   │       │   ├── guarani/alumnoGuarani/    # Módulo AlumnoGuarani (v3.29.0)
+│   │       │   ├── lectivo/                  # Módulo Lectivo (v3.30.0)
+│   │       │   ├── lectivoTotalImputacion/   # Módulo LectivoTotalImputacion (v3.31.0)
 │   │       │   ├── mercadoPagoContext/       # Módulo MercadoPagoContext (v3.24.0)
 │   │       │   ├── persona/                  # Módulo Persona (v3.24.0)
 │   │       │   ├── proveedor/                # Módulo Proveedor (v3.9.0)
@@ -1090,14 +1106,12 @@ Daniel Quinteros - daniel.quinterospinto@gmail.com
 
 Link del proyecto: [https://github.com/UM-services/um.tesoreria.core-service](https://github.com/UM-services/um.tesoreria.core-service)
 
-# UM Tesorería Core Service
-
 [![Java](https://img.shields.io/badge/Java-25-blue.svg)](https://www.java.com/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.2-brightgreen.svg)](https://spring.io/projects/spring-cloud)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-purple.svg)](https://kotlinlang.org/)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8+-orange.svg)](https://maven.apache.org/)
-[![Versión](https://img.shields.io/badge/versión-3.29.0-blue.svg)]()
+[![Versión](https://img.shields.io/badge/versión-3.33.1-blue.svg)]()
 
 ## Documentación
 - [Documentación en GitHub Pages](https://um-services.github.io/UM.tesoreria.core-service/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.33.0** (actualizada: 2026-07-06)
+**Versión actual del servicio: 3.33.1** (actualizada: 2026-07-06)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/docs/hexagonal-alumnoGuarani.mmd
+++ b/docs/hexagonal-alumnoGuarani.mmd
@@ -34,7 +34,7 @@ classDiagram
             +String fechaNacimiento
             +String nacionalidad
             +DocumentoPrincipalGuarani documentoPrincipal
-            +List~ContactoGuarani~ contactos
+            +List<ContactoGuarani> contactos
         }
 
         class DocumentoPrincipalGuarani {
@@ -95,7 +95,7 @@ classDiagram
 
         class CheckAllPreuniversitarioWithoutChequeraUseCase {
             <<interface>>
-            +desmarcarEnviados(List~AlumnoDeteccionRequest~) List~AlumnoDeteccionRequest~
+            +desmarcarEnviados(List<AlumnoDeteccionRequest>) List<AlumnoDeteccionRequest>
         }
     }
 
@@ -104,7 +104,7 @@ classDiagram
             -CreatePreuniversitarioUseCase createPreuniversitarioUseCase
             -CheckAllPreuniversitarioWithoutChequeraUseCase checkAllPreuniversitarioWithoutChequeraUseCase
             +createPreuniversitario(AlumnoGuarani) AlumnoGuarani
-            +desmarcarEnviados(List~AlumnoDeteccionRequest~) List~AlumnoDeteccionRequest~
+            +desmarcarEnviados(List<AlumnoDeteccionRequest>) List<AlumnoDeteccionRequest>
         }
 
         namespace usecases {
@@ -117,7 +117,7 @@ classDiagram
             class CheckAllPreuniversitarioWithoutChequeraUseCaseImpl {
                 -ChequeraSerieService chequeraSerieService
                 -LectivoService lectivoService
-                +desmarcarEnviados(List~AlumnoDeteccionRequest~) List~AlumnoDeteccionRequest~
+                +desmarcarEnviados(List<AlumnoDeteccionRequest>) List<AlumnoDeteccionRequest>
             }
         }
 
@@ -131,7 +131,7 @@ classDiagram
             class AlumnoGuaraniController {
                 -AlumnoGuaraniService alumnoGuaraniService
                 +createPreuniversitario(AlumnoGuaraniRequest) AlumnoGuarani
-                +desmarcarEnviadas(List~AlumnoDeteccionRequest~) List~AlumnoDeteccionRequest~
+                +desmarcarEnviadas(List<AlumnoDeteccionRequest>) List<AlumnoDeteccionRequest>
             }
 
             namespace dto {

--- a/docs/hexagonal-articulo.mmd
+++ b/docs/hexagonal-articulo.mmd
@@ -41,11 +41,11 @@ classDiagram
         class ArticuloRepository {
             <<interface>>
             +create(Articulo) Articulo
-            +findById(Long) Optional~Articulo~
-            +findAll() List~Articulo~
-            +update(Long, Articulo) Optional~Articulo~
+            +findById(Long) Optional<Articulo>
+            +findAll() List<Articulo>
+            +update(Long, Articulo) Optional<Articulo>
             +deleteById(Long) boolean
-            +findLast() Optional~Articulo~
+            +findLast() Optional<Articulo>
         }
     }
 
@@ -60,13 +60,13 @@ classDiagram
             -GetPaginatedArticulosUseCase getPaginatedArticulosUseCase
             -SearchArticulosUseCase searchArticulosUseCase
             +createArticulo(Articulo) Articulo
-            +getArticuloById(Long) Optional~Articulo~
-            +getAllArticulos() List~Articulo~
-            +updateArticulo(Long, Articulo) Optional~Articulo~
+            +getArticuloById(Long) Optional<Articulo>
+            +getAllArticulos() List<Articulo>
+            +updateArticulo(Long, Articulo) Optional<Articulo>
             +deleteArticulo(Long) boolean
             +getNewArticulo() Articulo
-            +getPaginated(int, int) PaginatedResponse~Articulo~
-            +searchArticulos(String) List~ArticuloSearch~
+            +getPaginated(int, int) PaginatedResponse<Articulo>
+            +searchArticulos(String) List<ArticuloSearch>
         }
 
         namespace usecases {
@@ -77,17 +77,17 @@ classDiagram
 
             class GetArticuloByIdUseCaseImpl {
                 -ArticuloRepository repository
-                +getArticuloById(Long) Optional~Articulo~
+                +getArticuloById(Long) Optional<Articulo>
             }
 
             class GetAllArticulosUseCaseImpl {
                 -ArticuloRepository repository
-                +getAllArticulos() List~Articulo~
+                +getAllArticulos() List<Articulo>
             }
 
             class UpdateArticuloUseCaseImpl {
                 -ArticuloRepository repository
-                +updateArticulo(Long, Articulo) Optional~Articulo~
+                +updateArticulo(Long, Articulo) Optional<Articulo>
             }
 
             class DeleteArticuloUseCaseImpl {
@@ -102,12 +102,12 @@ classDiagram
 
         class GetPaginatedArticulosUseCaseImpl {
             -ArticuloRepository repository
-            +getPaginated(int, int) PaginatedResponse~Articulo~
+            +getPaginated(int, int) PaginatedResponse<Articulo>
         }
 
         class SearchArticulosUseCaseImpl {
             -ArticuloRepository repository
-            +searchArticulos(String) List~ArticuloSearch~
+            +searchArticulos(String) List<ArticuloSearch>
         }
         }
 
@@ -118,17 +118,17 @@ classDiagram
 
         class GetArticuloByIdUseCase {
             <<interface>>
-            +getArticuloById(Long) Optional~Articulo~
+            +getArticuloById(Long) Optional<Articulo>
         }
 
         class GetAllArticulosUseCase {
             <<interface>>
-            +getAllArticulos() List~Articulo~
+            +getAllArticulos() List<Articulo>
         }
 
         class UpdateArticuloUseCase {
             <<interface>>
-            +updateArticulo(Long, Articulo) Optional~Articulo~
+            +updateArticulo(Long, Articulo) Optional<Articulo>
         }
 
         class DeleteArticuloUseCase {
@@ -143,12 +143,12 @@ classDiagram
 
         class GetPaginatedArticulosUseCase {
             <<interface>>
-            +getPaginated(int, int) PaginatedResponse~Articulo~
+            +getPaginated(int, int) PaginatedResponse<Articulo>
         }
 
         class SearchArticulosUseCase {
             <<interface>>
-            +searchArticulos(String) List~ArticuloSearch~
+            +searchArticulos(String) List<ArticuloSearch>
         }
     }
 
@@ -171,18 +171,18 @@ classDiagram
 
             class JpaArticuloRepository {
                 <<JpaRepository>>
-                +findTopByOrderByArticuloIdDesc() Optional~ArticuloEntity~
+                +findTopByOrderByArticuloIdDesc() Optional<ArticuloEntity>
             }
 
             class JpaArticuloRepositoryAdapter {
                 -JpaArticuloRepository jpaArticuloRepository
                 -ArticuloMapper articuloMapper
                 +create(Articulo) Articulo
-                +findById(Long) Optional~Articulo~
-                +findAll() List~Articulo~
-                +update(Long, Articulo) Optional~Articulo~
+                +findById(Long) Optional<Articulo>
+                +findAll() List<Articulo>
+                +update(Long, Articulo) Optional<Articulo>
                 +deleteById(Long) boolean
-                +findLast() Optional~Articulo~
+                +findLast() Optional<Articulo>
             }
 
             class ArticuloMapper {
@@ -198,14 +198,14 @@ classDiagram
                 -ArticuloService articuloService
                 -ArticuloDtoMapper articuloDtoMapper
                 -CuentaService cuentaService
-                +createArticulo(ArticuloRequest) ResponseEntity~ArticuloResponse~
-                +getArticuloById(Long) ResponseEntity~ArticuloResponse~
-                +getAllArticulos() ResponseEntity~List~ArticuloResponse~~
-                +updateArticulo(Long, ArticuloRequest) ResponseEntity~ArticuloResponse~
-                +deleteArticulo(Long) ResponseEntity~Void~
-                +getNewArticulo() ResponseEntity~ArticuloResponse~
-                +getPaginatedArticulos(int, int) ResponseEntity~PaginatedResponse~ArticuloResponse~~
-                +searchArticulos(List~String~) ResponseEntity~List~ArticuloSearchResponse~~
+                +createArticulo(ArticuloRequest) ResponseEntity<ArticuloResponse>
+                +getArticuloById(Long) ResponseEntity<ArticuloResponse>
+                +getAllArticulos() ResponseEntity<List<ArticuloResponse>>
+                +updateArticulo(Long, ArticuloRequest) ResponseEntity<ArticuloResponse>
+                +deleteArticulo(Long) ResponseEntity<Void>
+                +getNewArticulo() ResponseEntity<ArticuloResponse>
+                +getPaginatedArticulos(int, int) ResponseEntity<PaginatedResponse<ArticuloResponse>>
+                +searchArticulos(List<String>) ResponseEntity<List<ArticuloSearchResponse>>
             }
 
             class ArticuloRequest {

--- a/docs/hexagonal-campanha.mmd
+++ b/docs/hexagonal-campanha.mmd
@@ -17,9 +17,9 @@ classDiagram
         class CampanhaRepository {
             <<interface>>
             +create(Campanha) Campanha
-            +findById(UUID) Optional~Campanha~
-            +findAll() List~Campanha~
-            +update(UUID, Campanha) Optional~Campanha~
+            +findById(UUID) Optional<Campanha>
+            +findAll() List<Campanha>
+            +update(UUID, Campanha) Optional<Campanha>
             +deleteByCampanhaId(UUID) boolean
         }
     }
@@ -32,9 +32,9 @@ classDiagram
             -UpdateCampanhaUseCase updateCampanhaUseCase
             -DeleteCampanhaUseCase deleteCampanhaUseCase
             +createCampanha(Campanha) Campanha
-            +getCampanhaById(UUID) Optional~Campanha~
-            +getAllCampanhas() List~Campanha~
-            +updateCampanha(UUID, Campanha) Optional~Campanha~
+            +getCampanhaById(UUID) Optional<Campanha>
+            +getAllCampanhas() List<Campanha>
+            +updateCampanha(UUID, Campanha) Optional<Campanha>
             +deleteCampanha(UUID) boolean
         }
 
@@ -45,15 +45,15 @@ classDiagram
             }
             class GetCampanhaByIdUseCaseImpl {
                 -CampanhaRepository repository
-                +getCampanhaById(UUID) Optional~Campanha~
+                +getCampanhaById(UUID) Optional<Campanha>
             }
             class GetAllCampanhasUseCaseImpl {
                 -CampanhaRepository repository
-                +getAllCampanhas() List~Campanha~
+                +getAllCampanhas() List<Campanha>
             }
             class UpdateCampanhaUseCaseImpl {
                 -CampanhaRepository repository
-                +updateCampanha(UUID, Campanha) Optional~Campanha~
+                +updateCampanha(UUID, Campanha) Optional<Campanha>
             }
             class DeleteCampanhaUseCaseImpl {
                 -CampanhaRepository repository
@@ -67,15 +67,15 @@ classDiagram
         }
         class GetCampanhaByIdUseCase {
             <<interface>>
-            +getCampanhaById(UUID) Optional~Campanha~
+            +getCampanhaById(UUID) Optional<Campanha>
         }
         class GetAllCampanhasUseCase {
             <<interface>>
-            +getAllCampanhas() List~Campanha~
+            +getAllCampanhas() List<Campanha>
         }
         class UpdateCampanhaUseCase {
             <<interface>>
-            +updateCampanha(UUID, Campanha) Optional~Campanha~
+            +updateCampanha(UUID, Campanha) Optional<Campanha>
         }
         class DeleteCampanhaUseCase {
             <<interface>>
@@ -95,7 +95,7 @@ classDiagram
 
             class JpaCampanhaRepository {
                 <<JpaRepository>>
-                +findByCampanhaId(UUID) Optional~CampanhaEntity~
+                +findByCampanhaId(UUID) Optional<CampanhaEntity>
                 +existsByCampanhaId(UUID) boolean
                 +deleteByCampanhaId(UUID) void
             }
@@ -104,9 +104,9 @@ classDiagram
                 -JpaCampanhaRepository repository
                 -CampanhaMapper mapper
                 +create(Campanha) Campanha
-                +findById(UUID) Optional~Campanha~
-                +findAll() List~Campanha~
-                +update(UUID, Campanha) Optional~Campanha~
+                +findById(UUID) Optional<Campanha>
+                +findAll() List<Campanha>
+                +update(UUID, Campanha) Optional<Campanha>
                 +deleteByCampanhaId(UUID) boolean
             }
 
@@ -120,11 +120,11 @@ classDiagram
             class CampanhaController {
                 -CampanhaService campanhaService
                 -CampanhaDtoMapper campanhaDtoMapper
-                +findByCampanhaId(UUID) ResponseEntity~CampanhaResponse~
-                +add(CampanhaRequest) ResponseEntity~CampanhaResponse~
-                +getAll() ResponseEntity~List~CampanhaResponse~~
-                +update(UUID, CampanhaRequest) ResponseEntity~CampanhaResponse~
-                +delete(UUID) ResponseEntity~Void~
+                +findByCampanhaId(UUID) ResponseEntity<CampanhaResponse>
+                +add(CampanhaRequest) ResponseEntity<CampanhaResponse>
+                +getAll() ResponseEntity<List<CampanhaResponse>>
+                +update(UUID, CampanhaRequest) ResponseEntity<CampanhaResponse>
+                +delete(UUID) ResponseEntity<Void>
             }
 
             class CampanhaRequest {

--- a/docs/hexagonal-chequeraCuota.mmd
+++ b/docs/hexagonal-chequeraCuota.mmd
@@ -41,20 +41,20 @@ classDiagram
 
         class ChequeraCuotaRepository {
             <<interface>>
-            +findAllByChequera(Integer, Integer, Long) List~ChequeraCuota~
-            +findAllByChequeraIds(Integer, Integer, Long, Integer, Integer) List~ChequeraCuota~
-            +findAllByAlternativa(Integer, Integer, Long, Integer, Integer) List~ChequeraCuota~
-            +findAllByAlternativaConImporte(Integer, Integer, Long, Integer, Integer) List~ChequeraCuota~
-            +findAllDebidas(Integer, Integer, Long) List~ChequeraCuota~
-            +findAllInconsistencias() List~ChequeraCuota~
-            +findAllPendientes(Integer, Integer, Long) List~ChequeraCuota~
-            +findAllPendientesBaja(Integer) List~ChequeraCuota~
-            +findAllPeriodosLectivo(Integer, Integer, Long) List~Integer~
-            +findAllByFacultadTipoChequeraSerieIds(List~Integer~, Integer, Long) List~ChequeraCuota~
-            +findById(Long) Optional~ChequeraCuota~
-            +findByUnique(Integer, Integer, Long, Integer, Integer, Integer) Optional~ChequeraCuota~
-            +findOneActivaImpagaPrevia(Integer, Integer, Long, Integer, Integer, Integer) Optional~ChequeraCuota~
-            +saveAll(List~ChequeraCuota~) List~ChequeraCuota~
+            +findAllByChequera(Integer, Integer, Long) List<ChequeraCuota>
+            +findAllByChequeraIds(Integer, Integer, Long, Integer, Integer) List<ChequeraCuota>
+            +findAllByAlternativa(Integer, Integer, Long, Integer, Integer) List<ChequeraCuota>
+            +findAllByAlternativaConImporte(Integer, Integer, Long, Integer, Integer) List<ChequeraCuota>
+            +findAllDebidas(Integer, Integer, Long) List<ChequeraCuota>
+            +findAllInconsistencias() List<ChequeraCuota>
+            +findAllPendientes(Integer, Integer, Long) List<ChequeraCuota>
+            +findAllPendientesBaja(Integer) List<ChequeraCuota>
+            +findAllPeriodosLectivo(Integer, Integer, Long) List<Integer>
+            +findAllByFacultadTipoChequeraSerieIds(List<Integer>, Integer, Long) List<ChequeraCuota>
+            +findById(Long) Optional<ChequeraCuota>
+            +findByUnique(Integer, Integer, Long, Integer, Integer, Integer) Optional<ChequeraCuota>
+            +findOneActivaImpagaPrevia(Integer, Integer, Long, Integer, Integer, Integer) Optional<ChequeraCuota>
+            +saveAll(List<ChequeraCuota>) List<ChequeraCuota>
             +update(ChequeraCuota) ChequeraCuota
             +updateBarras(Integer, Integer, Long, Integer, Integer, String, String) void
             +deleteAllByChequera(Integer, Integer, Long) void
@@ -87,19 +87,19 @@ classDiagram
     namespace application {
         class ChequeraCuotaService {
             -20+ use cases inyectados
-            +findAllByChequera() List~ChequeraCuota~
-            +findAllByChequeraIds() List~ChequeraCuota~
-            +findAllByAlternativa() List~ChequeraCuota~
-            +findAllByAlternativaConImporte() List~ChequeraCuota~
-            +findAllDebidas() List~ChequeraCuota~
-            +findAllInconsistencias() List~ChequeraCuota~
-            +findAllPendientes() List~ChequeraCuota~
-            +findAllPendientesBaja() List~ChequeraCuota~
-            +findAllPeriodosLectivo() List~Integer~
+            +findAllByChequera() List<ChequeraCuota>
+            +findAllByChequeraIds() List<ChequeraCuota>
+            +findAllByAlternativa() List<ChequeraCuota>
+            +findAllByAlternativaConImporte() List<ChequeraCuota>
+            +findAllDebidas() List<ChequeraCuota>
+            +findAllInconsistencias() List<ChequeraCuota>
+            +findAllPendientes() List<ChequeraCuota>
+            +findAllPendientesBaja() List<ChequeraCuota>
+            +findAllPeriodosLectivo() List<Integer>
             +findById(Long) ChequeraCuota
             +findByUnique(...) ChequeraCuota
             +findOneActivaImpagaPrevia(...) ChequeraCuota
-            +saveAll(List~ChequeraCuota~) List~ChequeraCuota~
+            +saveAll(List<ChequeraCuota>) List<ChequeraCuota>
             +update(ChequeraCuota) ChequeraCuota
             +updateBarras(...) void
             +deleteAllByChequera(...) void
@@ -160,8 +160,8 @@ classDiagram
 
             class JpaChequeraCuotaRepository {
                 <<JpaRepository>>
-                +findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieId(...) List~ChequeraCuotaEntity~
-                +findByChequeraCuotaId(Long) Optional~ChequeraCuotaEntity~
+                +findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieId(...) List<ChequeraCuotaEntity>
+                +findByChequeraCuotaId(Long) Optional<ChequeraCuotaEntity>
             }
 
             class JpaChequeraCuotaRepositoryAdapter

--- a/docs/hexagonal-chequeraProducto.mmd
+++ b/docs/hexagonal-chequeraProducto.mmd
@@ -14,18 +14,18 @@ classDiagram
 
         class ProductoRepository {
             <<interface>>
-            +findAll() List~Producto~
-            +findById(Integer) Optional~Producto~
+            +findAll() List<Producto>
+            +findById(Integer) Optional<Producto>
         }
 
         class GetAllProductosUseCase {
             <<interface>>
-            +getAllProductos() List~Producto~
+            +getAllProductos() List<Producto>
         }
 
         class GetProductoByIdUseCase {
             <<interface>>
-            +getProductoById(Integer) Optional~Producto~
+            +getProductoById(Integer) Optional<Producto>
         }
     }
 
@@ -33,9 +33,9 @@ classDiagram
         class ProductoService {
             -GetAllProductosUseCase getAllProductosUseCase
             -GetProductoByIdUseCase getProductoByIdUseCase
-            +findAll() List~Producto~
+            +findAll() List<Producto>
             +findByProductoId(Integer) Producto
-            +findAllByTipoChequera(Integer, Integer, Integer) List~ProductoTipoChequera~
+            +findAllByTipoChequera(Integer, Integer, Integer) List<ProductoTipoChequera>
         }
 
         namespace usecases {
@@ -56,14 +56,14 @@ classDiagram
 
             class JpaProductoRepository {
                 <<JpaRepository>>
-                +findByProductoId(Integer) Optional~ProductoEntity~
+                +findByProductoId(Integer) Optional<ProductoEntity>
             }
 
             class JpaProductoRepositoryAdapter {
                 -JpaProductoRepository repository
                 -ProductoMapper mapper
-                +findAll() List~Producto~
-                +findById(Integer) Optional~Producto~
+                +findAll() List<Producto>
+                +findById(Integer) Optional<Producto>
             }
 
             class ProductoMapper {
@@ -76,9 +76,9 @@ classDiagram
             class ProductoController {
                 -ProductoService service
                 -ProductoDtoMapper dtoMapper
-                +findAll() ResponseEntity~List~ProductoResponse~~
-                +findByProductoId(Integer) ResponseEntity~ProductoResponse~
-                +findAllByTipoChequera(Integer, Integer, Integer) ResponseEntity~List~ProductoTipoChequera~~
+                +findAll() ResponseEntity<List<ProductoResponse>>
+                +findByProductoId(Integer) ResponseEntity<ProductoResponse>
+                +findAllByTipoChequera(Integer, Integer, Integer) ResponseEntity<List<ProductoTipoChequera>>
             }
 
             class ProductoRequest {

--- a/docs/hexagonal-chequeraSerie.mmd
+++ b/docs/hexagonal-chequeraSerie.mmd
@@ -42,22 +42,22 @@ classDiagram
 
         class ChequeraSerieRepository {
             <<interface>>
-            +findAll() List~ChequeraSerie~
-            +findById(Long) Optional~ChequeraSerie~
-            +findAllByFacultad(Integer, Integer) List~ChequeraSerie~
-            +findAllByPersona(BigDecimal, Integer) List~ChequeraSerie~
-            +findAllByNumber(Long) List~ChequeraSerie~
-            +findByUnique(Integer, Integer, Long, String) Optional~ChequeraSerie~
-            +findByCbuOrVisa(Long) Optional~ChequeraSerie~
-            +findAltas(BigDecimal, Integer) List~ChequeraSerie~
-            +findIncompletas(BigDecimal, Integer) List~ChequeraSerie~
-            +findLast(BigDecimal, Integer) Optional~ChequeraSerie~
+            +findAll() List<ChequeraSerie>
+            +findById(Long) Optional<ChequeraSerie>
+            +findAllByFacultad(Integer, Integer) List<ChequeraSerie>
+            +findAllByPersona(BigDecimal, Integer) List<ChequeraSerie>
+            +findAllByNumber(Long) List<ChequeraSerie>
+            +findByUnique(Integer, Integer, Long, String) Optional<ChequeraSerie>
+            +findByCbuOrVisa(Long) Optional<ChequeraSerie>
+            +findAltas(BigDecimal, Integer) List<ChequeraSerie>
+            +findIncompletas(BigDecimal, Integer) List<ChequeraSerie>
+            +findLast(BigDecimal, Integer) Optional<ChequeraSerie>
             +save(ChequeraSerie) ChequeraSerie
             +deleteById(Long)
             +markSent(Long)
             +setPayPerTic(Long, Byte)
-            +getResumenLectivo(Integer, Integer, Integer) List~Object[]~
-            +getSpecialQueries() List~ChequeraSerieQueryResult~
+            +getResumenLectivo(Integer, Integer, Integer) List<Object[]>
+            +getSpecialQueries() List<ChequeraSerieQueryResult>
         }
     }
 

--- a/docs/hexagonal-chequeraTipoChequera.mmd
+++ b/docs/hexagonal-chequeraTipoChequera.mmd
@@ -23,13 +23,13 @@ classDiagram
 
         class TipoChequeraRepository {
             <<interface>>
-            +findAll() List~TipoChequera~
-            +findAllAsignable(Integer, Integer, Integer, Integer) List~TipoChequera~
-            +findAllByFacultadIdAndGeograficaId(Integer, Integer) List~TipoChequera~
-            +findAllByClaseChequeraId(Integer) List~TipoChequera~
-            +findAllByClaseChequeraIds(List~Integer~) List~TipoChequera~
-            +findById(Integer) Optional~TipoChequera~
-            +findLast() Optional~TipoChequera~
+            +findAll() List<TipoChequera>
+            +findAllAsignable(Integer, Integer, Integer, Integer) List<TipoChequera>
+            +findAllByFacultadIdAndGeograficaId(Integer, Integer) List<TipoChequera>
+            +findAllByClaseChequeraId(Integer) List<TipoChequera>
+            +findAllByClaseChequeraIds(List<Integer>) List<TipoChequera>
+            +findById(Integer) Optional<TipoChequera>
+            +findLast() Optional<TipoChequera>
             +create(TipoChequera) TipoChequera
             +update(TipoChequera) TipoChequera
             +deleteById(Integer)
@@ -40,11 +40,11 @@ classDiagram
 
     namespace application {
         class TipoChequeraService {
-            +findAll() List~TipoChequera~
-            +findAllAsignable(Integer, Integer, Integer, Integer) List~TipoChequera~
-            +findAllByFacultadIdAndGeograficaId(Integer, Integer) List~TipoChequera~
-            +findAllByClaseChequera(Integer) List~TipoChequera~
-            +findAllByClaseChequeraIds(List~Integer~) List~TipoChequera~
+            +findAll() List<TipoChequera>
+            +findAllAsignable(Integer, Integer, Integer, Integer) List<TipoChequera>
+            +findAllByFacultadIdAndGeograficaId(Integer, Integer) List<TipoChequera>
+            +findAllByClaseChequera(Integer) List<TipoChequera>
+            +findAllByClaseChequeraIds(List<Integer>) List<TipoChequera>
             +findByTipoChequeraId(Integer) TipoChequera
             +findLast() TipoChequera
             +add(TipoChequera) TipoChequera
@@ -52,7 +52,7 @@ classDiagram
             +delete(Integer)
             +unmark()
             +mark(Integer, Byte) TipoChequera
-            +findAllByStrings(List~String~) List~TipoChequeraSearch~
+            +findAllByStrings(List<String>) List<TipoChequeraSearch>
         }
 
         namespace usecases {
@@ -90,11 +90,11 @@ classDiagram
 
             class JpaTipoChequeraRepository {
                 <<JpaRepository>>
-                +findAllByTipoChequeraIdInAndGeograficaId(List~Integer~, Integer) List~TipoChequeraEntity~
-                +findAllByClaseChequeraId(Integer) List~TipoChequeraEntity~
-                +findAllByClaseChequeraIdIn(List~Integer~) List~TipoChequeraEntity~
-                +findTopByOrderByTipoChequeraIdDesc() Optional~TipoChequeraEntity~
-                +findByTipoChequeraId(Integer) Optional~TipoChequeraEntity~
+                +findAllByTipoChequeraIdInAndGeograficaId(List<Integer>, Integer) List<TipoChequeraEntity>
+                +findAllByClaseChequeraId(Integer) List<TipoChequeraEntity>
+                +findAllByClaseChequeraIdIn(List<Integer>) List<TipoChequeraEntity>
+                +findTopByOrderByTipoChequeraIdDesc() Optional<TipoChequeraEntity>
+                +findByTipoChequeraId(Integer) Optional<TipoChequeraEntity>
             }
 
             class JpaTipoChequeraRepositoryAdapter {
@@ -113,14 +113,14 @@ classDiagram
             class TipoChequeraController {
                 -TipoChequeraService service
                 -TipoChequeraDtoMapper dtoMapper
-                +findAll() ResponseEntity~List~TipoChequeraResponse~~
-                +findByTipoChequeraId(Integer) ResponseEntity~TipoChequeraResponse~
-                +add(TipoChequeraRequest) ResponseEntity~TipoChequeraResponse~
-                +update(TipoChequeraRequest, Integer) ResponseEntity~TipoChequeraResponse~
-                +delete(Integer) ResponseEntity~Void~
-                +findAllAsignable(Integer, Integer, Integer, Integer) ResponseEntity~List~TipoChequeraResponse~~
-                +mark(Integer, Byte) ResponseEntity~Void~
-                +unmark() ResponseEntity~Void~
+                +findAll() ResponseEntity<List<TipoChequeraResponse>>
+                +findByTipoChequeraId(Integer) ResponseEntity<TipoChequeraResponse>
+                +add(TipoChequeraRequest) ResponseEntity<TipoChequeraResponse>
+                +update(TipoChequeraRequest, Integer) ResponseEntity<TipoChequeraResponse>
+                +delete(Integer) ResponseEntity<Void>
+                +findAllAsignable(Integer, Integer, Integer, Integer) ResponseEntity<List<TipoChequeraResponse>>
+                +mark(Integer, Byte) ResponseEntity<Void>
+                +unmark() ResponseEntity<Void>
             }
 
             class TipoChequeraRequest {

--- a/docs/hexagonal-claseChequera.mmd
+++ b/docs/hexagonal-claseChequera.mmd
@@ -20,31 +20,31 @@ classDiagram
 
         class ClaseChequeraRepository {
             <<interface>>
-            +findAll() List~ClaseChequera~
-            +findByPreuniversitario(Byte) List~ClaseChequera~
-            +findByCurso(Byte) List~ClaseChequera~
-            +findByPosgrado(Byte) List~ClaseChequera~
-            +findByTitulo(Byte) List~ClaseChequera~
+            +findAll() List<ClaseChequera>
+            +findByPreuniversitario(Byte) List<ClaseChequera>
+            +findByCurso(Byte) List<ClaseChequera>
+            +findByPosgrado(Byte) List<ClaseChequera>
+            +findByTitulo(Byte) List<ClaseChequera>
         }
 
         class GetAllClaseChequeraUseCase {
             <<interface>>
-            +getAll() List~ClaseChequera~
+            +getAll() List<ClaseChequera>
         }
 
         class GetAllClaseChequeraByCursoUseCase {
             <<interface>>
-            +getAllByCurso() List~ClaseChequera~
+            +getAllByCurso() List<ClaseChequera>
         }
 
         class GetAllClaseChequeraByPosgradoUseCase {
             <<interface>>
-            +getAllByPosgrado() List~ClaseChequera~
+            +getAllByPosgrado() List<ClaseChequera>
         }
 
         class GetAllClaseChequeraByTituloUseCase {
             <<interface>>
-            +getAllByTitulo() List~ClaseChequera~
+            +getAllByTitulo() List<ClaseChequera>
         }
     }
 
@@ -54,10 +54,10 @@ classDiagram
             -GetAllClaseChequeraByCursoUseCase getAllClaseChequeraByCursoUseCase
             -GetAllClaseChequeraByPosgradoUseCase getAllClaseChequeraByPosgradoUseCase
             -GetAllClaseChequeraByTituloUseCase getAllClaseChequeraByTituloUseCase
-            +findAll() List~ClaseChequera~
-            +findAllByCurso() List~ClaseChequera~
-            +findAllByPosgrado() List~ClaseChequera~
-            +findAllByTitulo() List~ClaseChequera~
+            +findAll() List<ClaseChequera>
+            +findAllByCurso() List<ClaseChequera>
+            +findAllByPosgrado() List<ClaseChequera>
+            +findAllByTitulo() List<ClaseChequera>
         }
 
         namespace usecases {
@@ -85,21 +85,21 @@ classDiagram
 
             class JpaClaseChequeraRepository {
                 <<JpaRepository>>
-                +findAllByOrderByNombre() List~ClaseChequeraEntity~
-                +findByPreuniversitario(Byte) List~ClaseChequeraEntity~
-                +findByCurso(Byte) List~ClaseChequeraEntity~
-                +findByPosgrado(Byte) List~ClaseChequeraEntity~
-                +findByTitulo(Byte) List~ClaseChequeraEntity~
+                +findAllByOrderByNombre() List<ClaseChequeraEntity>
+                +findByPreuniversitario(Byte) List<ClaseChequeraEntity>
+                +findByCurso(Byte) List<ClaseChequeraEntity>
+                +findByPosgrado(Byte) List<ClaseChequeraEntity>
+                +findByTitulo(Byte) List<ClaseChequeraEntity>
             }
 
             class JpaClaseChequeraRepositoryAdapter {
                 -JpaClaseChequeraRepository repository
                 -ClaseChequeraMapper mapper
-                +findAll() List~ClaseChequera~
-                +findByPreuniversitario(Byte) List~ClaseChequera~
-                +findByCurso(Byte) List~ClaseChequera~
-                +findByPosgrado(Byte) List~ClaseChequera~
-                +findByTitulo(Byte) List~ClaseChequera~
+                +findAll() List<ClaseChequera>
+                +findByPreuniversitario(Byte) List<ClaseChequera>
+                +findByCurso(Byte) List<ClaseChequera>
+                +findByPosgrado(Byte) List<ClaseChequera>
+                +findByTitulo(Byte) List<ClaseChequera>
             }
 
             class ClaseChequeraMapper {
@@ -112,10 +112,10 @@ classDiagram
             class ClaseChequeraController {
                 -ClaseChequeraService service
                 -ClaseChequeraDtoMapper dtoMapper
-                +findAll() ResponseEntity~List~ClaseChequeraResponse~~
-                +findAllByCurso() ResponseEntity~List~ClaseChequeraResponse~~
-                +findAllByPosgrado() ResponseEntity~List~ClaseChequeraResponse~~
-                +findAllByTitulo() ResponseEntity~List~ClaseChequeraResponse~~
+                +findAll() ResponseEntity<List<ClaseChequeraResponse>>
+                +findAllByCurso() ResponseEntity<List<ClaseChequeraResponse>>
+                +findAllByPosgrado() ResponseEntity<List<ClaseChequeraResponse>>
+                +findAllByTitulo() ResponseEntity<List<ClaseChequeraResponse>>
             }
 
             class ClaseChequeraRequest {

--- a/docs/hexagonal-contrato.mmd
+++ b/docs/hexagonal-contrato.mmd
@@ -33,13 +33,13 @@ classDiagram
         class ContratoRepository {
             <<interface>>
             +create(Contrato) Contrato
-            +findById(Long) Optional~Contrato~
-            +findAllByFacultad(Integer, Integer) List~Contrato~
-            +findAllAjustable(OffsetDateTime) List~Contrato~
-            +findAllVigente(OffsetDateTime) List~Contrato~
-            +findAllByPersona(BigDecimal, Integer) List~Contrato~
-            +update(Long, Contrato) Optional~Contrato~
-            +saveAll(List~Contrato~) List~Contrato~
+            +findById(Long) Optional<Contrato>
+            +findAllByFacultad(Integer, Integer) List<Contrato>
+            +findAllAjustable(OffsetDateTime) List<Contrato>
+            +findAllVigente(OffsetDateTime) List<Contrato>
+            +findAllByPersona(BigDecimal, Integer) List<Contrato>
+            +update(Long, Contrato) Optional<Contrato>
+            +saveAll(List<Contrato>) List<Contrato>
             +deleteById(Long) boolean
         }
     }
@@ -56,13 +56,13 @@ classDiagram
             -SaveAllContratosUseCase saveAllContratosUseCase
             -UpdateContratoUseCase updateContratoUseCase
             +createContrato(Contrato) Contrato
-            +getContratosAjustables(OffsetDateTime) List~Contrato~
-            +getContratosByFacultad(Integer, Integer) List~Contrato~
-            +getContratosByPersona(BigDecimal, Integer) List~Contrato~
-            +getContratosVigentes(OffsetDateTime) List~Contrato~
-            +getContratoById(Long) Optional~Contrato~
-            +updateContrato(Long, Contrato) Optional~Contrato~
-            +saveAllContratos(List~Contrato~) List~Contrato~
+            +getContratosAjustables(OffsetDateTime) List<Contrato>
+            +getContratosByFacultad(Integer, Integer) List<Contrato>
+            +getContratosByPersona(BigDecimal, Integer) List<Contrato>
+            +getContratosVigentes(OffsetDateTime) List<Contrato>
+            +getContratoById(Long) Optional<Contrato>
+            +updateContrato(Long, Contrato) Optional<Contrato>
+            +saveAllContratos(List<Contrato>) List<Contrato>
             +deleteContrato(Long) boolean
         }
 
@@ -77,31 +77,31 @@ classDiagram
             }
             class GetAllContratosAjustablesUseCaseImpl {
                 -ContratoRepository repository
-                +getContratosAjustables(OffsetDateTime) List~Contrato~
+                +getContratosAjustables(OffsetDateTime) List<Contrato>
             }
             class GetAllContratosByFacultadUseCaseImpl {
                 -ContratoRepository repository
-                +getContratosByFacultad(Integer, Integer) List~Contrato~
+                +getContratosByFacultad(Integer, Integer) List<Contrato>
             }
             class GetAllContratosByPersonaUseCaseImpl {
                 -ContratoRepository repository
-                +getContratosByPersona(BigDecimal, Integer) List~Contrato~
+                +getContratosByPersona(BigDecimal, Integer) List<Contrato>
             }
             class GetAllContratosVigentesUseCaseImpl {
                 -ContratoRepository repository
-                +getContratosVigentes(OffsetDateTime) List~Contrato~
+                +getContratosVigentes(OffsetDateTime) List<Contrato>
             }
             class GetContratoByIdUseCaseImpl {
                 -ContratoRepository repository
-                +getContratoById(Long) Optional~Contrato~
+                +getContratoById(Long) Optional<Contrato>
             }
             class SaveAllContratosUseCaseImpl {
                 -ContratoRepository repository
-                +saveAllContratos(List~Contrato~) List~Contrato~
+                +saveAllContratos(List<Contrato>) List<Contrato>
             }
             class UpdateContratoUseCaseImpl {
                 -ContratoRepository repository
-                +updateContrato(Long, Contrato) Optional~Contrato~
+                +updateContrato(Long, Contrato) Optional<Contrato>
             }
         }
 
@@ -115,31 +115,31 @@ classDiagram
         }
         class GetAllContratosAjustablesUseCase {
             <<interface>>
-            +getContratosAjustables(OffsetDateTime) List~Contrato~
+            +getContratosAjustables(OffsetDateTime) List<Contrato>
         }
         class GetAllContratosByFacultadUseCase {
             <<interface>>
-            +getContratosByFacultad(Integer, Integer) List~Contrato~
+            +getContratosByFacultad(Integer, Integer) List<Contrato>
         }
         class GetAllContratosByPersonaUseCase {
             <<interface>>
-            +getContratosByPersona(BigDecimal, Integer) List~Contrato~
+            +getContratosByPersona(BigDecimal, Integer) List<Contrato>
         }
         class GetAllContratosVigentesUseCase {
             <<interface>>
-            +getContratosVigentes(OffsetDateTime) List~Contrato~
+            +getContratosVigentes(OffsetDateTime) List<Contrato>
         }
         class GetContratoByIdUseCase {
             <<interface>>
-            +getContratoById(Long) Optional~Contrato~
+            +getContratoById(Long) Optional<Contrato>
         }
         class SaveAllContratosUseCase {
             <<interface>>
-            +saveAllContratos(List~Contrato~) List~Contrato~
+            +saveAllContratos(List<Contrato>) List<Contrato>
         }
         class UpdateContratoUseCase {
             <<interface>>
-            +updateContrato(Long, Contrato) Optional~Contrato~
+            +updateContrato(Long, Contrato) Optional<Contrato>
         }
     }
 
@@ -171,11 +171,11 @@ classDiagram
 
             class JpaContratoRepository {
                 <<JpaRepository>>
-                +findAllByFacultadIdAndGeograficaId(Integer, Integer) List~ContratoEntity~
-                +findAllByAjusteAndHastaGreaterThanEqual(Byte, OffsetDateTime) List~ContratoEntity~
-                +findAllByHastaGreaterThanEqual(OffsetDateTime) List~ContratoEntity~
-                +findAllByPersonaIdAndDocumentoIdOrderByDesdeDesc(BigDecimal, Integer) List~ContratoEntity~
-                +findByContratoId(Long) Optional~ContratoEntity~
+                +findAllByFacultadIdAndGeograficaId(Integer, Integer) List<ContratoEntity>
+                +findAllByAjusteAndHastaGreaterThanEqual(Byte, OffsetDateTime) List<ContratoEntity>
+                +findAllByHastaGreaterThanEqual(OffsetDateTime) List<ContratoEntity>
+                +findAllByPersonaIdAndDocumentoIdOrderByDesdeDesc(BigDecimal, Integer) List<ContratoEntity>
+                +findByContratoId(Long) Optional<ContratoEntity>
                 +deleteByContratoId(Long) void
                 +existsByContratoId(Long) boolean
             }
@@ -184,13 +184,13 @@ classDiagram
                 -JpaContratoRepository repository
                 -ContratoMapper mapper
                 +create(Contrato) Contrato
-                +findById(Long) Optional~Contrato~
-                +findAllByFacultad(Integer, Integer) List~Contrato~
-                +findAllAjustable(OffsetDateTime) List~Contrato~
-                +findAllVigente(OffsetDateTime) List~Contrato~
-                +findAllByPersona(BigDecimal, Integer) List~Contrato~
-                +update(Long, Contrato) Optional~Contrato~
-                +saveAll(List~Contrato~) List~Contrato~
+                +findById(Long) Optional<Contrato>
+                +findAllByFacultad(Integer, Integer) List<Contrato>
+                +findAllAjustable(OffsetDateTime) List<Contrato>
+                +findAllVigente(OffsetDateTime) List<Contrato>
+                +findAllByPersona(BigDecimal, Integer) List<Contrato>
+                +update(Long, Contrato) Optional<Contrato>
+                +saveAll(List<Contrato>) List<Contrato>
                 +deleteById(Long) boolean
             }
 
@@ -204,12 +204,12 @@ classDiagram
             class ContratoController {
                 -ContratoService contratoService
                 -ContratoDtoMapper contratoDtoMapper
-                +findAllAjustable(OffsetDateTime) ResponseEntity~List~ContratoResponse~~
-                +findAllVigente(OffsetDateTime) ResponseEntity~List~ContratoResponse~~
-                +findAllByPersona(BigDecimal, Integer) ResponseEntity~List~ContratoResponse~~
-                +findByContratoId(Long) ResponseEntity~ContratoResponse~
-                +update(Long, ContratoRequest) ResponseEntity~ContratoResponse~
-                +saveAll(List~ContratoRequest~) ResponseEntity~List~ContratoResponse~~
+                +findAllAjustable(OffsetDateTime) ResponseEntity<List<ContratoResponse>>
+                +findAllVigente(OffsetDateTime) ResponseEntity<List<ContratoResponse>>
+                +findAllByPersona(BigDecimal, Integer) ResponseEntity<List<ContratoResponse>>
+                +findByContratoId(Long) ResponseEntity<ContratoResponse>
+                +update(Long, ContratoRequest) ResponseEntity<ContratoResponse>
+                +saveAll(List<ContratoRequest>) ResponseEntity<List<ContratoResponse>>
             }
 
             class ContratoRequest {

--- a/docs/hexagonal-dependencia.mmd
+++ b/docs/hexagonal-dependencia.mmd
@@ -23,8 +23,8 @@ classDiagram
 
         class DependenciaRepository {
             <<interface>>
-            +findAll() List~Dependencia~
-            +findById(Integer) Optional~Dependencia~
+            +findAll() List<Dependencia>
+            +findById(Integer) Optional<Dependencia>
             +save(Dependencia) Dependencia
         }
     }
@@ -34,7 +34,7 @@ classDiagram
             -GetAllDependenciasUseCase getAllDependenciasUseCase
             -GetDependenciaByIdUseCase getDependenciaByIdUseCase
             -UpdateDependenciaUseCase updateDependenciaUseCase
-            +findAll() List~Dependencia~
+            +findAll() List<Dependencia>
             +findByDependenciaId(Integer) Dependencia
             +update(Integer, Dependencia) Dependencia
         }
@@ -42,12 +42,12 @@ classDiagram
         namespace usecases {
             class GetAllDependenciasUseCaseImpl {
                 -DependenciaRepository repository
-                +getAll() List~Dependencia~
+                +getAll() List<Dependencia>
             }
 
             class GetDependenciaByIdUseCaseImpl {
                 -DependenciaRepository repository
-                +getById(Integer) Optional~Dependencia~
+                +getById(Integer) Optional<Dependencia>
             }
 
             class UpdateDependenciaUseCaseImpl {
@@ -58,12 +58,12 @@ classDiagram
 
         class GetAllDependenciasUseCase {
             <<interface>>
-            +getAll() List~Dependencia~
+            +getAll() List<Dependencia>
         }
 
         class GetDependenciaByIdUseCase {
             <<interface>>
-            +getById(Integer) Optional~Dependencia~
+            +getById(Integer) Optional<Dependencia>
         }
 
         class UpdateDependenciaUseCase {
@@ -89,15 +89,15 @@ classDiagram
 
             class JpaDependenciaRepository {
                 <<JpaRepository>>
-                +findAllByOrderByNombre() List~DependenciaEntity~
-                +findByDependenciaId(Integer) Optional~DependenciaEntity~
+                +findAllByOrderByNombre() List<DependenciaEntity>
+                +findByDependenciaId(Integer) Optional<DependenciaEntity>
             }
 
             class JpaDependenciaRepositoryAdapter {
                 -JpaDependenciaRepository repository
                 -DependenciaMapper mapper
-                +findAll() List~Dependencia~
-                +findById(Integer) Optional~Dependencia~
+                +findAll() List<Dependencia>
+                +findById(Integer) Optional<Dependencia>
                 +save(Dependencia) Dependencia
             }
 
@@ -113,9 +113,9 @@ classDiagram
             class DependenciaController {
                 -DependenciaService service
                 -DependenciaDtoMapper mapper
-                +findAll() ResponseEntity~List~DependenciaResponse~~
-                +findByDependenciaId(Integer) ResponseEntity~DependenciaResponse~
-                +update(Integer, DependenciaRequest) ResponseEntity~DependenciaResponse~
+                +findAll() ResponseEntity<List<DependenciaResponse>>
+                +findByDependenciaId(Integer) ResponseEntity<DependenciaResponse>
+                +update(Integer, DependenciaRequest) ResponseEntity<DependenciaResponse>
             }
 
             class DependenciaRequest {

--- a/docs/hexagonal-documento.mmd
+++ b/docs/hexagonal-documento.mmd
@@ -13,8 +13,8 @@ classDiagram
 
         class DocumentoRepository {
             <<interface>>
-            +findAll() List~Documento~
-            +findById(Integer) Optional~Documento~
+            +findAll() List<Documento>
+            +findById(Integer) Optional<Documento>
         }
     }
 
@@ -22,7 +22,7 @@ classDiagram
         class DocumentoService {
             -GetAllDocumentosUseCase getAllDocumentosUseCase
             -GetDocumentoByIdUseCase getDocumentoByIdUseCase
-            +findAll() List~Documento~
+            +findAll() List<Documento>
             +findByDocumentoId(Integer) Documento
         }
 
@@ -44,14 +44,14 @@ classDiagram
 
             class JpaDocumentoRepository {
                 <<JpaRepository>>
-                +findByDocumentoId(Integer) Optional~DocumentoEntity~
+                +findByDocumentoId(Integer) Optional<DocumentoEntity>
             }
 
             class JpaDocumentoRepositoryAdapter {
                 -JpaDocumentoRepository repository
                 -DocumentoMapper mapper
-                +findAll() List~Documento~
-                +findById(Integer) Optional~Documento~
+                +findAll() List<Documento>
+                +findById(Integer) Optional<Documento>
             }
 
             class DocumentoMapper {
@@ -64,8 +64,8 @@ classDiagram
             class DocumentoController {
                 -DocumentoService service
                 -DocumentoDtoMapper dtoMapper
-                +findAll() ResponseEntity~List~DocumentoResponse~~
-                +findByDocumentoId(Integer) ResponseEntity~DocumentoResponse~
+                +findAll() ResponseEntity<List<DocumentoResponse>>
+                +findByDocumentoId(Integer) ResponseEntity<DocumentoResponse>
             }
 
             class DocumentoRequest

--- a/docs/hexagonal-domicilio.mmd
+++ b/docs/hexagonal-domicilio.mmd
@@ -32,10 +32,10 @@ classDiagram
         class DomicilioRepository {
             <<interface>>
             +create(Domicilio) Domicilio
-            +findById(Long) Optional~Domicilio~
-            +findByUnique(BigDecimal, Integer) Optional~Domicilio~
-            +findFirstByPersonaId(BigDecimal) Optional~Domicilio~
-            +update(Long, Domicilio) Optional~Domicilio~
+            +findById(Long) Optional<Domicilio>
+            +findByUnique(BigDecimal, Integer) Optional<Domicilio>
+            +findFirstByPersonaId(BigDecimal) Optional<Domicilio>
+            +update(Long, Domicilio) Optional<Domicilio>
             +deleteById(Long) boolean
         }
     }
@@ -51,15 +51,15 @@ classDiagram
             -DeleteDomicilioUseCase deleteDomicilioUseCase
             -GetAllDomiciliosByUnifiedsUseCase getAllDomiciliosByUnifiedsUseCase
             -GetDomicilioByPersonaIdUseCase getDomicilioByPersonaIdUseCase
-            +findByDomicilioId(Long) Optional~Domicilio~
+            +findByDomicilioId(Long) Optional<Domicilio>
             +findByUnique(Integer, Integer) Domicilio
             +findWithPagador(Integer, Integer, Integer) Domicilio
-            +findFirstByPersonaId(Integer) Optional~Domicilio~
+            +findFirstByPersonaId(Integer) Optional<Domicilio>
             +create(Domicilio) Domicilio
-            +update(Long, Domicilio) Optional~Domicilio~
+            +update(Long, Domicilio) Optional<Domicilio>
             +sincronize(Domicilio) Domicilio
             +capture(Integer, Integer) Domicilio
-            +findAllByUnifieds(String) List~Domicilio~
+            +findAllByUnifieds(String) List<Domicilio>
             +delete(Long) void
         }
 
@@ -114,19 +114,19 @@ classDiagram
 
             class JpaDomicilioRepository {
                 <<JpaRepository>>
-                +findByDomicilioId(Long) Optional~DomicilioEntity~
-                +findByPersonaIdAndDocumentoId(Integer, Integer) Optional~DomicilioEntity~
-                +findFirstByPersonaId(Integer) Optional~DomicilioEntity~
+                +findByDomicilioId(Long) Optional<DomicilioEntity>
+                +findByPersonaIdAndDocumentoId(Integer, Integer) Optional<DomicilioEntity>
+                +findFirstByPersonaId(Integer) Optional<DomicilioEntity>
             }
 
             class JpaDomicilioRepositoryAdapter {
                 -JpaDomicilioRepository repository
                 -DomicilioMapper mapper
                 +create(Domicilio) Domicilio
-                +findById(Long) Optional~Domicilio~
-            +findByUnique(BigDecimal, Integer) Optional~Domicilio~
-            +findFirstByPersonaId(BigDecimal) Optional~Domicilio~
-            +update(Long, Domicilio) Optional~Domicilio~
+                +findById(Long) Optional<Domicilio>
+            +findByUnique(BigDecimal, Integer) Optional<Domicilio>
+            +findFirstByPersonaId(BigDecimal) Optional<Domicilio>
+            +update(Long, Domicilio) Optional<Domicilio>
             +deleteById(Long) boolean
             }
 
@@ -140,15 +140,15 @@ classDiagram
             class DomicilioController {
                 -DomicilioService domicilioService
                 -DomicilioDtoMapper dtoMapper
-                +findById(Long) ResponseEntity~DomicilioResponse~
-                +findUnique(Integer, Integer) ResponseEntity~DomicilioResponse~
-                +findWithPagador(Integer, Integer, Integer) ResponseEntity~DomicilioResponse~
-                +create(DomicilioRequest) ResponseEntity~DomicilioResponse~
-                +update(Long, DomicilioRequest) ResponseEntity~DomicilioResponse~
-                +sincronize(DomicilioRequest) ResponseEntity~DomicilioResponse~
-                +capture(Integer, Integer) ResponseEntity~DomicilioResponse~
-                +findByUnifieds(String) ResponseEntity~List~DomicilioResponse~~
-                +delete(Long) ResponseEntity~Void~
+                +findById(Long) ResponseEntity<DomicilioResponse>
+                +findUnique(Integer, Integer) ResponseEntity<DomicilioResponse>
+                +findWithPagador(Integer, Integer, Integer) ResponseEntity<DomicilioResponse>
+                +create(DomicilioRequest) ResponseEntity<DomicilioResponse>
+                +update(Long, DomicilioRequest) ResponseEntity<DomicilioResponse>
+                +sincronize(DomicilioRequest) ResponseEntity<DomicilioResponse>
+                +capture(Integer, Integer) ResponseEntity<DomicilioResponse>
+                +findByUnifieds(String) ResponseEntity<List<DomicilioResponse>>
+                +delete(Long) ResponseEntity<Void>
             }
 
             class DomicilioRequest

--- a/docs/hexagonal-facturaPendiente.mmd
+++ b/docs/hexagonal-facturaPendiente.mmd
@@ -25,24 +25,24 @@ classDiagram
         class FacturaPendienteRepository {
             <<interface>>
             +updateFechaPagoInProveedorPago(Long, OffsetDateTime)
-            +findFacturasPendientes(OffsetDateTime, OffsetDateTime) List~FacturaPendiente~
+            +findFacturasPendientes(OffsetDateTime, OffsetDateTime) List<FacturaPendiente>
         }
     }
 
     namespace application {
         class FacturaPendienteService {
             -GetFacturasPendientesUseCase getFacturasPendientesUseCase
-            +findAllFacturasPendientesBetweenDates(OffsetDateTime, OffsetDateTime) List~FacturaPendiente~
+            +findAllFacturasPendientesBetweenDates(OffsetDateTime, OffsetDateTime) List<FacturaPendiente>
         }
 
         class GetFacturasPendientesUseCaseImpl {
             -FacturaPendienteRepository repository
-            +getFacturasPendientes(OffsetDateTime, OffsetDateTime) List~FacturaPendiente~
+            +getFacturasPendientes(OffsetDateTime, OffsetDateTime) List<FacturaPendiente>
         }
 
         class GetFacturasPendientesUseCase {
             <<interface>>
-            +getFacturasPendientes(OffsetDateTime, OffsetDateTime) List~FacturaPendiente~
+            +getFacturasPendientes(OffsetDateTime, OffsetDateTime) List<FacturaPendiente>
         }
     }
 
@@ -68,13 +68,13 @@ classDiagram
             class JpaFacturaPendienteRepository {
                 <<JpaRepository>>
                 +updateFechaPagoInProveedorPago(Long, OffsetDateTime)
-                +findFacturasPendientes(OffsetDateTime, OffsetDateTime) List~FacturaPendienteEntity~
+                +findFacturasPendientes(OffsetDateTime, OffsetDateTime) List<FacturaPendienteEntity>
             }
 
             class JpaFacturaPendienteRepositoryAdapter {
                 -JpaFacturaPendienteRepository repository
                 +updateFechaPagoInProveedorPago(Long, OffsetDateTime)
-                +findFacturasPendientes(OffsetDateTime, OffsetDateTime) List~FacturaPendiente~
+                +findFacturasPendientes(OffsetDateTime, OffsetDateTime) List<FacturaPendiente>
             }
         }
     }

--- a/docs/hexagonal-facultad.mmd
+++ b/docs/hexagonal-facultad.mmd
@@ -22,9 +22,9 @@ classDiagram
 
         class FacultadRepository {
             <<interface>>
-            +findAll() List~Facultad~
-            +findAllIn(List~Integer~) List~Facultad~
-            +findById(Integer) Optional~Facultad~
+            +findAll() List<Facultad>
+            +findAllIn(List<Integer>) List<Facultad>
+            +findById(Integer) Optional<Facultad>
         }
     }
 
@@ -33,44 +33,44 @@ classDiagram
             -GetAllFacultadesUseCase getAllFacultadesUseCase
             -GetFacultadesFiltradasUseCase getFacultadesFiltradasUseCase
             -GetFacultadByIdUseCase getFacultadByIdUseCase
-            +findAll() List~Facultad~
-            +findFacultades() List~Facultad~
+            +findAll() List<Facultad>
+            +findFacultades() List<Facultad>
             +findByFacultadId(Integer) Facultad
-            +findAllByLectivoId(Integer) List~FacultadLectivo~
-            +findAllByPersona(BigDecimal, Integer, Integer) List~FacultadPersona~
-            +findAllByDisenho(Integer, Integer) List~FacultadLectivoSede~
+            +findAllByLectivoId(Integer) List<FacultadLectivo>
+            +findAllByPersona(BigDecimal, Integer, Integer) List<FacultadPersona>
+            +findAllByDisenho(Integer, Integer) List<FacultadLectivoSede>
         }
 
         namespace usecases {
             class GetAllFacultadesUseCaseImpl {
                 -FacultadRepository repository
-                +getAll() List~Facultad~
+                +getAll() List<Facultad>
             }
 
             class GetFacultadByIdUseCaseImpl {
                 -FacultadRepository repository
-                +getById(Integer) Optional~Facultad~
+                +getById(Integer) Optional<Facultad>
             }
 
             class GetFacultadesFiltradasUseCaseImpl {
                 -FacultadRepository repository
-                +getFacultadesFiltradas() List~Facultad~
+                +getFacultadesFiltradas() List<Facultad>
             }
         }
 
         class GetAllFacultadesUseCase {
             <<interface>>
-            +getAll() List~Facultad~
+            +getAll() List<Facultad>
         }
 
         class GetFacultadByIdUseCase {
             <<interface>>
-            +getById(Integer) Optional~Facultad~
+            +getById(Integer) Optional<Facultad>
         }
 
         class GetFacultadesFiltradasUseCase {
             <<interface>>
-            +getFacultadesFiltradas() List~Facultad~
+            +getFacultadesFiltradas() List<Facultad>
         }
     }
 
@@ -90,16 +90,16 @@ classDiagram
 
             class JpaFacultadRepository {
                 <<JpaRepository>>
-                +findAllByFacultadIdIn(List~Integer~) List~FacultadEntity~
-                +findByFacultadId(Integer) Optional~FacultadEntity~
+                +findAllByFacultadIdIn(List<Integer>) List<FacultadEntity>
+                +findByFacultadId(Integer) Optional<FacultadEntity>
             }
 
             class JpaFacultadRepositoryAdapter {
                 -JpaFacultadRepository repository
                 -FacultadMapper mapper
-                +findAll() List~Facultad~
-                +findAllIn(List~Integer~) List~Facultad~
-                +findById(Integer) Optional~Facultad~
+                +findAll() List<Facultad>
+                +findAllIn(List<Integer>) List<Facultad>
+                +findById(Integer) Optional<Facultad>
             }
 
             class FacultadMapper {
@@ -111,12 +111,12 @@ classDiagram
             class FacultadController {
                 -FacultadService service
                 -FacultadDtoMapper mapper
-                +findAll() ResponseEntity~List~FacultadResponse~~
-                +findFacultades() ResponseEntity~List~FacultadResponse~~
-                +findByFacultadId(Integer) ResponseEntity~FacultadResponse~
-                +findAllByLectivoId(Integer) ResponseEntity~List~FacultadLectivo~~
-                +findAllByPersona(BigDecimal, Integer, Integer) ResponseEntity~List~FacultadPersona~~
-                +findAllByDisenho(Integer, Integer) ResponseEntity~List~FacultadLectivoSede~~
+                +findAll() ResponseEntity<List<FacultadResponse>>
+                +findFacultades() ResponseEntity<List<FacultadResponse>>
+                +findByFacultadId(Integer) ResponseEntity<FacultadResponse>
+                +findAllByLectivoId(Integer) ResponseEntity<List<FacultadLectivo>>
+                +findAllByPersona(BigDecimal, Integer, Integer) ResponseEntity<List<FacultadPersona>>
+                +findAllByDisenho(Integer, Integer) ResponseEntity<List<FacultadLectivoSede>>
             }
 
             class FacultadResponse {

--- a/docs/hexagonal-lectivo.mmd
+++ b/docs/hexagonal-lectivo.mmd
@@ -16,12 +16,12 @@ classDiagram
 
         class LectivoRepository {
             <<interface>>
-            +findAll() List~Lectivo~
-            +findAllReverse() List~Lectivo~
-            +findAllByPersona(BigDecimal, Integer) List~Lectivo~
-            +findById(Integer) Optional~Lectivo~
-            +findByFecha(OffsetDateTime) Optional~Lectivo~
-            +findLast() Optional~Lectivo~
+            +findAll() List<Lectivo>
+            +findAllReverse() List<Lectivo>
+            +findAllByPersona(BigDecimal, Integer) List<Lectivo>
+            +findById(Integer) Optional<Lectivo>
+            +findByFecha(OffsetDateTime) Optional<Lectivo>
+            +findLast() Optional<Lectivo>
             +create(Lectivo) Lectivo
             +deleteById(Integer)
         }
@@ -37,12 +37,12 @@ classDiagram
             -GetLectivoByFechaUseCase getLectivoByFechaUseCase
             -GetLastLectivoUseCase getLastLectivoUseCase
             -DeleteLectivoUseCase deleteLectivoUseCase
-            +findAll() List~Lectivo~
-            +findAllReverse() List~Lectivo~
-            +findAllByPersona(BigDecimal, Integer) List~Lectivo~
+            +findAll() List<Lectivo>
+            +findAllReverse() List<Lectivo>
+            +findAllByPersona(BigDecimal, Integer) List<Lectivo>
             +findByLectivoId(Integer) Lectivo
             +findByFecha(OffsetDateTime) Lectivo
-            +findLast() Optional~Lectivo~
+            +findLast() Optional<Lectivo>
             +createLectivo(Lectivo) Lectivo
             +deleteByLectivoId(Integer)
         }
@@ -73,22 +73,22 @@ classDiagram
 
             class JpaLectivoRepository {
                 <<JpaRepository>>
-                +findAllByLectivoIdIn(List~Integer~, Sort) List~LectivoEntity~
-                +findByLectivoId(Integer) Optional~LectivoEntity~
-                +findByFechaInicioLessThanEqualAndFechaFinalGreaterThanEqual(OffsetDateTime, OffsetDateTime) Optional~LectivoEntity~
-                +findTopByOrderByLectivoIdDesc() Optional~LectivoEntity~
+                +findAllByLectivoIdIn(List<Integer>, Sort) List<LectivoEntity>
+                +findByLectivoId(Integer) Optional<LectivoEntity>
+                +findByFechaInicioLessThanEqualAndFechaFinalGreaterThanEqual(OffsetDateTime, OffsetDateTime) Optional<LectivoEntity>
+                +findTopByOrderByLectivoIdDesc() Optional<LectivoEntity>
             }
 
             class JpaLectivoRepositoryAdapter {
                 -JpaLectivoRepository repository
                 -JpaChequeraSerieRepository chequeraSerieRepository
                 -LectivoMapper mapper
-                +findAll() List~Lectivo~
-                +findAllReverse() List~Lectivo~
-                +findAllByPersona(BigDecimal, Integer) List~Lectivo~
-                +findById(Integer) Optional~Lectivo~
-                +findByFecha(OffsetDateTime) Optional~Lectivo~
-                +findLast() Optional~Lectivo~
+                +findAll() List<Lectivo>
+                +findAllReverse() List<Lectivo>
+                +findAllByPersona(BigDecimal, Integer) List<Lectivo>
+                +findById(Integer) Optional<Lectivo>
+                +findByFecha(OffsetDateTime) Optional<Lectivo>
+                +findLast() Optional<Lectivo>
                 +create(Lectivo) Lectivo
                 +deleteById(Integer)
             }
@@ -103,13 +103,13 @@ classDiagram
             class LectivoController {
                 -LectivoService service
                 -LectivoDtoMapper dtoMapper
-                +findAll() ResponseEntity~List~LectivoResponse~~
-                +findAllReverse() ResponseEntity~List~LectivoResponse~~
-                +findAllByPersona(BigDecimal, Integer) ResponseEntity~List~LectivoResponse~~
-                +findByLectivoId(Integer) ResponseEntity~LectivoResponse~
-                +findLast() ResponseEntity~LectivoResponse~
-                +add(LectivoRequest) ResponseEntity~LectivoResponse~
-                +deleteByLectivoId(Integer) ResponseEntity~Void~
+                +findAll() ResponseEntity<List<LectivoResponse>>
+                +findAllReverse() ResponseEntity<List<LectivoResponse>>
+                +findAllByPersona(BigDecimal, Integer) ResponseEntity<List<LectivoResponse>>
+                +findByLectivoId(Integer) ResponseEntity<LectivoResponse>
+                +findLast() ResponseEntity<LectivoResponse>
+                +add(LectivoRequest) ResponseEntity<LectivoResponse>
+                +deleteByLectivoId(Integer) ResponseEntity<Void>
             }
 
             class LectivoRequest {

--- a/docs/hexagonal-lectivoTotalImputacion.mmd
+++ b/docs/hexagonal-lectivoTotalImputacion.mmd
@@ -52,12 +52,12 @@ classDiagram
 
         class LectivoTotalImputacionRepository {
             <<interface>>
-            +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
-            +findAllByLectivo(Integer) List~LectivoTotalImputacion~
-            +findByProducto(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacion~
+            +findAllByTipo(Integer, Integer, Integer) List<LectivoTotalImputacion>
+            +findAllByLectivo(Integer) List<LectivoTotalImputacion>
+            +findByProducto(Integer, Integer, Integer, Integer) Optional<LectivoTotalImputacion>
             +add(LectivoTotalImputacion) LectivoTotalImputacion
-            +update(Long, LectivoTotalImputacion) Optional~LectivoTotalImputacion~
-            +findById(Long) Optional~LectivoTotalImputacion~
+            +update(Long, LectivoTotalImputacion) Optional<LectivoTotalImputacion>
+            +findById(Long) Optional<LectivoTotalImputacion>
         }
     }
 
@@ -68,27 +68,27 @@ classDiagram
             -FindByProductoUseCase findByProductoUseCase
             -AddLectivoTotalImputacionUseCase addLectivoTotalImputacionUseCase
             -UpdateLectivoTotalImputacionUseCase updateLectivoTotalImputacionUseCase
-            +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
-            +findAllByLectivo(Integer) List~LectivoTotalImputacion~
-            +findByProducto(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacion~
+            +findAllByTipo(Integer, Integer, Integer) List<LectivoTotalImputacion>
+            +findAllByLectivo(Integer) List<LectivoTotalImputacion>
+            +findByProducto(Integer, Integer, Integer, Integer) Optional<LectivoTotalImputacion>
             +add(LectivoTotalImputacion) LectivoTotalImputacion
-            +update(Long, LectivoTotalImputacion) Optional~LectivoTotalImputacion~
+            +update(Long, LectivoTotalImputacion) Optional<LectivoTotalImputacion>
         }
 
         namespace usecases {
             class FindAllByTipoUseCaseImpl {
                 -LectivoTotalImputacionRepository repository
-                +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
+                +findAllByTipo(Integer, Integer, Integer) List<LectivoTotalImputacion>
             }
 
             class FindAllByLectivoUseCaseImpl {
                 -LectivoTotalImputacionRepository repository
-                +findAllByLectivo(Integer) List~LectivoTotalImputacion~
+                +findAllByLectivo(Integer) List<LectivoTotalImputacion>
             }
 
             class FindByProductoUseCaseImpl {
                 -LectivoTotalImputacionRepository repository
-                +findByProducto(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacion~
+                +findByProducto(Integer, Integer, Integer, Integer) Optional<LectivoTotalImputacion>
             }
 
             class AddLectivoTotalImputacionUseCaseImpl {
@@ -98,23 +98,23 @@ classDiagram
 
             class UpdateLectivoTotalImputacionUseCaseImpl {
                 -LectivoTotalImputacionRepository repository
-                +update(Long, LectivoTotalImputacion) Optional~LectivoTotalImputacion~
+                +update(Long, LectivoTotalImputacion) Optional<LectivoTotalImputacion>
             }
         }
 
         class FindAllByTipoUseCase {
             <<interface>>
-            +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
+            +findAllByTipo(Integer, Integer, Integer) List<LectivoTotalImputacion>
         }
 
         class FindAllByLectivoUseCase {
             <<interface>>
-            +findAllByLectivo(Integer) List~LectivoTotalImputacion~
+            +findAllByLectivo(Integer) List<LectivoTotalImputacion>
         }
 
         class FindByProductoUseCase {
             <<interface>>
-            +findByProducto(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacion~
+            +findByProducto(Integer, Integer, Integer, Integer) Optional<LectivoTotalImputacion>
         }
 
         class AddLectivoTotalImputacionUseCase {
@@ -124,7 +124,7 @@ classDiagram
 
         class UpdateLectivoTotalImputacionUseCase {
             <<interface>>
-            +update(Long, LectivoTotalImputacion) Optional~LectivoTotalImputacion~
+            +update(Long, LectivoTotalImputacion) Optional<LectivoTotalImputacion>
         }
     }
 
@@ -146,21 +146,21 @@ classDiagram
 
             class JpaLectivoTotalImputacionRepository {
                 <<JpaRepository>>
-                +findAllByFacultadIdAndLectivoIdAndTipoChequeraId(Integer, Integer, Integer) List~LectivoTotalImputacionEntity~
-                +findAllByLectivoId(Integer) List~LectivoTotalImputacionEntity~
-                +findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoId(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacionEntity~
-                +findByLectivoTotalImputacionId(Long) Optional~LectivoTotalImputacionEntity~
+                +findAllByFacultadIdAndLectivoIdAndTipoChequeraId(Integer, Integer, Integer) List<LectivoTotalImputacionEntity>
+                +findAllByLectivoId(Integer) List<LectivoTotalImputacionEntity>
+                +findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoId(Integer, Integer, Integer, Integer) Optional<LectivoTotalImputacionEntity>
+                +findByLectivoTotalImputacionId(Long) Optional<LectivoTotalImputacionEntity>
             }
 
             class JpaLectivoTotalImputacionRepositoryAdapter {
                 -JpaLectivoTotalImputacionRepository jpaLectivoTotalImputacionRepository
                 -LectivoTotalImputacionMapper mapper
-                +findAllByTipo(Integer, Integer, Integer) List~LectivoTotalImputacion~
-                +findAllByLectivo(Integer) List~LectivoTotalImputacion~
-                +findByProducto(Integer, Integer, Integer, Integer) Optional~LectivoTotalImputacion~
+                +findAllByTipo(Integer, Integer, Integer) List<LectivoTotalImputacion>
+                +findAllByLectivo(Integer) List<LectivoTotalImputacion>
+                +findByProducto(Integer, Integer, Integer, Integer) Optional<LectivoTotalImputacion>
                 +add(LectivoTotalImputacion) LectivoTotalImputacion
-                +update(Long, LectivoTotalImputacion) Optional~LectivoTotalImputacion~
-                +findById(Long) Optional~LectivoTotalImputacion~
+                +update(Long, LectivoTotalImputacion) Optional<LectivoTotalImputacion>
+                +findById(Long) Optional<LectivoTotalImputacion>
             }
 
             class LectivoTotalImputacionMapper {
@@ -178,11 +178,11 @@ classDiagram
             class LectivoTotalImputacionController {
                 -LectivoTotalImputacionService service
                 -LectivoTotalImputacionDtoMapper mapper
-                +findAllByLectivo(Integer) ResponseEntity~List~LectivoTotalImputacionResponse~~
-                +findAllByTipo(Integer, Integer, Integer) ResponseEntity~List~LectivoTotalImputacionResponse~~
-                +findByProducto(Integer, Integer, Integer, Integer) ResponseEntity~LectivoTotalImputacionResponse~
-                +add(LectivoTotalImputacionRequest) ResponseEntity~LectivoTotalImputacionResponse~
-                +update(LectivoTotalImputacionRequest, Long) ResponseEntity~LectivoTotalImputacionResponse~
+                +findAllByLectivo(Integer) ResponseEntity<List<LectivoTotalImputacionResponse>>
+                +findAllByTipo(Integer, Integer, Integer) ResponseEntity<List<LectivoTotalImputacionResponse>>
+                +findByProducto(Integer, Integer, Integer, Integer) ResponseEntity<LectivoTotalImputacionResponse>
+                +add(LectivoTotalImputacionRequest) ResponseEntity<LectivoTotalImputacionResponse>
+                +update(LectivoTotalImputacionRequest, Long) ResponseEntity<LectivoTotalImputacionResponse>
             }
 
             class LectivoTotalImputacionRequest {

--- a/docs/hexagonal-mercadoPagoContext.mmd
+++ b/docs/hexagonal-mercadoPagoContext.mmd
@@ -32,16 +32,16 @@ classDiagram
 
         class MercadoPagoContextRepository {
             <<interface>>
-            +findByMercadoPagoContextId(Long) Optional~MercadoPagoContext~
-            +findByChequeraCuotaIdAndActivo(Long, Byte) Optional~MercadoPagoContext~
-            +findByReservaVacanteIdAndActivo(UUID, Byte) Optional~MercadoPagoContext~
-            +findAllByChequeraCuotaIdAndActivo(Long, Byte) List~MercadoPagoContext~
-            +findAllActiveChequeraCuota() List~Long~
-            +findAllActiveToChange(OffsetDateTime, OffsetDateTime) List~MercadoPagoContext~
-            +findAllByChequeraCuotaIds(List~Long~) List~MercadoPagoContext~
-            +findAllSinImputar() List~MercadoPagoContext~
+            +findByMercadoPagoContextId(Long) Optional<MercadoPagoContext>
+            +findByChequeraCuotaIdAndActivo(Long, Byte) Optional<MercadoPagoContext>
+            +findByReservaVacanteIdAndActivo(UUID, Byte) Optional<MercadoPagoContext>
+            +findAllByChequeraCuotaIdAndActivo(Long, Byte) List<MercadoPagoContext>
+            +findAllActiveChequeraCuota() List<Long>
+            +findAllActiveToChange(OffsetDateTime, OffsetDateTime) List<MercadoPagoContext>
+            +findAllByChequeraCuotaIds(List<Long>) List<MercadoPagoContext>
+            +findAllSinImputar() List<MercadoPagoContext>
             +save(MercadoPagoContext) MercadoPagoContext
-            +saveAll(List~MercadoPagoContext~) List~MercadoPagoContext~
+            +saveAll(List<MercadoPagoContext>) List<MercadoPagoContext>
         }
     }
 
@@ -59,16 +59,16 @@ classDiagram
             -SaveAllMercadoPagoContextsUseCase saveAllUseCase
             -UpdateMercadoPagoContextUseCase updateUseCase
             +add(MercadoPagoContext) MercadoPagoContext
-            +findById(Long) Optional~MercadoPagoContext~
-            +findActiveByChequeraCuotaId(Long) Optional~MercadoPagoContext~
+            +findById(Long) Optional<MercadoPagoContext>
+            +findActiveByChequeraCuotaId(Long) Optional<MercadoPagoContext>
             +findActiveByReservaVacanteId(UUID) MercadoPagoContext
-            +findAllActiveChequeraCuota() List~Long~
-            +findAllActiveToChange() List~MercadoPagoContext~
-            +findAllByChequeraCuotaIdAndActivo(Long, Byte) List~MercadoPagoContext~
-            +findAllByChequeraCuotaIds(List~Long~) List~MercadoPagoContext~
-            +findAllSinImputar() List~MercadoPagoContext~
+            +findAllActiveChequeraCuota() List<Long>
+            +findAllActiveToChange() List<MercadoPagoContext>
+            +findAllByChequeraCuotaIdAndActivo(Long, Byte) List<MercadoPagoContext>
+            +findAllByChequeraCuotaIds(List<Long>) List<MercadoPagoContext>
+            +findAllSinImputar() List<MercadoPagoContext>
             +processPaymentEvent(Long, Long) void
-            +saveAll(List~MercadoPagoContext~) List~MercadoPagoContext~
+            +saveAll(List<MercadoPagoContext>) List<MercadoPagoContext>
             +update(MercadoPagoContext) MercadoPagoContext
         }
 
@@ -121,29 +121,29 @@ classDiagram
 
             class JpaMercadoPagoContextRepository {
                 <<JpaRepository>>
-                +findByMercadoPagoContextId(Long) Optional~MercadoPagoContextEntity~
-                +findByChequeraCuotaIdAndActivo(Long, Byte) Optional~MercadoPagoContextEntity~
-                +findByReservaVacanteId(UUID) Optional~MercadoPagoContextEntity~
-                +findAllByChequeraCuotaIdAndActivo(Long, Byte) List~MercadoPagoContextEntity~
-                +findAllByActivoAndFechaVencimientoBetween(OffsetDateTime, OffsetDateTime) List~MercadoPagoContextEntity~
-                +findAllByChequeraCuotaIdInAndActivo(List~Long~, Byte) List~MercadoPagoContextEntity~
-                +findAllByActivoOrderByMercadoPagoContextIdDesc() List~MercadoPagoContextEntity~
-                +findAllByStatusAndChequeraPagoIdIsNull(String) List~MercadoPagoContextEntity~
+                +findByMercadoPagoContextId(Long) Optional<MercadoPagoContextEntity>
+                +findByChequeraCuotaIdAndActivo(Long, Byte) Optional<MercadoPagoContextEntity>
+                +findByReservaVacanteId(UUID) Optional<MercadoPagoContextEntity>
+                +findAllByChequeraCuotaIdAndActivo(Long, Byte) List<MercadoPagoContextEntity>
+                +findAllByActivoAndFechaVencimientoBetween(OffsetDateTime, OffsetDateTime) List<MercadoPagoContextEntity>
+                +findAllByChequeraCuotaIdInAndActivo(List<Long>, Byte) List<MercadoPagoContextEntity>
+                +findAllByActivoOrderByMercadoPagoContextIdDesc() List<MercadoPagoContextEntity>
+                +findAllByStatusAndChequeraPagoIdIsNull(String) List<MercadoPagoContextEntity>
             }
 
             class JpaMercadoPagoContextRepositoryAdapter {
                 -JpaMercadoPagoContextRepository repository
                 -MercadoPagoContextMapper mapper
-                +findByMercadoPagoContextId(Long) Optional~MercadoPagoContext~
-                +findByChequeraCuotaIdAndActivo(Long, Byte) Optional~MercadoPagoContext~
-                +findByReservaVacanteIdAndActivo(UUID, Byte) Optional~MercadoPagoContext~
-                +findAllByChequeraCuotaIdAndActivo(Long, Byte) List~MercadoPagoContext~
-                +findAllActiveChequeraCuota() List~Long~
-                +findAllActiveToChange(OffsetDateTime, OffsetDateTime) List~MercadoPagoContext~
-                +findAllByChequeraCuotaIds(List~Long~) List~MercadoPagoContext~
-                +findAllSinImputar() List~MercadoPagoContext~
+                +findByMercadoPagoContextId(Long) Optional<MercadoPagoContext>
+                +findByChequeraCuotaIdAndActivo(Long, Byte) Optional<MercadoPagoContext>
+                +findByReservaVacanteIdAndActivo(UUID, Byte) Optional<MercadoPagoContext>
+                +findAllByChequeraCuotaIdAndActivo(Long, Byte) List<MercadoPagoContext>
+                +findAllActiveChequeraCuota() List<Long>
+                +findAllActiveToChange(OffsetDateTime, OffsetDateTime) List<MercadoPagoContext>
+                +findAllByChequeraCuotaIds(List<Long>) List<MercadoPagoContext>
+                +findAllSinImputar() List<MercadoPagoContext>
                 +save(MercadoPagoContext) MercadoPagoContext
-                +saveAll(List~MercadoPagoContext~) List~MercadoPagoContext~
+                +saveAll(List<MercadoPagoContext>) List<MercadoPagoContext>
             }
 
             class MercadoPagoContextMapper {
@@ -158,11 +158,11 @@ classDiagram
             class MercadoPagoContextController {
                 -MercadoPagoContextService service
                 -MercadoPagoContextDtoMapper dtoMapper
-                +findByChequeraCuotaIdAndActivo(Long) ResponseEntity~MercadoPagoContextResponse~
-                +findById(Long) ResponseEntity~MercadoPagoContextResponse~
-                +findAllActiveChequeraCuota() ResponseEntity~List~Long~~
-                +findAllActiveToChange() ResponseEntity~List~MercadoPagoContextResponse~~
-                +findAllSinImputar() ResponseEntity~List~MercadoPagoContextResponse~~
+                +findByChequeraCuotaIdAndActivo(Long) ResponseEntity<MercadoPagoContextResponse>
+                +findById(Long) ResponseEntity<MercadoPagoContextResponse>
+                +findAllActiveChequeraCuota() ResponseEntity<List<Long>>
+                +findAllActiveToChange() ResponseEntity<List<MercadoPagoContextResponse>>
+                +findAllSinImputar() ResponseEntity<List<MercadoPagoContextResponse>>
             }
 
             class MercadoPagoContextRequest {

--- a/docs/hexagonal-persona.mmd
+++ b/docs/hexagonal-persona.mmd
@@ -23,10 +23,10 @@ classDiagram
 
         class PersonaRepository {
             <<interface>>
-            +findByPersonaIdAndDocumentoId(BigDecimal, Integer) Optional~Persona~
-            +findTopByPersonaId(BigDecimal) Optional~Persona~
-            +findByUniqueId(Long) Optional~Persona~
-            +findAllByCbuLike(String) List~Persona~
+            +findByPersonaIdAndDocumentoId(BigDecimal, Integer) Optional<Persona>
+            +findTopByPersonaId(BigDecimal) Optional<Persona>
+            +findByUniqueId(Long) Optional<Persona>
+            +findAllByCbuLike(String) List<Persona>
             +save(Persona) Persona
         }
     }
@@ -47,13 +47,13 @@ classDiagram
             -GetDeudaPersonaUseCase getDeudaPersonaUseCase
             -GetInscripcionFullUseCase getInscripcionFullUseCase
             +findByUnique(BigDecimal, Integer) Persona
-            +findTopByPersonaId(BigDecimal) Optional~Persona~
-            +findByUniqueId(Long) Optional~Persona~
-            +findAllSantander() List~Persona~
-            +findInscriptosSinChequera(...) List~Persona~
-            +findDeudoresByLectivo(...) List~Persona~
-            +findUnifieds(String) List~Persona~
-            +findByStrings(String, String, Integer) List~Persona~
+            +findTopByPersonaId(BigDecimal) Optional<Persona>
+            +findByUniqueId(Long) Optional<Persona>
+            +findAllSantander() List<Persona>
+            +findInscriptosSinChequera(...) List<Persona>
+            +findDeudoresByLectivo(...) List<Persona>
+            +findUnifieds(String) List<Persona>
+            +findByStrings(String, String, Integer) List<Persona>
             +getDeudaPersona(...) DeudaPersonaDto
             +getInscripcionFull(...) InscripcionFullDto
             +create(Persona) Persona
@@ -103,19 +103,19 @@ classDiagram
 
             class JpaPersonaRepository {
                 <<JpaRepository>>
-                +findByPersonaIdAndDocumentoId(BigDecimal, Integer) Optional~PersonaEntity~
-                +findTopByPersonaId(BigDecimal) Optional~PersonaEntity~
-                +findByUniqueId(Long) Optional~PersonaEntity~
-                +findAllByCbuLike(String) List~PersonaEntity~
+                +findByPersonaIdAndDocumentoId(BigDecimal, Integer) Optional<PersonaEntity>
+                +findTopByPersonaId(BigDecimal) Optional<PersonaEntity>
+                +findByUniqueId(Long) Optional<PersonaEntity>
+                +findAllByCbuLike(String) List<PersonaEntity>
             }
 
             class JpaPersonaRepositoryAdapter {
                 -JpaPersonaRepository repository
                 -PersonaMapper mapper
-                +findByPersonaIdAndDocumentoId(BigDecimal, Integer) Optional~Persona~
-                +findTopByPersonaId(BigDecimal) Optional~Persona~
-                +findByUniqueId(Long) Optional~Persona~
-                +findAllByCbuLike(String) List~Persona~
+                +findByPersonaIdAndDocumentoId(BigDecimal, Integer) Optional<Persona>
+                +findTopByPersonaId(BigDecimal) Optional<Persona>
+                +findByUniqueId(Long) Optional<Persona>
+                +findAllByCbuLike(String) List<Persona>
                 +save(Persona) Persona
             }
 
@@ -129,18 +129,18 @@ classDiagram
             class PersonaController {
                 -PersonaService personaService
                 -PersonaDtoMapper dtoMapper
-                +findUnique(BigDecimal, Integer) ResponseEntity~PersonaResponse~
-                +findTopByPersonaId(BigDecimal) ResponseEntity~PersonaResponse~
-                +findByUniqueId(Long) ResponseEntity~PersonaResponse~
-                +findAllSantander() ResponseEntity~List~PersonaResponse~~
-                +findInscriptosSinChequera(...) ResponseEntity~List~PersonaResponse~~
-                +findDeudoresByLectivo(...) ResponseEntity~List~PersonaResponse~~
-                +findUnifieds(String) ResponseEntity~List~PersonaResponse~~
-                +findByStrings(...) ResponseEntity~List~PersonaResponse~~
-                +getDeudaPersona(...) ResponseEntity~DeudaPersonaDto~
-                +getInscripcionFull(...) ResponseEntity~InscripcionFullDto~
-                +create(PersonaRequest) ResponseEntity~PersonaResponse~
-                +update(PersonaRequest) ResponseEntity~PersonaResponse~
+                +findUnique(BigDecimal, Integer) ResponseEntity<PersonaResponse>
+                +findTopByPersonaId(BigDecimal) ResponseEntity<PersonaResponse>
+                +findByUniqueId(Long) ResponseEntity<PersonaResponse>
+                +findAllSantander() ResponseEntity<List<PersonaResponse>>
+                +findInscriptosSinChequera(...) ResponseEntity<List<PersonaResponse>>
+                +findDeudoresByLectivo(...) ResponseEntity<List<PersonaResponse>>
+                +findUnifieds(String) ResponseEntity<List<PersonaResponse>>
+                +findByStrings(...) ResponseEntity<List<PersonaResponse>>
+                +getDeudaPersona(...) ResponseEntity<DeudaPersonaDto>
+                +getInscripcionFull(...) ResponseEntity<InscripcionFullDto>
+                +create(PersonaRequest) ResponseEntity<PersonaResponse>
+                +update(PersonaRequest) ResponseEntity<PersonaResponse>
             }
 
             class PersonaRequest

--- a/docs/hexagonal-reservaVacante.mmd
+++ b/docs/hexagonal-reservaVacante.mmd
@@ -24,7 +24,7 @@ classDiagram
         class ReservaVacanteRepository {
             <<interface>>
             +create(ReservaVacante) ReservaVacante
-            +findByReservaVacanteId(UUID) Optional~ReservaVacante~
+            +findByReservaVacanteId(UUID) Optional<ReservaVacante>
             +update(ReservaVacante, UUID) ReservaVacante
         }
     }
@@ -91,14 +91,14 @@ classDiagram
 
             class JpaReservaVacanteRepository {
                 <<JpaRepository>>
-                +findByReservaVacanteId(UUID) Optional~ReservaVacanteEntity~
+                +findByReservaVacanteId(UUID) Optional<ReservaVacanteEntity>
             }
 
             class JpaReservaVacanteRepositoryAdapter {
                 -JpaReservaVacanteRepository repository
                 -ReservaVacanteMapper mapper
                 +create(ReservaVacante) ReservaVacante
-                +findByReservaVacanteId(UUID) Optional~ReservaVacante~
+                +findByReservaVacanteId(UUID) Optional<ReservaVacante>
                 +update(ReservaVacante, UUID) ReservaVacante
             }
 
@@ -112,8 +112,8 @@ classDiagram
             class ReservaVacanteController {
                 -ReservaVacanteService reservaVacanteService
                 -ReservaVacanteDtoMapper reservaVacanteDtoMapper
-                +add(ReservaVacanteRequest) ResponseEntity~ReservaVacanteResponse~
-                +get(UUID) ResponseEntity~ReservaVacanteResponse~
+                +add(ReservaVacanteRequest) ResponseEntity<ReservaVacanteResponse>
+                +get(UUID) ResponseEntity<ReservaVacanteResponse>
             }
 
             class ReservaVacanteRequest {

--- a/docs/sequence-consulta-articulos.mmd
+++ b/docs/sequence-consulta-articulos.mmd
@@ -14,31 +14,31 @@ sequenceDiagram
     Ctrl->>S: getPaginated(0, 10)
     S->>R: findPaginated(Pageable)
     R->>DB: SELECT * FROM articulos LIMIT 10 OFFSET 0
-    DB-->>R: Page~ArticuloEntity~
-    R-->>S: PaginatedResponse~Articulo~
-    S-->>Ctrl: PaginatedResponse~ArticuloResponse~
+    DB-->>R: Page<ArticuloEntity>
+    R-->>S: PaginatedResponse<Articulo>
+    S-->>Ctrl: PaginatedResponse<ArticuloResponse>
     Ctrl->>CS: findByNumeroCuenta(numeroCuenta)
-    CS-->>Ctrl: Optional~Cuenta~
-    Ctrl-->>C: ResponseEntity~PaginatedResponse~ 200 OK
+    CS-->>Ctrl: Optional<Cuenta>
+    Ctrl-->>C: ResponseEntity<PaginatedResponse> 200 OK
 
     %% Búsqueda por criterio
     C->>Ctrl: POST /articulo/search
     Ctrl->>S: searchArticulos(conditions)
     S->>R: search(criterio)
     R->>DB: SELECT * FROM articulos WHERE condiciones
-    DB-->>R: List~ArticuloSearch~
-    R-->>S: List~ArticuloSearch~
-    S-->>Ctrl: List~ArticuloSearchResponse~
+    DB-->>R: List<ArticuloSearch>
+    R-->>S: List<ArticuloSearch>
+    S-->>Ctrl: List<ArticuloSearchResponse>
     Ctrl->>CS: findByNumeroCuenta(numeroCuenta)
-    CS-->>Ctrl: Optional~Cuenta~
-    Ctrl-->>C: ResponseEntity~List~ArticuloSearchResponse~~ 200 OK
+    CS-->>Ctrl: Optional<Cuenta>
+    Ctrl-->>C: ResponseEntity<List<ArticuloSearchResponse>> 200 OK
 
     %% Consulta general
     C->>Ctrl: GET /articulo/
     Ctrl->>S: getAllArticulos()
     S->>R: findAll()
     R->>DB: SELECT * FROM articulos
-    DB-->>R: List~ArticuloEntity~
-    R-->>S: List~Articulo~
-    S-->>Ctrl: List~ArticuloResponse~
-    Ctrl-->>C: ResponseEntity~List~ArticuloResponse~~ 200 OK
+    DB-->>R: List<ArticuloEntity>
+    R-->>S: List<Articulo>
+    S-->>Ctrl: List<ArticuloResponse>
+    Ctrl-->>C: ResponseEntity<List<ArticuloResponse>> 200 OK


### PR DESCRIPTION
Closes #279

## Descripción

Corregir la sintaxis de genéricos en los diagramas Mermaid (`*.mmd`) de arquitectura hexagonal y secuencia. Los archivos usaban virgulillas (`~`) para tipos genéricos (ej: `List~String~`) cuando Mermaid requiere angular (`<>`) (ej: `List<String>`). Se actualiza también la versión del servicio a `3.33.1` y el `CHANGELOG.md`.

## Cambios Realizados

- Corregida sintaxis de genéricos en 20 diagramas Mermaid (`~` → `<>`)
  - 18 diagramas `hexagonal-*.mmd`
  - 1 diagrama `sequence-consulta-articulos.mmd`
  - Ejemplos: `List~Documento~` → `List<Documento>`, `Optional~Facultad~` → `Optional<Facultad>`, `ResponseEntity~List~Foo~~` → `ResponseEntity<List<Foo>>`
- Actualizado `docs/README.md` con versión `3.33.1`
- Actualizado `README.md` con versión `3.33.1` y sección de novedades
- Actualizado `CHANGELOG.md` con entrada para `3.33.1`

## Archivos Modificados

- `CHANGELOG.md`
- `README.md`
- `docs/README.md`
- `docs/hexagonal-*.mmd` (18 archivos)
- `docs/sequence-consulta-articulos.mmd`

## Verificación

- Los cambios son puramente sintácticos en diagramas de documentación, sin impacto en código fuente ni funcionalidad.
- La corrección asegura compatibilidad con parsers y herramientas de renderizado Mermaid v10+.
- Verificado mediante `git diff` (20 archivos, +464/-441 líneas).