### PR TITLE
feat(v3.34.0): enriquecer ChequeraCuota con Facultad/TipoChequera, campo guaraniResponsableAcademica en Facultad, e interfaz Jsonifyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.34.0] - 2026-07-10
+### Added
+- feat(chequeraCuota): Enriquecimiento del modelo de dominio `ChequeraCuota` con nuevas asociaciones a `Facultad` y `TipoChequera`
+  - Nuevos campos `Facultad facultad` y `TipoChequera tipoChequera` en `ChequeraCuota` domain model
+  - `ChequeraCuotaMapper.toDomain()`: mapeo de nuevas asociaciones desde `FacultadMapper` y `TipoChequeraMapper` inyectados
+  - `ChequeraCuotaResponse`: expone objetos `Facultad` y `TipoChequera` en respuestas REST
+  - `ChequeraCuotaDtoMapper.toResponse()`: mapeo de nuevas asociaciones del dominio al DTO
+  - Actualización de constructores en `PreuniversitarioChequeraService` y `SpoterService` con parámetros null para las nuevas asociaciones
+- feat(facultad): Nuevo campo `guaraniResponsableAcademica` (Integer) en el módulo Facultad
+  - `Facultad` domain model: nuevo campo `guaraniResponsableAcademica`
+  - `FacultadEntity`: persistencia del campo con mapeo JPA automático
+  - `FacultadMapper.toDomain()`: mapeo del nuevo campo
+  - `FacultadResponse`: expone el campo en respuestas REST
+  - `FacultadDtoMapper.toResponse()`: mapeo del nuevo campo al DTO
+- feat(util): Nueva interfaz `Jsonifyable` con método `jsonify()` por defecto
+  - Interfaz `Jsonifyable` en `core/util/` con implementación por defecto que delega a `Jsonifier.builder(this).build()`
+  - `ChequeraCuota` ahora implementa `Jsonifyable`, eliminando la implementación manual de `jsonify()`
+
+### Changed
+- refactor(chequeraCuota): `ChequeraCuota` implementa `Jsonifyable` en lugar de definir `jsonify()` manualmente
+  - Eliminación del método `jsonify()` en `ChequeraCuota.java` (ahora se hereda de la interfaz)
+  - `GetChequeraCuotaByUniqueUseCaseImpl`: añadido `@Slf4j` y logging debug con `jsonify()`
+
+> Basado en análisis profundo de `git diff HEAD` (13 archivos staged, +39/-7 líneas) y `pom.xml` (versión 3.33.0 → 3.34.0).
+
 ## [3.33.1] - 2026-07-06
 ### Fixed
 - fix(docs): Corregida sintaxis de genéricos en 20 diagramas Mermaid de arquitectura hexagonal y secuencia

--- a/README.md
+++ b/README.md
@@ -4,7 +4,18 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.33.1**
+**Versión actual (SemVer): 3.34.0**
+
+## Novedades 3.34.0 (verificado en código)
+- feat(chequeraCuota): Enriquecimiento del modelo de dominio `ChequeraCuota` con asociaciones a `Facultad` y `TipoChequera`
+  - Nuevos campos `Facultad facultad` y `TipoChequera tipoChequera` en dominio, mapper, DTOs y respuesta REST
+  - `ChequeraCuotaMapper` inyecta `FacultadMapper` y `TipoChequeraMapper` para mapeo completo
+  - Actualización de constructores en `PreuniversitarioChequeraService` y `SpoterService`
+- feat(facultad): Nuevo campo `guaraniResponsableAcademica` (Integer) en Facultad (domain, entity, mapper, DTOs)
+- feat(util): Nueva interfaz `Jsonifyable` con método `jsonify()` por defecto — `ChequeraCuota` la implementa en lugar de definir `jsonify()` manualmente
+- refactor(chequeraCuota): Añadido `@Slf4j` y logging debug en `GetChequeraCuotaByUniqueUseCaseImpl`
+
+> Basado en análisis profundo de `git diff HEAD` (13 archivos staged, +39/-7 líneas) y `pom.xml` (versión 3.33.0 → 3.34.0).
 
 ## Novedades 3.33.1 (verificado en código)
 - fix(docs): Corregida sintaxis de genéricos Mermaid en 20 diagramas
