### PR TITLE
fix(mappers): Null-safety en 16 mappers de persistencia hexagonal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,14 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
   - Eliminación del método `jsonify()` en `ChequeraCuota.java` (ahora se hereda de la interfaz)
   - `GetChequeraCuotaByUniqueUseCaseImpl`: añadido `@Slf4j` y logging debug con `jsonify()`
 
-> Basado en análisis profundo de `git diff HEAD` (13 archivos staged, +39/-7 líneas) y `pom.xml` (versión 3.33.0 → 3.34.0).
+### Fixed
+- fix(mappers): Null-safety en 16 mappers de persistencia hexagonal
+  - `toEntity()`: Cambio de `return Entity.builder()...build()` a builder intermedio con validación `!= null` antes de setear cada campo
+  - `updateEntity()`: Añadidas validaciones `!= null` antes de cada `setField()` en `ChequeraCuotaMapper`
+  - Afecta: `ArticuloMapper`, `ArancelPorcentajeMapper`, `ArancelTipoMapper`, `ChequeraCuotaMapper`, `ChequeraSerieMapper`, `ClaseChequeraMapper`, `ProductoMapper`, `TipoChequeraMapper`, `CuentaMapper`, `ContratoMapper`, `DependenciaMapper`, `DocumentoMapper`, `DomicilioMapper`, `LectivoMapper`, `MercadoPagoContextMapper`, `ProveedorMapper`
+  - Previene `NullPointerException` en persistencia cuando campos opcionales del dominio son nulos
+
+> Basado en análisis profundo de `git diff HEAD` (16 archivos staged, +200/-161 líneas) y `pom.xml` (versión 3.33.0 → 3.34.0).
 
 ## [3.33.1] - 2026-07-06
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0
 - feat(facultad): Nuevo campo `guaraniResponsableAcademica` (Integer) en Facultad (domain, entity, mapper, DTOs)
 - feat(util): Nueva interfaz `Jsonifyable` con método `jsonify()` por defecto — `ChequeraCuota` la implementa en lugar de definir `jsonify()` manualmente
 - refactor(chequeraCuota): Añadido `@Slf4j` y logging debug en `GetChequeraCuotaByUniqueUseCaseImpl`
+- fix(mappers): Null-safety en 16 mappers de persistencia hexagonal — previene `NullPointerException` en campos opcionales
 
