### PR TITLE
fix(chequeraSerie): siempre establecer cuotasDeuda en el builder

### DIFF
--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/persistence/mapper/ChequeraSerieMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/persistence/mapper/ChequeraSerieMapper.java
@@ -100,7 +100,7 @@ public class ChequeraSerieMapper {
         if (domain.getRetenida() != null) builder.retenida(domain.getRetenida());
         if (domain.getHpum() != null) builder.hpum(domain.getHpum());
         if (domain.getBecaPorcentaje() != null) builder.becaPorcentaje(domain.getBecaPorcentaje());
-        if (domain.getCuotasDeuda() != null) builder.cuotasDeuda(domain.getCuotasDeuda());
+        builder.cuotasDeuda(domain.getCuotasDeuda());
         if (domain.getImporteDeuda() != null) builder.importeDeuda(domain.getImporteDeuda());
 
         return builder.build();


### PR DESCRIPTION
Se elimina la condición null check para asegurar que cuotasDeuda se establezca siempre en el builder, incluso cuando sea null. Esto garantiza que el campo se maneje de manera consistente y explícita.