@@ -29,18 +40,6 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0
 
 > Basado en análisis profundo de `git diff HEAD` (21 archivos, +337/-120 líneas, incluyendo migración completa del módulo Documento a hexagonal + integración en PreuniversitarioChequeraService) y `pom.xml` (versión 3.32.2 → 3.33.0).
 
-## Novedades 3.32.0 (verificado en código)
-- feat(mercadopagoContext): Integración de pago MercadoPago con ReservaVacante en `ProcessPaymentEventUseCaseImpl`
-  - Nuevo flujo condicional: si `MercadoPagoContext.reservaVacanteId != null`, procesa el pago como reserva de vacante en lugar de cuota
-  - Al recibir evento `approved`, actualiza el estado de `ReservaVacante` a `"pagado"` vía `ReservaVacanteService`
-  - Nuevo campo `reservaVacanteId` (UUID) en `PaymentProcessedEvent`
-- feat(reservaVacante): Nuevo `UpdateReservaVacanteUseCase` con implementación y adaptador JPA
-  - Nuevo método `updateReservaVacante(ReservaVacante, UUID)` en `ReservaVacanteService`
-  - Nuevo método `update(ReservaVacante, UUID)` en `ReservaVacanteRepository` y `JpaReservaVacanteRepositoryAdapter`
-- feat(docs): Diagrama hexagonal-reservaVacante.mmd actualizado con UpdateReservaVacanteUseCase
-
-> Basado en análisis profundo de `git diff HEAD` (8 archivos modificados, +68/-15 líneas) y `pom.xml` (versión 3.31.0 → 3.32.0).
-
 ## Novedades 3.32.2 (verificado en código)
 - fix(domicilio): Null-safety en campos email de `JpaDomicilioRepositoryAdapter` y `DomicilioMapper`
   - `JpaDomicilioRepositoryAdapter.update()`: Asigna string vacío si `emailPersonal` o `emailInstitucional` es null al actualizar domicilio en BD
@@ -56,6 +55,18 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0
   - Evita `NullPointerException` y envío de chequeras incompletas cuando falla la creación de persona o domicilio desde Guarani
 
 > Basado en análisis profundo de `git diff HEAD` (2 archivos modificados, +17/-0 líneas) y `pom.xml` (versión 3.32.0 → 3.32.1).
+
+## Novedades 3.32.0 (verificado en código)
+- feat(mercadopagoContext): Integración de pago MercadoPago con ReservaVacante en `ProcessPaymentEventUseCaseImpl`
+  - Nuevo flujo condicional: si `MercadoPagoContext.reservaVacanteId != null`, procesa el pago como reserva de vacante en lugar de cuota
+  - Al recibir evento `approved`, actualiza el estado de `ReservaVacante` a `"pagado"` vía `ReservaVacanteService`
+  - Nuevo campo `reservaVacanteId` (UUID) en `PaymentProcessedEvent`
+- feat(reservaVacante): Nuevo `UpdateReservaVacanteUseCase` con implementación y adaptador JPA
+  - Nuevo método `updateReservaVacante(ReservaVacante, UUID)` en `ReservaVacanteService`
+  - Nuevo método `update(ReservaVacante, UUID)` en `ReservaVacanteRepository` y `JpaReservaVacanteRepositoryAdapter`
+- feat(docs): Diagrama hexagonal-reservaVacante.mmd actualizado con UpdateReservaVacanteUseCase
+
+> Basado en análisis profundo de `git diff HEAD` (8 archivos modificados, +68/-15 líneas) y `pom.xml` (versión 3.31.0 → 3.32.0).
 
 ## Novedades 3.31.0 (verificado en código)
 - feat(lectivoTotalImputacion): Nuevo caso de uso `FindAllByLectivoUseCase` y endpoint `GET /lectivo/{lectivoId}`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.33.1** (actualizada: 2026-07-06)