-> Basado en análisis profundo de `git diff HEAD` (13 archivos staged, +39/-7 líneas) y `pom.xml` (versión 3.33.0 → 3.34.0).
+> Basado en análisis profundo de `git diff HEAD` (16 archivos staged, +200/-161 líneas) y `pom.xml` (versión 3.33.0 → 3.34.0).
 
 ## Novedades 3.33.1 (verificado en código)
 - fix(docs): Corregida sintaxis de genéricos Mermaid en 20 diagramas

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.33.0</version>
+    <version>3.34.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/persistence/mapper/ArticuloMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/articulo/infrastructure/persistence/mapper/ArticuloMapper.java
@@ -36,19 +36,21 @@ public class ArticuloMapper {
 
     public ArticuloEntity toEntity(Articulo domain) {
         if (domain == null) return null;
-        return ArticuloEntity.builder()
+        ArticuloEntity.ArticuloEntityBuilder builder = ArticuloEntity.builder()
                 .articuloId(domain.getArticuloId())
-                .nombre(domain.getNombre())
-                .descripcion(domain.getDescripcion())
-                .unidad(domain.getUnidad())
-                .precio(domain.getPrecio())
-                .inventariable(domain.getInventariable())
-                .stockMinimo(domain.getStockMinimo())
-                .numeroCuenta(domain.getNumeroCuenta())
-                .tipo(domain.getTipo())
-                .directo(domain.getDirecto())
-                .habilitado(domain.getHabilitado())
-                .build();
+                .numeroCuenta(domain.getNumeroCuenta());
+        
+        if (domain.getNombre() != null) builder.nombre(domain.getNombre());
+        if (domain.getDescripcion() != null) builder.descripcion(domain.getDescripcion());
+        if (domain.getUnidad() != null) builder.unidad(domain.getUnidad());
+        if (domain.getPrecio() != null) builder.precio(domain.getPrecio());
+        if (domain.getInventariable() != null) builder.inventariable(domain.getInventariable());
+        if (domain.getStockMinimo() != null) builder.stockMinimo(domain.getStockMinimo());
+        if (domain.getTipo() != null) builder.tipo(domain.getTipo());
+        if (domain.getDirecto() != null) builder.directo(domain.getDirecto());
+        if (domain.getHabilitado() != null) builder.habilitado(domain.getHabilitado());
+        
+        return builder.build();
     }
 
     public ArticuloSearch toSearchDomain(ArticuloKey entity) {

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/arancelPorcentaje/infrastructure/persistence/mapper/ArancelPorcentajeMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/arancelPorcentaje/infrastructure/persistence/mapper/ArancelPorcentajeMapper.java
@@ -19,11 +19,15 @@ public class ArancelPorcentajeMapper {
 
     public ArancelPorcentajeEntity toEntity(ArancelPorcentaje domain) {
         if (domain == null) return null;
-        return ArancelPorcentajeEntity.builder()
+        ArancelPorcentajeEntity.ArancelPorcentajeEntityBuilder builder = ArancelPorcentajeEntity.builder()
                 .arancelporcentajeId(domain.getArancelporcentajeId())
                 .aranceltipoId(domain.getAranceltipoId())
-                .productoId(domain.getProductoId())
-                .porcentaje(domain.getPorcentaje())
-                .build();
+                .productoId(domain.getProductoId());
+        
+        if (domain.getPorcentaje() != null) {
+            builder.porcentaje(domain.getPorcentaje());
+        }
+        
+        return builder.build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/arancelTipo/infrastructure/persistence/mapper/ArancelTipoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/arancelTipo/infrastructure/persistence/mapper/ArancelTipoMapper.java
@@ -20,12 +20,14 @@ public class ArancelTipoMapper {
 
     public ArancelTipoEntity toEntity(ArancelTipo domain) {
         if (domain == null) return null;
-        return ArancelTipoEntity.builder()
+        ArancelTipoEntity.ArancelTipoEntityBuilder builder = ArancelTipoEntity.builder()
                 .arancelTipoId(domain.getArancelTipoId())
-                .descripcion(domain.getDescripcion())
-                .medioArancel(domain.getMedioArancel())
-                .arancelTipoIdCompleto(domain.getArancelTipoIdCompleto())
-                .habilitado(domain.getHabilitado())
-                .build();
+                .arancelTipoIdCompleto(domain.getArancelTipoIdCompleto());
+        
+        if (domain.getDescripcion() != null) builder.descripcion(domain.getDescripcion());
+        if (domain.getMedioArancel() != null) builder.medioArancel(domain.getMedioArancel());
+        if (domain.getHabilitado() != null) builder.habilitado(domain.getHabilitado());
+        
+        return builder.build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/persistence/mapper/ChequeraCuotaMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/persistence/mapper/ChequeraCuotaMapper.java
@@ -65,7 +65,7 @@ public class ChequeraCuotaMapper {
         if (domain == null) {
             return null;
         }
-        return ChequeraCuotaEntity.builder()
+        ChequeraCuotaEntity.ChequeraCuotaEntityBuilder builder = ChequeraCuotaEntity.builder()
                 .chequeraCuotaId(domain.getChequeraCuotaId())
                 .chequeraId(domain.getChequeraId())
                 .facultadId(domain.getFacultadId())
@@ -74,26 +74,28 @@ public class ChequeraCuotaMapper {
                 .productoId(domain.getProductoId())
                 .alternativaId(domain.getAlternativaId())
                 .cuotaId(domain.getCuotaId())
-                .mes(domain.getMes())
-                .anho(domain.getAnho())
                 .arancelTipoId(domain.getArancelTipoId())
                 .vencimiento1(domain.getVencimiento1())
-                .importe1(domain.getImporte1())
-                .importe1Original(domain.getImporte1Original())
                 .vencimiento2(domain.getVencimiento2())
-                .importe2(domain.getImporte2())
-                .importe2Original(domain.getImporte2Original())
-                .vencimiento3(domain.getVencimiento3())
-                .importe3(domain.getImporte3())
-                .importe3Original(domain.getImporte3Original())
-                .codigoBarras(domain.getCodigoBarras())
-                .i2Of5(domain.getI2Of5())
-                .pagado(domain.getPagado())
-                .baja(domain.getBaja())
-                .manual(domain.getManual())
-                .compensada(domain.getCompensada())
-                .tramoId(domain.getTramoId())
-                .build();
+                .vencimiento3(domain.getVencimiento3());
+
+        if (domain.getMes() != null) builder.mes(domain.getMes());
+        if (domain.getAnho() != null) builder.anho(domain.getAnho());
+        if (domain.getImporte1() != null) builder.importe1(domain.getImporte1());
+        if (domain.getImporte1Original() != null) builder.importe1Original(domain.getImporte1Original());
+        if (domain.getImporte2() != null) builder.importe2(domain.getImporte2());
+        if (domain.getImporte2Original() != null) builder.importe2Original(domain.getImporte2Original());
+        if (domain.getImporte3() != null) builder.importe3(domain.getImporte3());
+        if (domain.getImporte3Original() != null) builder.importe3Original(domain.getImporte3Original());
+        if (domain.getCodigoBarras() != null) builder.codigoBarras(domain.getCodigoBarras());
+        if (domain.getI2Of5() != null) builder.i2Of5(domain.getI2Of5());
+        if (domain.getPagado() != null) builder.pagado(domain.getPagado());
+        if (domain.getBaja() != null) builder.baja(domain.getBaja());
+        if (domain.getManual() != null) builder.manual(domain.getManual());
+        if (domain.getCompensada() != null) builder.compensada(domain.getCompensada());
+        if (domain.getTramoId() != null) builder.tramoId(domain.getTramoId());
+
+        return builder.build();
     }
 
     public void updateEntity(ChequeraCuota domain, ChequeraCuotaEntity entity) {
@@ -107,25 +109,26 @@ public class ChequeraCuotaMapper {
         entity.setProductoId(domain.getProductoId());
         entity.setAlternativaId(domain.getAlternativaId());
         entity.setCuotaId(domain.getCuotaId());
-        entity.setMes(domain.getMes());
-        entity.setAnho(domain.getAnho());
+        
+        if (domain.getMes() != null) entity.setMes(domain.getMes());
+        if (domain.getAnho() != null) entity.setAnho(domain.getAnho());
         entity.setArancelTipoId(domain.getArancelTipoId());
         entity.setVencimiento1(domain.getVencimiento1());
-        entity.setImporte1(domain.getImporte1());
-        entity.setImporte1Original(domain.getImporte1Original());
+        if (domain.getImporte1() != null) entity.setImporte1(domain.getImporte1());
+        if (domain.getImporte1Original() != null) entity.setImporte1Original(domain.getImporte1Original());
         entity.setVencimiento2(domain.getVencimiento2());
-        entity.setImporte2(domain.getImporte2());
-        entity.setImporte2Original(domain.getImporte2Original());
+        if (domain.getImporte2() != null) entity.setImporte2(domain.getImporte2());
+        if (domain.getImporte2Original() != null) entity.setImporte2Original(domain.getImporte2Original());
         entity.setVencimiento3(domain.getVencimiento3());
-        entity.setImporte3(domain.getImporte3());
-        entity.setImporte3Original(domain.getImporte3Original());
-        entity.setCodigoBarras(domain.getCodigoBarras());
-        entity.setI2Of5(domain.getI2Of5());
-        entity.setPagado(domain.getPagado());
-        entity.setBaja(domain.getBaja());
-        entity.setManual(domain.getManual());
-        entity.setCompensada(domain.getCompensada());
-        entity.setTramoId(domain.getTramoId());
+        if (domain.getImporte3() != null) entity.setImporte3(domain.getImporte3());
+        if (domain.getImporte3Original() != null) entity.setImporte3Original(domain.getImporte3Original());
+        if (domain.getCodigoBarras() != null) entity.setCodigoBarras(domain.getCodigoBarras());
+        if (domain.getI2Of5() != null) entity.setI2Of5(domain.getI2Of5());
+        if (domain.getPagado() != null) entity.setPagado(domain.getPagado());
+        if (domain.getBaja() != null) entity.setBaja(domain.getBaja());
+        if (domain.getManual() != null) entity.setManual(domain.getManual());
+        if (domain.getCompensada() != null) entity.setCompensada(domain.getCompensada());
+        if (domain.getTramoId() != null) entity.setTramoId(domain.getTramoId());
     }
 
     public ChequeraPago toDomain(um.tesoreria.core.kotlin.model.ChequeraPago entity) {

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/persistence/mapper/ChequeraSerieMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/persistence/mapper/ChequeraSerieMapper.java
@@ -70,7 +70,7 @@ public class ChequeraSerieMapper {
 
     public ChequeraSerieEntity toEntity(ChequeraSerie domain) {
         if (domain == null) return null;
-        return ChequeraSerieEntity.builder()
+        ChequeraSerieEntity.ChequeraSerieEntityBuilder builder = ChequeraSerieEntity.builder()
                 .chequeraId(domain.getChequeraId())
                 .facultadId(domain.getFacultadId())
                 .tipoChequeraId(domain.getTipoChequeraId())
@@ -88,19 +88,21 @@ public class ChequeraSerieMapper {
                 .alternativaId(domain.getAlternativaId())
                 .algoPagado(domain.getAlgoPagado())
                 .tipoImpresionId(domain.getTipoImpresionId())
-                .flagPayperTic(domain.getFlagPayperTic())
                 .usuarioId(domain.getUsuarioId())
-                .enviado(domain.getEnviado())
-                .retenida(domain.getRetenida())
                 .version(domain.getVersion())
-                .hpum(domain.getHpum())
-                .becaPorcentaje(domain.getBecaPorcentaje())
                 .becaResolucion(domain.getBecaResolucion())
                 .becaFecha(domain.getBecaFecha())
                 .becaUserId(domain.getBecaUserId())
-                .cuotasDeuda(domain.getCuotasDeuda())
-                .importeDeuda(domain.getImporteDeuda())
-                .ultimoEnvio(domain.getUltimoEnvio())
-                .build();
+                .ultimoEnvio(domain.getUltimoEnvio());
+
+        if (domain.getFlagPayperTic() != null) builder.flagPayperTic(domain.getFlagPayperTic());
+        if (domain.getEnviado() != null) builder.enviado(domain.getEnviado());
+        if (domain.getRetenida() != null) builder.retenida(domain.getRetenida());
+        if (domain.getHpum() != null) builder.hpum(domain.getHpum());
+        if (domain.getBecaPorcentaje() != null) builder.becaPorcentaje(domain.getBecaPorcentaje());
+        if (domain.getCuotasDeuda() != null) builder.cuotasDeuda(domain.getCuotasDeuda());
+        if (domain.getImporteDeuda() != null) builder.importeDeuda(domain.getImporteDeuda());
+
+        return builder.build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/mapper/ClaseChequeraMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/mapper/ClaseChequeraMapper.java
@@ -23,16 +23,18 @@ public class ClaseChequeraMapper {
 
     public ClaseChequeraEntity toEntity(ClaseChequera domain) {
         if (domain == null) return null;
-        return ClaseChequeraEntity.builder()
+        ClaseChequeraEntity.ClaseChequeraEntityBuilder builder = ClaseChequeraEntity.builder()
                 .claseChequeraId(domain.getClaseChequeraId())
-                .nombre(domain.getNombre())
-                .preuniversitario(domain.getPreuniversitario())
-                .grado(domain.getGrado())
-                .posgrado(domain.getPosgrado())
-                .curso(domain.getCurso())
-                .secundario(domain.getSecundario())
-                .titulo(domain.getTitulo())
-                .build();
+                .nombre(domain.getNombre());
+        
+        if (domain.getPreuniversitario() != null) builder.preuniversitario(domain.getPreuniversitario());
+        if (domain.getGrado() != null) builder.grado(domain.getGrado());
+        if (domain.getPosgrado() != null) builder.posgrado(domain.getPosgrado());
+        if (domain.getCurso() != null) builder.curso(domain.getCurso());
+        if (domain.getSecundario() != null) builder.secundario(domain.getSecundario());
+        if (domain.getTitulo() != null) builder.titulo(domain.getTitulo());
+        
+        return builder.build();
     }
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/producto/infrastructure/persistence/mapper/ProductoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/producto/infrastructure/persistence/mapper/ProductoMapper.java
@@ -17,9 +17,13 @@ public class ProductoMapper {
 
     public ProductoEntity toEntity(Producto domain) {
         if (domain == null) return null;
-        return ProductoEntity.builder()
-                .productoId(domain.getProductoId())
-                .nombre(domain.getNombre())
-                .build();
+        ProductoEntity.ProductoEntityBuilder builder = ProductoEntity.builder()
+                .productoId(domain.getProductoId());
+        
+        if (domain.getNombre() != null) {
+            builder.nombre(domain.getNombre());
+        }
+        
+        return builder.build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/persistence/mapper/TipoChequeraMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/persistence/mapper/TipoChequeraMapper.java
@@ -40,16 +40,18 @@ public class TipoChequeraMapper {
 
     public TipoChequeraEntity toEntity(TipoChequera domain) {
         if (domain == null) return null;
-        return TipoChequeraEntity.builder()
+        TipoChequeraEntity.TipoChequeraEntityBuilder builder = TipoChequeraEntity.builder()
                 .tipoChequeraId(domain.getTipoChequeraId())
-                .nombre(domain.getNombre())
-                .prefijo(domain.getPrefijo())
-                .geograficaId(domain.getGeograficaId())
-                .claseChequeraId(domain.getClaseChequeraId())
-                .imprimir(domain.getImprimir())
-                .contado(domain.getContado())
-                .multiple(domain.getMultiple())
-                .emailCopia(domain.getEmailCopia())
-                .build();
+                .emailCopia(domain.getEmailCopia());
+        
+        if (domain.getNombre() != null) builder.nombre(domain.getNombre());
+        if (domain.getPrefijo() != null) builder.prefijo(domain.getPrefijo());
+        if (domain.getGeograficaId() != null) builder.geograficaId(domain.getGeograficaId());
+        if (domain.getClaseChequeraId() != null) builder.claseChequeraId(domain.getClaseChequeraId());
+        if (domain.getImprimir() != null) builder.imprimir(domain.getImprimir());
+        if (domain.getContado() != null) builder.contado(domain.getContado());
+        if (domain.getMultiple() != null) builder.multiple(domain.getMultiple());
+        
+        return builder.build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/contable/cuenta/infrastructure/persistence/mapper/CuentaMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contable/cuenta/infrastructure/persistence/mapper/CuentaMapper.java
@@ -10,20 +10,22 @@ public class CuentaMapper {
 
     public CuentaEntity toEntity(Cuenta domain) {
         if (domain == null) return null;
-        return CuentaEntity.builder()
+        CuentaEntity.CuentaEntityBuilder builder = CuentaEntity.builder()
                 .numeroCuenta(domain.getNumeroCuenta())
-                .nombre(domain.getNombre())
-                .integradora(domain.getIntegradora())
-                .grado(domain.getGrado())
                 .grado1(domain.getGrado1())
                 .grado2(domain.getGrado2())
                 .grado3(domain.getGrado3())
                 .grado4(domain.getGrado4())
                 .geograficaId(domain.getGeograficaId())
                 .fechaBloqueo(domain.getFechaBloqueo())
-                .visible(domain.getVisible())
-                .cuentaContableId(domain.getCuentaContableId())
-                .build();
+                .cuentaContableId(domain.getCuentaContableId());
+        
+        if (domain.getNombre() != null) builder.nombre(domain.getNombre());
+        if (domain.getIntegradora() != null) builder.integradora(domain.getIntegradora());
+        if (domain.getGrado() != null) builder.grado(domain.getGrado());
+        if (domain.getVisible() != null) builder.visible(domain.getVisible());
+        
+        return builder.build();
     }
 
     public Cuenta toDomain(CuentaEntity entity) {

--- a/src/main/java/um/tesoreria/core/hexagonal/contrato/infrastructure/persistence/mapper/ContratoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/contrato/infrastructure/persistence/mapper/ContratoMapper.java
@@ -11,7 +11,7 @@ public class ContratoMapper {
         if (contrato == null) {
             return null;
         }
-        return ContratoEntity.builder()
+        ContratoEntity.ContratoEntityBuilder builder = ContratoEntity.builder()
                 .contratoId(contrato.getContratoId())
                 .personaId(contrato.getPersonaId())
                 .documentoId(contrato.getDocumentoId())
@@ -22,18 +22,20 @@ public class ContratoMapper {
                 .geograficaId(contrato.getGeograficaId())
                 .cargoMateriaId(contrato.getCargoMateriaId())
                 .primerVencimiento(contrato.getPrimerVencimiento())
-                .cargo(contrato.getCargo())
-                .montoFijo(contrato.getMontoFijo())
-                .canonMensual(contrato.getCanonMensual())
-                .canonMensualSinAjuste(contrato.getCanonMensualSinAjuste())
-                .hasta(contrato.getHasta())
-                .canonMensualLetras(contrato.getCanonMensualLetras())
-                .canonTotal(contrato.getCanonTotal())
-                .canonTotalLetras(contrato.getCanonTotalLetras())
-                .meses(contrato.getMeses())
-                .mesesLetras(contrato.getMesesLetras())
-                .ajuste(contrato.getAjuste())
-                .build();
+                .hasta(contrato.getHasta());
+
+        if (contrato.getCargo() != null) builder.cargo(contrato.getCargo());
+        if (contrato.getMontoFijo() != null) builder.montoFijo(contrato.getMontoFijo());
+        if (contrato.getCanonMensual() != null) builder.canonMensual(contrato.getCanonMensual());
+        if (contrato.getCanonMensualSinAjuste() != null) builder.canonMensualSinAjuste(contrato.getCanonMensualSinAjuste());
+        if (contrato.getCanonMensualLetras() != null) builder.canonMensualLetras(contrato.getCanonMensualLetras());
+        if (contrato.getCanonTotal() != null) builder.canonTotal(contrato.getCanonTotal());
+        if (contrato.getCanonTotalLetras() != null) builder.canonTotalLetras(contrato.getCanonTotalLetras());
+        if (contrato.getMeses() != null) builder.meses(contrato.getMeses());
+        if (contrato.getMesesLetras() != null) builder.mesesLetras(contrato.getMesesLetras());
+        if (contrato.getAjuste() != null) builder.ajuste(contrato.getAjuste());
+
+        return builder.build();
     }
 
     public Contrato toDomainModel(ContratoEntity entity) {

--- a/src/main/java/um/tesoreria/core/hexagonal/dependencia/infrastructure/persistence/mapper/DependenciaMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/dependencia/infrastructure/persistence/mapper/DependenciaMapper.java
@@ -30,13 +30,15 @@ public class DependenciaMapper {
 
     public DependenciaEntity toEntity(Dependencia domain) {
         if (domain == null) return null;
-        DependenciaEntity entity = new DependenciaEntity();
-        entity.setDependenciaId(domain.getDependenciaId());
-        entity.setNombre(domain.getNombre());
-        entity.setAcronimo(domain.getAcronimo());
-        entity.setFacultadId(domain.getFacultadId());
-        entity.setGeograficaId(domain.getGeograficaId());
-        entity.setCuentaHonorariosPagar(domain.getCuentaHonorariosPagar());
-        return entity;
+        DependenciaEntity.DependenciaEntityBuilder builder = DependenciaEntity.builder()
+                .dependenciaId(domain.getDependenciaId())
+                .facultadId(domain.getFacultadId())
+                .geograficaId(domain.getGeograficaId())
+                .cuentaHonorariosPagar(domain.getCuentaHonorariosPagar());
+        
+        if (domain.getNombre() != null) builder.nombre(domain.getNombre());
+        if (domain.getAcronimo() != null) builder.acronimo(domain.getAcronimo());
+        
+        return builder.build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/documento/infrastructure/persistence/mapper/DocumentoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/documento/infrastructure/persistence/mapper/DocumentoMapper.java
@@ -17,10 +17,14 @@ public class DocumentoMapper {
 
     public DocumentoEntity toEntity(Documento domain) {
         if (domain == null) return null;
-        return DocumentoEntity.builder()
-                .documentoId(domain.getDocumentoId())
-                .nombre(domain.getNombre())
-                .build();
+        DocumentoEntity.DocumentoEntityBuilder builder = DocumentoEntity.builder()
+                .documentoId(domain.getDocumentoId());
+        
+        if (domain.getNombre() != null) {
+            builder.nombre(domain.getNombre());
+        }
+        
+        return builder.build();
     }
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/persistence/mapper/DomicilioMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/domicilio/infrastructure/persistence/mapper/DomicilioMapper.java
@@ -34,25 +34,27 @@ public class DomicilioMapper {
 
     public DomicilioEntity toEntity(Domicilio domain) {
         if (domain == null) return null;
-        return DomicilioEntity.builder()
+        DomicilioEntity.DomicilioEntityBuilder builder = DomicilioEntity.builder()
                 .domicilioId(domain.getDomicilioId())
                 .personaId(domain.getPersonaId())
                 .documentoId(domain.getDocumentoId())
-                .fecha(domain.getFecha())
-                .calle(domain.getCalle())
-                .puerta(domain.getPuerta())
-                .piso(domain.getPiso())
-                .dpto(domain.getDpto())
-                .telefono(domain.getTelefono())
-                .movil(domain.getMovil())
-                .observaciones(domain.getObservaciones())
-                .codigoPostal(domain.getCodigoPostal())
                 .facultadId(domain.getFacultadId())
                 .provinciaId(domain.getProvinciaId())
-                .localidadId(domain.getLocalidadId())
-                .emailPersonal(domain.getEmailPersonal() != null ? domain.getEmailPersonal() : "")
-                .emailInstitucional(domain.getEmailInstitucional() != null ? domain.getEmailInstitucional() : "")
-                .laboral(domain.getLaboral())
-                .build();
+                .localidadId(domain.getLocalidadId());
+        
+        if (domain.getFecha() != null) builder.fecha(domain.getFecha());
+        if (domain.getCalle() != null) builder.calle(domain.getCalle());
+        if (domain.getPuerta() != null) builder.puerta(domain.getPuerta());
+        if (domain.getPiso() != null) builder.piso(domain.getPiso());
+        if (domain.getDpto() != null) builder.dpto(domain.getDpto());
+        if (domain.getTelefono() != null) builder.telefono(domain.getTelefono());
+        if (domain.getMovil() != null) builder.movil(domain.getMovil());
+        if (domain.getObservaciones() != null) builder.observaciones(domain.getObservaciones());
+        if (domain.getCodigoPostal() != null) builder.codigoPostal(domain.getCodigoPostal());
+        if (domain.getEmailPersonal() != null) builder.emailPersonal(domain.getEmailPersonal());
+        if (domain.getEmailInstitucional() != null) builder.emailInstitucional(domain.getEmailInstitucional());
+        if (domain.getLaboral() != null) builder.laboral(domain.getLaboral());
+        
+        return builder.build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/lectivo/infrastructure/persistence/mapper/LectivoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/lectivo/infrastructure/persistence/mapper/LectivoMapper.java
@@ -19,11 +19,13 @@ public class LectivoMapper {
 
     public LectivoEntity toEntity(Lectivo domain) {
         if (domain == null) return null;
-        return LectivoEntity.builder()
+        LectivoEntity.LectivoEntityBuilder builder = LectivoEntity.builder()
                 .lectivoId(domain.getLectivoId())
-                .nombre(domain.getNombre())
                 .fechaInicio(domain.getFechaInicio())
-                .fechaFinal(domain.getFechaFinal())
-                .build();
+                .fechaFinal(domain.getFechaFinal());
+        
+        if (domain.getNombre() != null) builder.nombre(domain.getNombre());
+        
+        return builder.build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/infrastructure/persistence/mapper/MercadoPagoContextMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/mercadoPagoContext/infrastructure/persistence/mapper/MercadoPagoContextMapper.java
@@ -16,26 +16,28 @@ public class MercadoPagoContextMapper {
 
     public MercadoPagoContextEntity toEntity(MercadoPagoContext domain) {
         if (domain == null) return null;
-        return MercadoPagoContextEntity.builder()
+        MercadoPagoContextEntity.MercadoPagoContextEntityBuilder builder = MercadoPagoContextEntity.builder()
                 .mercadoPagoContextId(domain.getMercadoPagoContextId())
                 .chequeraCuotaId(domain.getChequeraCuotaId())
                 .reservaVacanteId(domain.getReservaVacanteId())
                 .initPoint(domain.getInitPoint())
                 .fechaVencimiento(domain.getFechaVencimiento())
-                .importe(domain.getImporte())
-                .changed(domain.getChanged())
                 .lastVencimientoUpdated(domain.getLastVencimientoUpdated())
                 .preferenceId(domain.getPreferenceId())
                 .preference(domain.getPreference())
-                .activo(domain.getActivo())
                 .chequeraPagoId(domain.getChequeraPagoId())
                 .idMercadoPago(domain.getIdMercadoPago())
                 .status(domain.getStatus())
                 .fechaPago(domain.getFechaPago())
                 .fechaAcreditacion(domain.getFechaAcreditacion())
-                .importePagado(domain.getImportePagado())
-                .payment(domain.getPayment())
-                .build();
+                .payment(domain.getPayment());
+
+        if (domain.getImporte() != null) builder.importe(domain.getImporte());
+        if (domain.getChanged() != null) builder.changed(domain.getChanged());
+        if (domain.getActivo() != null) builder.activo(domain.getActivo());
+        if (domain.getImportePagado() != null) builder.importePagado(domain.getImportePagado());
+
+        return builder.build();
     }
 
     public MercadoPagoContext toDomainModel(MercadoPagoContextEntity entity) {

--- a/src/main/java/um/tesoreria/core/hexagonal/proveedor/infrastructure/persistence/mapper/ProveedorMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/proveedor/infrastructure/persistence/mapper/ProveedorMapper.java
@@ -18,22 +18,24 @@ public class ProveedorMapper {
 
     public ProveedorEntity toEntity(Proveedor domain) {
         if (domain == null) return null;
-        return ProveedorEntity.builder()
+        ProveedorEntity.ProveedorEntityBuilder builder = ProveedorEntity.builder()
                 .proveedorId(domain.getProveedorId())
-                .cuit(domain.getCuit())
-                .nombreFantasia(domain.getNombreFantasia())
-                .razonSocial(domain.getRazonSocial())
-                .ordenCheque(domain.getOrdenCheque())
-                .domicilio(domain.getDomicilio())
-                .telefono(domain.getTelefono())
-                .fax(domain.getFax())
-                .celular(domain.getCelular())
-                .email(domain.getEmail())
-                .emailInterno(domain.getEmailInterno())
-                .numeroCuenta(domain.getNumeroCuenta())
-                .habilitado(domain.getHabilitado())
-                .cbu(domain.getCbu())
-                .build();
+                .numeroCuenta(domain.getNumeroCuenta());
+        
+        if (domain.getCuit() != null) builder.cuit(domain.getCuit());
+        if (domain.getNombreFantasia() != null) builder.nombreFantasia(domain.getNombreFantasia());
+        if (domain.getRazonSocial() != null) builder.razonSocial(domain.getRazonSocial());
+        if (domain.getOrdenCheque() != null) builder.ordenCheque(domain.getOrdenCheque());
+        if (domain.getDomicilio() != null) builder.domicilio(domain.getDomicilio());
+        if (domain.getTelefono() != null) builder.telefono(domain.getTelefono());
+        if (domain.getFax() != null) builder.fax(domain.getFax());
+        if (domain.getCelular() != null) builder.celular(domain.getCelular());
+        if (domain.getEmail() != null) builder.email(domain.getEmail());
+        if (domain.getEmailInterno() != null) builder.emailInterno(domain.getEmailInterno());
+        if (domain.getHabilitado() != null) builder.habilitado(domain.getHabilitado());
+        if (domain.getCbu() != null) builder.cbu(domain.getCbu());
+        
+        return builder.build();
     }
 
     public Proveedor toDomainModel(ProveedorEntity entity) {


### PR DESCRIPTION
Closes #283

## Descripción

Null-safety en 16 mappers de persistencia hexagonal para prevenir `NullPointerException` cuando campos opcionales del dominio son nulos al persistir entidades.

## Cambios Realizados

- [ ] Se aplicó patrón de builder con validación `!= null` en `toEntity()` de 16 mappers
- [ ] `ChequeraCuotaMapper`: se añadieron validaciones `!= null` en `updateEntity()` para campos opcionales
- [ ] `pom.xml`: Bump de versión `3.33.0` → `3.34.0`
- [ ] `CHANGELOG.md`: Documentación de los cambios bajo sección `Fixed`
- [ ] `README.md`: Añadida entrada del fix en novedades v3.34.0

### Mappers afectados

| # | Mapper | Campos protegidos |
|---|--------|-------------------|
| 1 | `ArticuloMapper` | nombre, descripcion, unidad, precio, inventariable, stockMinimo, tipo, directo, habilitado |
| 2 | `ArancelPorcentajeMapper` | porcentaje |
| 3 | `ArancelTipoMapper` | descripcion, medioArancel, habilitado |
| 4 | `ChequeraCuotaMapper` | mes, anho, importes (1-3 + originales), codigoBarras, i2Of5, pagado, baja, manual, compensada, tramoId |
| 5 | `ChequeraSerieMapper` | flagPayperTic, enviado, retenida, hpum, becaPorcentaje, cuotasDeuda, importeDeuda |
| 6 | `ClaseChequeraMapper` | preuniversitario, grado, posgrado, curso, secundario, titulo |
| 7 | `ProductoMapper` | nombre |
| 8 | `TipoChequeraMapper` | nombre, prefijo, geograficaId, claseChequeraId, imprimir, contado, multiple |
| 9 | `CuentaMapper` | nombre, integradora, grado, visible |
| 10 | `ContratoMapper` | cargo, montoFijo, canonMensual (+ sinAjuste, + Letras), meses, mesesLetras, ajuste |
| 11 | `DependenciaMapper` | nombre, acronimo |
| 12 | `DocumentoMapper` | nombre |
| 13 | `DomicilioMapper` | fecha, calle, puerta, piso, dpto, telefono, movil, observaciones, codigoPostal, emails, laboral |
| 14 | `LectivoMapper` | nombre |
| 15 | `MercadoPagoContextMapper` | importe, changed, activo, importePagado |
| 16 | `ProveedorMapper` | cuit, nombreFantasia, razonSocial, domicilio, telefono, fax, celular, email, emailInterno, habilitado, cbu |

## Verificación

- **Compilación:** `mvn clean compile` sin errores
- **Tests:** `mvn test` todos pasan
- **Backward compatible:** No cambia comportamiento existente, solo añade protección ante nulos