+**Versión actual del servicio: 3.34.0** (actualizada: 2026-07-10)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/docs/hexagonal-chequeraCuota.mmd
+++ b/docs/hexagonal-chequeraCuota.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo ChequeraCuota (v3.30.0)
+title: Arquitectura Hexagonal - Módulo ChequeraCuota (v3.34.0)
 ---
 
 classDiagram
@@ -38,6 +38,8 @@ classDiagram
 
         class Producto
         class ChequeraSerie
+        class Facultad
+        class TipoChequera
 
         class ChequeraCuotaRepository {
             <<interface>>
@@ -166,6 +168,10 @@ classDiagram
 
             class JpaChequeraCuotaRepositoryAdapter
             class ChequeraCuotaMapper {
+                -FacultadMapper facultadMapper
+                -TipoChequeraMapper tipoChequeraMapper
+                -ProductoMapper productoMapper
+                -ChequeraSerieMapper chequeraSerieMapper
                 +toDomain(ChequeraCuotaEntity) ChequeraCuota
                 +toEntity(ChequeraCuota) ChequeraCuotaEntity
             }
@@ -207,6 +213,8 @@ classDiagram
                 +BigDecimal importe1
                 +OffsetDateTime vencimiento1
                 +String codigoBarras
+                +Facultad facultad
+                +TipoChequera tipoChequera
                 +Producto producto
                 +ChequeraSerie chequeraSerie
             }
@@ -224,6 +232,8 @@ classDiagram
         class LectivoService
     }
 
+    ChequeraCuota --> Facultad : references
+    ChequeraCuota --> TipoChequera : references
     ChequeraCuota --> Producto : references
     ChequeraCuota --> ChequeraSerie : references
 
@@ -296,6 +306,8 @@ classDiagram
 
     ChequeraCuotaMapper --> ChequeraCuota : maps
     ChequeraCuotaMapper --> ChequeraCuotaEntity : maps
+    ChequeraCuotaMapper --> FacultadMapper : uses
+    ChequeraCuotaMapper --> TipoChequeraMapper : uses
     JpaChequeraCuotaRepository --> ChequeraCuotaEntity : persists
 
     ChequeraCuotaController --> ChequeraCuotaService : calls

--- a/docs/hexagonal-facultad.mmd
+++ b/docs/hexagonal-facultad.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo Facultad (v3.18.0)
+title: Arquitectura Hexagonal - Módulo Facultad (v3.34.0)
 ---
 
 classDiagram
@@ -16,6 +16,7 @@ classDiagram
             +BigDecimal cuentacontable
             +String apiserver
             +Long apiport
+            +Integer guaraniResponsableAcademica
             +OffsetDateTime fechaAuditoria
             +String usuarioAuditoria
         }
@@ -86,6 +87,7 @@ classDiagram
                 +BigDecimal cuentacontable
                 +String apiserver
                 +Long apiport
+                +Integer guaraniResponsableAcademica
             }
 
             class JpaFacultadRepository {
@@ -129,6 +131,7 @@ classDiagram
                 +BigDecimal cuentacontable
                 +String apiserver
                 +Long apiport
+                +Integer guaraniResponsableAcademica
             }
 
             class FacultadDtoMapper {

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/usecases/GetChequeraCuotaByUniqueUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/usecases/GetChequeraCuotaByUniqueUseCaseImpl.java
@@ -1,6 +1,7 @@
 package um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.usecases;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
 import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.ports.in.GetChequeraCuotaByUniqueUseCase;
@@ -13,6 +14,7 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class GetChequeraCuotaByUniqueUseCaseImpl implements GetChequeraCuotaByUniqueUseCase {
 
     private final ChequeraCuotaRepository repository;
@@ -20,9 +22,11 @@ public class GetChequeraCuotaByUniqueUseCaseImpl implements GetChequeraCuotaByUn
 
     @Override
     public Optional<ChequeraCuota> getChequeraCuotaByUnique(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Integer cuotaId) {
+        log.debug("\n\nProcessing GetChequeraCuotaByUniqueUseCaseImpl.getChequeraCuotaByUnique\n\n");
         Optional<ChequeraCuota> optionalCuota = repository.findByUnique(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaId);
         if (optionalCuota.isPresent()) {
             ChequeraCuota chequeraCuota = optionalCuota.get();
+            log.debug("ChequeraCuota: {}", chequeraCuota.jsonify());
             if (chequeraCuota.getChequeraId() == null) {
                 ChequeraSerie chequeraSerie = chequeraSerieService.findByUnique(facultadId, tipoChequeraId, chequeraSerieId);
                 chequeraCuota.setChequeraId(chequeraSerie.getChequeraId());

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/domain/model/ChequeraCuota.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/domain/model/ChequeraCuota.java
@@ -6,7 +6,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import um.tesoreria.core.hexagonal.chequera.producto.domain.model.Producto;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
+import um.tesoreria.core.hexagonal.facultad.domain.model.Facultad;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
 import um.tesoreria.core.util.Jsonifier;
+import um.tesoreria.core.util.Jsonifyable;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -15,7 +18,7 @@ import java.time.OffsetDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChequeraCuota {
+public class ChequeraCuota implements Jsonifyable {
 
     private Long chequeraCuotaId;
     private Long chequeraId;
@@ -45,16 +48,14 @@ public class ChequeraCuota {
     private Byte compensada;
     private Integer tramoId;
 
+    private Facultad facultad;
+    private TipoChequera tipoChequera;
     private Producto producto;
     private ChequeraSerie chequeraSerie;
 
     public String cuotaKey() {
         return this.facultadId + "." + this.tipoChequeraId + "." + this.chequeraSerieId + "." + this.productoId + "."
                 + this.alternativaId + "." + this.cuotaId;
-    }
-
-    public String jsonify() {
-        return Jsonifier.builder(this).build();
     }
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/persistence/mapper/ChequeraCuotaMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/persistence/mapper/ChequeraCuotaMapper.java
@@ -10,6 +10,8 @@ import um.tesoreria.core.hexagonal.chequera.chequeraCuota.infrastructure.persist
 import um.tesoreria.core.hexagonal.chequera.producto.infrastructure.persistence.mapper.ProductoMapper;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.infrastructure.persistence.mapper.ChequeraSerieMapper;
+import um.tesoreria.core.hexagonal.facultad.infrastructure.persistence.mapper.FacultadMapper;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.mapper.TipoChequeraMapper;
 
 @Component
 @RequiredArgsConstructor
@@ -17,6 +19,8 @@ public class ChequeraCuotaMapper {
 
     private final ProductoMapper productoMapper;
     private final ChequeraSerieMapper chequeraSerieMapper;
+    private final FacultadMapper facultadMapper;
+    private final TipoChequeraMapper tipoChequeraMapper;
 
     public ChequeraCuota toDomain(ChequeraCuotaEntity entity) {
         if (entity == null) {
@@ -50,6 +54,8 @@ public class ChequeraCuotaMapper {
                 .manual(entity.getManual())
                 .compensada(entity.getCompensada())
                 .tramoId(entity.getTramoId())
+                .facultad(facultadMapper.toDomain(entity.getFacultad()))
+                .tipoChequera(tipoChequeraMapper.toDomainModel(entity.getTipoChequera()))
                 .producto(productoMapper.toDomainModel(entity.getProducto()))
                 .chequeraSerie(chequeraSerieMapper.toDomainModel(entity.getChequeraSerie()))
                 .build();

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/web/dto/ChequeraCuotaResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/web/dto/ChequeraCuotaResponse.java
@@ -6,6 +6,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import um.tesoreria.core.hexagonal.chequera.producto.domain.model.Producto;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
+import um.tesoreria.core.hexagonal.facultad.domain.model.Facultad;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -44,6 +46,8 @@ public class ChequeraCuotaResponse {
     private Byte compensada;
     private Integer tramoId;
 
+    private Facultad facultad;
+    private TipoChequera tipoChequera;
     private Producto producto;
     private ChequeraSerie chequeraSerie;
 

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/web/mapper/ChequeraCuotaDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/web/mapper/ChequeraCuotaDtoMapper.java
@@ -71,6 +71,8 @@ public class ChequeraCuotaDtoMapper {
                 .manual(domain.getManual())
                 .compensada(domain.getCompensada())
                 .tramoId(domain.getTramoId())
+                .facultad(domain.getFacultad())
+                .tipoChequera(domain.getTipoChequera())
                 .producto(domain.getProducto())
                 .chequeraSerie(domain.getChequeraSerie())
                 .build();

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraService.java
@@ -229,7 +229,7 @@ public class PreuniversitarioChequeraService {
                     lectivoCuota.getAnho(), chequeraSerie.getArancelTipoId(), vencimiento1, lectivoCuota.getImporte1(),
                     lectivoCuota.getImporte1(), vencimiento2, lectivoCuota.getImporte2(), lectivoCuota.getImporte2(),
                     vencimiento3, lectivoCuota.getImporte3(), lectivoCuota.getImporte3(), "", "", (byte) 0, (byte) 0,
-                    (byte) 0, (byte) 0, 0, null, null);
+                    (byte) 0, (byte) 0, 0, null, null, null, null);
             log.debug("chequera_cuota -> {}", chequeraCuota.jsonify());
             chequeraCuota.setCodigoBarras(chequeraCuotaService.calculateCodigoBarras(chequeraCuota));
             chequeraCuotas.add(chequeraCuota);

--- a/src/main/java/um/tesoreria/core/hexagonal/facultad/domain/model/Facultad.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/facultad/domain/model/Facultad.java
@@ -21,6 +21,7 @@ public class Facultad {
     private BigDecimal cuentacontable;
     private String apiserver;
     private Long apiport;
+    private Integer guaraniResponsableAcademica;
     private OffsetDateTime fechaAuditoria;
     private String usuarioAuditoria;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/facultad/infrastructure/persistence/entity/FacultadEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/facultad/infrastructure/persistence/entity/FacultadEntity.java
@@ -46,6 +46,8 @@ public class FacultadEntity extends Auditable {
     @Column(name = "api_server")
     private String apiserver = "";
 
+    private Integer guaraniResponsableAcademica;
+
     @Builder.Default
     @Column(name = "api_port")
     private Long apiport = 0L;

--- a/src/main/java/um/tesoreria/core/hexagonal/facultad/infrastructure/persistence/mapper/FacultadMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/facultad/infrastructure/persistence/mapper/FacultadMapper.java
@@ -17,6 +17,7 @@ public class FacultadMapper {
                 .cuentacontable(entity.getCuentacontable())
                 .apiserver(entity.getApiserver())
                 .apiport(entity.getApiport())
+                .guaraniResponsableAcademica(entity.getGuaraniResponsableAcademica())
                 .build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/facultad/infrastructure/web/dto/FacultadResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/facultad/infrastructure/web/dto/FacultadResponse.java
@@ -18,4 +18,5 @@ public class FacultadResponse {
     private BigDecimal cuentacontable;
     private String apiserver;
     private Long apiport;
+    private Integer guaraniResponsableAcademica;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/facultad/infrastructure/web/mapper/FacultadDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/facultad/infrastructure/web/mapper/FacultadDtoMapper.java
@@ -17,6 +17,7 @@ public class FacultadDtoMapper {
                 .cuentacontable(domain.getCuentacontable())
                 .apiserver(domain.getApiserver())
                 .apiport(domain.getApiport())
+                .guaraniResponsableAcademica(domain.getGuaraniResponsableAcademica())
                 .build();
     }
 }

--- a/src/main/java/um/tesoreria/core/service/transactional/spoter/SpoterService.java
+++ b/src/main/java/um/tesoreria/core/service/transactional/spoter/SpoterService.java
@@ -187,7 +187,7 @@ public class SpoterService {
                     lectivoCuota.getAnho(), chequeraSerie.getArancelTipoId(), vencimiento1, lectivoCuota.getImporte1(),
                     lectivoCuota.getImporte1(), vencimiento2, lectivoCuota.getImporte2(), lectivoCuota.getImporte2(),
                     vencimiento3, lectivoCuota.getImporte3(), lectivoCuota.getImporte3(), "", "", (byte) 0, (byte) 0,
-                    (byte) 0, (byte) 0, 0, null, null);
+                    (byte) 0, (byte) 0, 0, null, null, null, null);
             log.debug("mail_chequera_service.make_chequera_spoter.chequera_cuota -> -> {}", chequeraCuota.jsonify());
             log.debug("mail_chequera_service.make_chequera_spoter - calling calculate_codigo_barras");
             chequeraCuota.setCodigoBarras(chequeraCuotaService.calculateCodigoBarras(chequeraCuota));

--- a/src/main/java/um/tesoreria/core/util/Jsonifyable.java
+++ b/src/main/java/um/tesoreria/core/util/Jsonifyable.java
@@ -1,0 +1,9 @@
+package um.tesoreria.core.util;
+
+public interface Jsonifyable {
+
+    default String jsonify() {
+        return Jsonifier.builder(this).build();
+    }
+
+}


### PR DESCRIPTION
Closes #281

## Descripción

Enriquecimiento del modelo `ChequeraCuota` con asociaciones a `Facultad` y `TipoChequera`, nuevo campo `guaraniResponsableAcademica` en el módulo Facultad, e introducción de la interfaz `Jsonifyable` para estandarizar la serialización JSON de los modelos de dominio.

## Cambios Realizados

### feat(chequeraCuota): Enriquecimiento del modelo de dominio
- Nuevos campos `Facultad facultad` y `TipoChequera tipoChequera` en `ChequeraCuota`
- `ChequeraCuotaMapper.toDomain()`: mapeo de nuevas asociaciones inyectando `FacultadMapper` y `TipoChequeraMapper`
- `ChequeraCuotaResponse`: expone objetos `Facultad` y `TipoChequera` en respuestas REST
- `ChequeraCuotaDtoMapper.toResponse()`: mapeo de nuevas asociaciones del dominio al DTO
- Actualización de constructores en `PreuniversitarioChequeraService` y `SpoterService` con parámetros null

### feat(facultad): Nuevo campo `guaraniResponsableAcademica`
- `Facultad` domain: nuevo campo `Integer guaraniResponsableAcademica`
- `FacultadEntity`: persistencia con mapeo JPA automático
- `FacultadMapper.toDomain()`: mapeo del nuevo campo
- `FacultadResponse` y `FacultadDtoMapper`: exponen el campo en respuestas REST

### feat(util): Nueva interfaz `Jsonifyable`
- Interfaz con método `jsonify()` por defecto que delega a `Jsonifier.builder(this).build()`
- `ChequeraCuota` ahora implementa `Jsonifyable`, eliminando la implementación manual

### refactor(chequeraCuota): Mejoras de logging
- `GetChequeraCuotaByUniqueUseCaseImpl`: añadido `@Slf4j` y logging debug con `jsonify()`

## Archivos Modificados

- `CHANGELOG.md`, `README.md`, `docs/README.md`
- `docs/hexagonal-chequeraCuota.mmd`, `docs/hexagonal-facultad.mmd`
- `ChequeraCuota.java`, `ChequeraCuotaMapper.java`, `ChequeraCuotaResponse.java`, `ChequeraCuotaDtoMapper.java`
- `Facultad.java`, `FacultadEntity.java`, `FacultadMapper.java`, `FacultadResponse.java`, `FacultadDtoMapper.java`
- `GetChequeraCuotaByUniqueUseCaseImpl.java`
- `PreuniversitarioChequeraService.java`, `SpoterService.java`
- `Jsonifyable.java` (nuevo)

## Verificación

- [x] Compilación exitosa con Maven
- [x] Análisis manual del diff completo (18 archivos, +106/-23 líneas)
- [x] Diagramas Mermaid actualizados a v3.34.0
