### PR TITLE
feat(v3.38.0): GetCuotaActualUseCase, endpoints batch MercadoPago, parámetro plazo en PoliticaArancelaria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.38.0] - 2026-07-19
+### Added
+- feat(chequeraCuota): Nuevo caso de uso `GetCuotaActualUseCase` para obtener la cuota vigente por fecha
+  - Nuevo puerto de entrada: `GetCuotaActualUseCase` con método `getCuotaActual(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, OffsetDateTime fechaActual)`
+  - Nueva implementación: `GetCuotaActualUseCaseImpl` que filtra cuotas por vencimiento (`vencimiento1` o `vencimiento2` anterior a `fechaActual`) y resuelve `chequeraId` si es null
+  - Dependencia cruzada con `ChequeraSerieService` para resolver `chequeraId` faltante
+  - Nuevo endpoint en `ChequeraCuotaController`: `GET /chequeraCuota/cuotaActual/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{productoId}/{alternativaId}`
+  - Nuevo método `getCuotaActual()` en `ChequeraCuotaService` con delegación al caso de uso y `ChequeraCuotaException` en caso de no encontrar cuota
+  - Nuevo constructor `ChequeraCuotaException(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId)` para errores de búsqueda por 5 claves
+- feat(politicaArancelaria): Nuevo parámetro `plazo` (días) en endpoint de recálculo de cuota
+  - Endpoint actualizado: `GET /api/tesoreria/core/politicaArancelaria/recalculate/cuota/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{productoId}/{alternativaId}/{cuotaId}/plazo/{dias}`
+  - Nuevo DTO `PoliticaArancelariaResponse` con 28 campos (chequeraCuota completa + importes originales)
+  - Nuevo `PoliticaArancelariaDtoMapper` para conversión dominio `ChequeraCuota` → DTO
+  - `RecalculateCuotaByUniqueIndexUseCaseImpl` refactorizado: compara `importe3` con cuota de referencia (`getCuotaActual`), actualiza `importe3` y `vencimiento3` con `plazo` días
+  - `RecalculateCuotaByUniqueIndexUseCase` interface actualizada con parámetro `Integer plazo`
+- feat(mercadoPago): Nuevos endpoints batch para gestión de contextos MercadoPago
+  - `GET /mercadoPagoCore/makeContextsChequera/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{alternativaId}`: crea contextos MP para todas las cuotas pendientes de una chequera
+  - `PUT /mercadoPagoCore/updateContexts`: actualiza una lista de contextos MP en batch
+  - `MercadoPagoCoreService.makeContextsChequera()`: itera cuotas pendientes, valida disponibilidad, crea/actualiza contextos y retorna `List<UMPreferenceMPDto>`
+  - `MercadoPagoCoreService.updateContexts()`: delega a `mercadoPagoContextService.saveAll()`
+- feat(chequeraCuota): Enriquecimiento del `@EntityGraph` en `findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaId`
+  - Agregadas asociaciones anidadas: `tipoChequera.geografica`, `tipoChequera.claseChequera`, `chequeraSerie.facultad`, `chequeraSerie.tipoChequera`, `chequeraSerie.persona`, `chequeraSerie.domicilio`, `chequeraSerie.lectivo`, `chequeraSerie.arancelTipo`, `chequeraSerie.geografica`
+  - Mejora rendimiento: evita `LazyInitializationException` en consultas que usan `findAllByChequeraAlternativa`
+
+### Fixed
+- fix(docs): Eliminación de namespaces vacíos en 20 diagramas Mermaid
+  - Removidos bloques `namespace infrastructure { }` vacíos que causaban `Syntax Error` en Mermaid v10+
+  - Afecta diagramas: alumnoGuarani, articulo, campanha, chequeraCuota, chequeraPago, chequeraProducto, chequeraSerie, chequeraTipoChequera, chequeraTotal, claseChequera, contrato, dependencia, documento, domicilio, facturaPendiente, facultad, lectivo, lectivoTotalImputacion, mercadoPagoContext, persona, reservaVacante, usuario
+- fix(docs): Agregado sanitizador en `script.js` para eliminar namespaces vacíos al vuelo antes de renderizar
+- fix(chequeraCuota): Comentado log verbose de `findAllByChequeraAlternativa` en `JpaChequeraCuotaRepositoryAdapter` (reducir ruido en logs de producción)
+
+> Basado en análisis profundo de `git diff HEAD` (39 archivos staged, +284/-160 líneas, incluyendo nuevos use cases, endpoints batch MercadoPago, parámetro plazo en politicaArancelaria y limpieza de diagramas) y `pom.xml` (versión 3.37.0 → 3.38.0).
+
 ## [3.37.0] - 2026-07-17
 ### Added
 - feat(chequeraPago): Nuevo módulo ChequeraPago con arquitectura hexagonal completa bajo `hexagonal/chequera/chequeraPago/`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,24 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.37.0**
+**Versión actual (SemVer): 3.38.0**
+
+## Novedades 3.38.0 (verificado en código)
+- feat(chequeraCuota): Nuevo caso de uso `GetCuotaActualUseCase` para obtener la cuota vigente por fecha
+  - Filtra cuotas por `vencimiento1` o `vencimiento2` anterior a `fechaActual`
+  - Resuelve `chequeraId` si es null, delegando a `ChequeraSerieService.findByUnique()`
+  - Nuevo endpoint: `GET /chequeraCuota/cuotaActual/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{productoId}/{alternativaId}`
+- feat(politicaArancelaria): Nuevo parámetro `plazo` (días) en endpoint de recálculo de cuota
+  - Endpoint: `GET .../politicaArancelaria/recalculate/cuota/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{productoId}/{alternativaId}/{cuotaId}/plazo/{dias}`
+  - Nuevo DTO `PoliticaArancelariaResponse` con 28 campos + `PoliticaArancelariaDtoMapper`
+  - `RecalculateCuotaByUniqueIndexUseCaseImpl`: compara importe3 con cuota de referencia, actualiza vencimiento3 con plazo días
+- feat(mercadoPago): Nuevos endpoints batch para contextos MercadoPago
+  - `GET /mercadoPagoCore/makeContextsChequera/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{alternativaId}`: crea contextos MP para cuotas pendientes
+  - `PUT /mercadoPagoCore/updateContexts`: actualiza lista de contextos MP en batch
+- feat(chequeraCuota): Enriquecimiento del `@EntityGraph` con 9 asociaciones anidadas adicionales (evita LazyInitializationException)
+- fix(docs): Eliminación de namespaces vacíos en 20 diagramas Mermaid + sanitizador en `script.js`
+
+> Basado en análisis profundo de `git diff HEAD` (39 archivos staged, +284/-160 líneas) y `pom.xml` (versión 3.37.0 → 3.38.0).
 
 ## Novedades 3.37.0 (verificado en código)
 - feat(chequeraPago): Nuevo módulo ChequeraPago con arquitectura hexagonal completa (12 casos de uso)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.37.0** (actualizada: 2026-07-17)
+**Versión actual del servicio: 3.38.0** (actualizada: 2026-07-19)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -12,7 +12,7 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-cuentaMovimiento.mmd`: Arquitectura hexagonal del módulo CuentaMovimiento (asientos contables) - v3.36.0 (nuevo módulo, 11 casos de uso).
 - `hexagonal-proveedorMovimiento.mmd`: Arquitectura hexagonal del módulo ProveedorMovimiento (movimientos de proveedores) - v3.36.0 (nuevo módulo, 13 casos de uso).
 - `hexagonal-track.mmd`: Arquitectura hexagonal del módulo Track (seguimiento) - v3.36.0 (nuevo módulo, 4 casos de uso).
-- `hexagonal-chequeraCuota.mmd`: Arquitectura hexagonal del módulo ChequeraCuota (20+ casos de uso individuales) - v3.30.0 (refactorización masiva a casos de uso).
+- `hexagonal-chequeraCuota.mmd`: Arquitectura hexagonal del módulo ChequeraCuota (21 casos de uso individuales) - v3.38.0 (nuevo caso de uso GetCuotaActualUseCase + endpoint cuotaActual).
 - `hexagonal-mercadoPagoContext.mmd`: Arquitectura hexagonal del módulo MercadoPagoContext (contexto de pagos MP) - v3.26.0.
 - `hexagonal-auth.mmd`: Arquitectura hexagonal del módulo Auth (autenticación de usuarios).
 - `hexagonal-geografica.mmd`: Arquitectura hexagonal del módulo Geografica (entidades geográficas).
@@ -44,7 +44,7 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-persona.mmd`: Arquitectura hexagonal del módulo Persona (gestión de personas) - v3.24.0.
 - `hexagonal-chequeraPago.mmd`: Arquitectura hexagonal del módulo ChequeraPago (gestión de pagos de chequeras con 12 casos de uso) - v3.37.0 (nuevo módulo, migración desde Kotlin legacy).
 - `hexagonal-chequeraTotal.mmd`: Arquitectura hexagonal del módulo ChequeraTotal (totales de chequeras con 5 casos de uso) - v3.37.0 (nuevo módulo).
-- `hexagonal-politicaArancelaria.mmd`: Arquitectura hexagonal del módulo PoliticaArancelaria (recálculo de cuotas por política arancelaria) - v3.37.0 (nuevo módulo).
+- `hexagonal-politicaArancelaria.mmd`: Arquitectura hexagonal del módulo PoliticaArancelaria (recálculo de cuotas por política arancelaria) - v3.38.0 (parámetro plazo, DTO PoliticaArancelariaResponse + PoliticaArancelariaDtoMapper).
 
 - `deployment.mmd`: Diagrama de despliegue del microservicio.
 
@@ -64,6 +64,11 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `sequence-movimientos-cuenta.mmd`: Movimientos de cuenta.
 - `sequence-pago-chequera.mmd`: Pago de chequera.
 - `sequence-reemplazo-chequera.mmd`: Reemplazo de chequera.
+
+## Reglas para la creación de Diagramas Mermaid
+- **No incluir namespaces vacíos**: En diagramas de clase (`classDiagram`), nunca incluir bloques vacíos como `namespace infrastructure { }`. Mermaid v10 arroja `Syntax Error` si un namespace no contiene al menos una clase.
+- **Formato de genéricos**: Utilizar tildes `~` para tipos genéricos (ej. `List~String~` en lugar de `<String>`).
+- **Validación automática**: `docs/script.js` sanitiza bloques `namespace` vacíos al vuelo antes de renderizar, pero los archivos `.mmd` deben guardarse limpios.
 
 ## Notas sobre el pipeline
 - El pipeline de documentación debe validar la sintaxis Mermaid antes de publicar.

--- a/docs/hexagonal-alumnoGuarani.mmd
+++ b/docs/hexagonal-alumnoGuarani.mmd
@@ -128,8 +128,6 @@ classDiagram
         }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_web {
             class AlumnoGuaraniController {
                 -AlumnoGuaraniService alumnoGuaraniService
@@ -158,8 +156,6 @@ classDiagram
             class AlumnoGuaraniDtoMapper {
                 +toDomain(AlumnoGuaraniRequest) AlumnoGuarani
             }
-    }
-    namespace infrastructure {
     }
 
     AlumnoGuarani --> PersonaGuarani

--- a/docs/hexagonal-articulo.mmd
+++ b/docs/hexagonal-articulo.mmd
@@ -154,8 +154,6 @@ classDiagram
         }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class ArticuloEntity {
                 +Long articuloId
@@ -194,9 +192,6 @@ classDiagram
                 +toEntity(Articulo) ArticuloEntity
                 +toSearchDomain(ArticuloKey) ArticuloSearch
             }
-    }
-    namespace infrastructure {
-
     }
     namespace infrastructure_web {
             class ArticuloController {
@@ -265,8 +260,6 @@ classDiagram
                 +toResponse(Articulo) ArticuloResponse
                 +toSearchResponse(ArticuloSearch) ArticuloSearchResponse
             }
-    }
-    namespace infrastructure {
     }
 
     ArticuloService --> CreateArticuloUseCase : uses

--- a/docs/hexagonal-campanha.mmd
+++ b/docs/hexagonal-campanha.mmd
@@ -85,8 +85,6 @@ classDiagram
         }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class CampanhaEntity {
                 +UUID campanhaId
@@ -118,9 +116,6 @@ classDiagram
                 +toDomainModel(CampanhaEntity) Campanha
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class CampanhaController {
                 -CampanhaService campanhaService
@@ -151,8 +146,6 @@ classDiagram
                 +toDomain(CampanhaRequest) Campanha
                 +toResponse(Campanha) CampanhaResponse
             }
-    }
-    namespace infrastructure {
     }
 
     CampanhaService --> CreateCampanhaUseCase : uses

--- a/docs/hexagonal-chequeraCuota.mmd
+++ b/docs/hexagonal-chequeraCuota.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo ChequeraCuota (v3.34.0)
+title: Arquitectura Hexagonal - Módulo ChequeraCuota (v3.38.0)
 ---
 
 classDiagram
@@ -80,6 +80,7 @@ classDiagram
         class FindAllPeriodosLectivoUseCase { <<interface>> }
         class GetChequeraCuotaByIdUseCase { <<interface>> }
         class GetChequeraCuotaByUniqueUseCase { <<interface>> }
+        class GetCuotaActualUseCase { <<interface>> }
         class GetOneActivaImpagaPreviaUseCase { <<interface>> }
         class SaveAllChequeraCuotasUseCase { <<interface>> }
         class UpdateBarrasUseCase { <<interface>> }
@@ -100,6 +101,7 @@ classDiagram
             +findAllPeriodosLectivo() List~Integer~
             +findById(Long) ChequeraCuota
             +findByUnique(...) ChequeraCuota
+            +getCuotaActual(Integer, Integer, Long, Integer, Integer, OffsetDateTime) ChequeraCuota
             +findOneActivaImpagaPrevia(...) ChequeraCuota
             +saveAll(List~ChequeraCuota~) List~ChequeraCuota~
             +update(ChequeraCuota) ChequeraCuota
@@ -137,6 +139,7 @@ classDiagram
             class FindAllPeriodosLectivoUseCaseImpl
             class GetChequeraCuotaByIdUseCaseImpl
             class GetChequeraCuotaByUniqueUseCaseImpl
+            class GetCuotaActualUseCaseImpl
             class GetOneActivaImpagaPreviaUseCaseImpl
             class SaveAllChequeraCuotasUseCaseImpl
             class UpdateBarrasUseCaseImpl
@@ -147,8 +150,6 @@ classDiagram
         class ChequeraCuotaException
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class ChequeraCuotaEntity {
                 +@Table(name="chequera_cuota")
@@ -179,9 +180,6 @@ classDiagram
                 +toEntity(ChequeraCuota) ChequeraCuotaEntity
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class ChequeraCuotaController {
                 -ChequeraCuotaService service
@@ -195,6 +193,7 @@ classDiagram
                 +calculateDeuda(...) ResponseEntity
                 +update(...) ResponseEntity
                 +updateBarras(...) ResponseEntity
+                +getCuotaActual(Integer, Integer, Long, Integer, Integer) ResponseEntity
             }
 
             class ChequeraCuotaRequest {
@@ -229,8 +228,6 @@ classDiagram
                 +toResponse(ChequeraCuota) ChequeraCuotaResponse
             }
     }
-    namespace infrastructure {
-    }
 
     namespace external {
         class FacultadService
@@ -259,6 +256,7 @@ classDiagram
     ChequeraCuotaService --> FindAllPeriodosLectivoUseCase : uses
     ChequeraCuotaService --> GetChequeraCuotaByIdUseCase : uses
     ChequeraCuotaService --> GetChequeraCuotaByUniqueUseCase : uses
+    ChequeraCuotaService --> GetCuotaActualUseCase : uses
     ChequeraCuotaService --> GetOneActivaImpagaPreviaUseCase : uses
     ChequeraCuotaService --> SaveAllChequeraCuotasUseCase : uses
     ChequeraCuotaService --> UpdateBarrasUseCase : uses
@@ -280,6 +278,7 @@ classDiagram
     FindAllPeriodosLectivoUseCaseImpl ..|> FindAllPeriodosLectivoUseCase : implements
     GetChequeraCuotaByIdUseCaseImpl ..|> GetChequeraCuotaByIdUseCase : implements
     GetChequeraCuotaByUniqueUseCaseImpl ..|> GetChequeraCuotaByUniqueUseCase : implements
+    GetCuotaActualUseCaseImpl ..|> GetCuotaActualUseCase : implements
     GetOneActivaImpagaPreviaUseCaseImpl ..|> GetOneActivaImpagaPreviaUseCase : implements
     SaveAllChequeraCuotasUseCaseImpl ..|> SaveAllChequeraCuotasUseCase : implements
     UpdateBarrasUseCaseImpl ..|> UpdateBarrasUseCase : implements
@@ -301,6 +300,7 @@ classDiagram
     FindAllPeriodosLectivoUseCaseImpl --> ChequeraCuotaRepository : uses
     GetChequeraCuotaByIdUseCaseImpl --> ChequeraCuotaRepository : uses
     GetChequeraCuotaByUniqueUseCaseImpl --> ChequeraCuotaRepository : uses
+    GetCuotaActualUseCaseImpl --> ChequeraCuotaRepository : uses
     GetOneActivaImpagaPreviaUseCaseImpl --> ChequeraCuotaRepository : uses
     SaveAllChequeraCuotasUseCaseImpl --> ChequeraCuotaRepository : uses
     UpdateBarrasUseCaseImpl --> ChequeraCuotaRepository : uses

--- a/docs/hexagonal-chequeraPago.mmd
+++ b/docs/hexagonal-chequeraPago.mmd
@@ -112,8 +112,6 @@ classDiagram
         class IsPagadoUseCase { <<interface>> }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class ChequeraPagoEntity {
                 +@Table(name="chequera_pago")
@@ -180,9 +178,6 @@ classDiagram
                 +toEntity(ChequeraPago) ChequeraPagoEntity
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class ChequeraPagoController {
                 -ChequeraPagoService service
@@ -247,8 +242,6 @@ classDiagram
                 +toDomain(ChequeraPagoRequest) ChequeraPago
                 +toResponse(ChequeraPago) ChequeraPagoResponse
             }
-    }
-    namespace infrastructure {
     }
 
     ChequeraPagoService --> CreateChequeraPagoUseCase : uses

--- a/docs/hexagonal-chequeraProducto.mmd
+++ b/docs/hexagonal-chequeraProducto.mmd
@@ -48,8 +48,6 @@ classDiagram
         class ProductoException
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class ProductoEntity {
                 +Integer productoId
@@ -74,9 +72,6 @@ classDiagram
                 +toEntity(Producto) ProductoEntity
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class ProductoController {
                 -ProductoService service
@@ -100,8 +95,6 @@ classDiagram
                 +toDomain(ProductoRequest) Producto
                 +toResponse(Producto) ProductoResponse
             }
-    }
-    namespace infrastructure {
     }
 
     ProductoService --> GetAllProductosUseCase : uses

--- a/docs/hexagonal-chequeraSerie.mmd
+++ b/docs/hexagonal-chequeraSerie.mmd
@@ -103,8 +103,6 @@ classDiagram
         class ChequeraSerieException
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class ChequeraSerieEntity {
                 +Long chequeraSerieId
@@ -129,9 +127,6 @@ classDiagram
                 +toEntity(ChequeraSerie) ChequeraSerieEntity
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class ChequeraSerieController {
                 -ChequeraSerieService service
@@ -144,8 +139,6 @@ classDiagram
                 +toDomain(ChequeraSerieRequest) ChequeraSerie
                 +toResponse(ChequeraSerie) ChequeraSerieResponse
             }
-    }
-    namespace infrastructure {
     }
 
     ChequeraSerieService --> CreateChequeraSerieUseCase : uses

--- a/docs/hexagonal-chequeraTipoChequera.mmd
+++ b/docs/hexagonal-chequeraTipoChequera.mmd
@@ -74,8 +74,6 @@ classDiagram
         class TipoChequeraException
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class TipoChequeraEntity {
                 +Integer tipoChequeraId
@@ -110,9 +108,6 @@ classDiagram
                 +toDomainModel(TipoChequeraEntity) TipoChequera
                 +toEntity(TipoChequera) TipoChequeraEntity
             }
-    }
-    namespace infrastructure {
-
     }
     namespace infrastructure_web {
             class TipoChequeraController {
@@ -158,8 +153,6 @@ classDiagram
                 +toDomain(TipoChequeraRequest) TipoChequera
                 +toResponse(TipoChequera) TipoChequeraResponse
             }
-    }
-    namespace infrastructure {
     }
 
     TipoChequeraService --> GetAllTipoChequeraUseCase : uses

--- a/docs/hexagonal-chequeraTotal.mmd
+++ b/docs/hexagonal-chequeraTotal.mmd
@@ -60,8 +60,6 @@ classDiagram
         class UpdateChequeraTotalUseCase { <<interface>> }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class ChequeraTotalEntity {
                 +@Table(name="chequera_total")
@@ -98,9 +96,6 @@ classDiagram
                 +toEntity(ChequeraTotal) ChequeraTotalEntity
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class ChequeraTotalController {
                 -ChequeraTotalService service
@@ -120,8 +115,6 @@ classDiagram
             class ChequeraTotalDtoMapper {
                 +toResponse(ChequeraTotal) ChequeraTotalResponse
             }
-    }
-    namespace infrastructure {
     }
 
     ChequeraTotalService --> CreateChequeraTotalUseCase : uses

--- a/docs/hexagonal-claseChequera.mmd
+++ b/docs/hexagonal-claseChequera.mmd
@@ -72,8 +72,6 @@ classDiagram
         class ClaseChequeraException
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class ClaseChequeraEntity {
                 +Integer claseChequeraId
@@ -109,9 +107,6 @@ classDiagram
                 +toDomain(ClaseChequeraEntity) ClaseChequera
                 +toEntity(ClaseChequera) ClaseChequeraEntity
             }
-    }
-    namespace infrastructure {
-
     }
     namespace infrastructure_web {
             class ClaseChequeraController {
@@ -149,8 +144,6 @@ classDiagram
                 +toDomain(ClaseChequeraRequest) ClaseChequera
                 +toResponse(ClaseChequera) ClaseChequeraResponse
             }
-    }
-    namespace infrastructure {
     }
 
     ClaseChequeraService --> GetAllClaseChequeraUseCase : uses

--- a/docs/hexagonal-contrato.mmd
+++ b/docs/hexagonal-contrato.mmd
@@ -145,8 +145,6 @@ classDiagram
         }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class ContratoEntity {
                 +Long contratoId
@@ -201,9 +199,6 @@ classDiagram
                 +toEntity(Contrato) ContratoEntity
                 +toDomainModel(ContratoEntity) Contrato
             }
-    }
-    namespace infrastructure {
-
     }
     namespace infrastructure_web {
             class ContratoController {
@@ -268,8 +263,6 @@ classDiagram
                 +toDomain(ContratoRequest) Contrato
                 +toResponse(Contrato) ContratoResponse
             }
-    }
-    namespace infrastructure {
     }
 
     ContratoService --> CreateContratoUseCase : uses

--- a/docs/hexagonal-dependencia.mmd
+++ b/docs/hexagonal-dependencia.mmd
@@ -74,8 +74,6 @@ classDiagram
         }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class DependenciaEntity {
                 +Integer dependenciaId
@@ -110,9 +108,6 @@ classDiagram
                 +toDomain(DependenciaEntity) Dependencia
                 +toEntity(Dependencia) DependenciaEntity
             }
-    }
-    namespace infrastructure {
-
     }
     namespace infrastructure_web {
             class DependenciaController {
@@ -150,8 +145,6 @@ classDiagram
                 +toDomain(DependenciaRequest) Dependencia
                 +toResponse(Dependencia) DependenciaResponse
             }
-    }
-    namespace infrastructure {
     }
 
     DependenciaService --> GetAllDependenciasUseCase : uses

--- a/docs/hexagonal-documento.mmd
+++ b/docs/hexagonal-documento.mmd
@@ -37,8 +37,6 @@ classDiagram
         class GetDocumentoByIdUseCase { <<interface>> }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class DocumentoEntity {
                 +Integer documentoId
@@ -62,9 +60,6 @@ classDiagram
                 +toEntity(Documento) DocumentoEntity
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class DocumentoController {
                 -DocumentoService service
@@ -79,8 +74,6 @@ classDiagram
                 +toDomain(DocumentoRequest) Documento
                 +toResponse(Documento) DocumentoResponse
             }
-    }
-    namespace infrastructure {
     }
 
     DocumentoService --> GetAllDocumentosUseCase : uses

--- a/docs/hexagonal-domicilio.mmd
+++ b/docs/hexagonal-domicilio.mmd
@@ -90,8 +90,6 @@ classDiagram
         class DomicilioException
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class DomicilioEntity {
                 +Long domicilioId
@@ -138,9 +136,6 @@ classDiagram
                 +toDomainModel(DomicilioEntity) Domicilio
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class DomicilioController {
                 -DomicilioService domicilioService
@@ -162,8 +157,6 @@ classDiagram
                 +toDomain(DomicilioRequest) Domicilio
                 +toResponse(Domicilio) DomicilioResponse
             }
-    }
-    namespace infrastructure {
     }
 
     DomicilioService --> CreateDomicilioUseCase : uses

--- a/docs/hexagonal-facturaPendiente.mmd
+++ b/docs/hexagonal-facturaPendiente.mmd
@@ -46,8 +46,6 @@ classDiagram
         }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class FacturaPendienteEntity {
                 <<Immutable>>
@@ -77,8 +75,6 @@ classDiagram
                 +updateFechaPagoInProveedorPago(Long, OffsetDateTime)
                 +findFacturasPendientes(OffsetDateTime, OffsetDateTime) List~FacturaPendiente~
             }
-    }
-    namespace infrastructure {
     }
 
     FacturaPendienteService --> GetFacturasPendientesUseCase : uses

--- a/docs/hexagonal-facultad.mmd
+++ b/docs/hexagonal-facultad.mmd
@@ -77,8 +77,6 @@ classDiagram
         }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class FacultadEntity {
                 +Integer facultadId
@@ -111,9 +109,6 @@ classDiagram
                 +toDomain(FacultadEntity) Facultad
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class FacultadController {
                 -FacultadService service
@@ -142,8 +137,6 @@ classDiagram
             class FacultadDtoMapper {
                 +toResponse(Facultad) FacultadResponse
             }
-    }
-    namespace infrastructure {
     }
 
     FacultadService --> GetAllFacultadesUseCase : uses

--- a/docs/hexagonal-lectivo.mmd
+++ b/docs/hexagonal-lectivo.mmd
@@ -63,8 +63,6 @@ classDiagram
         class LectivoException
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class LectivoEntity {
                 +Integer lectivoId
@@ -101,9 +99,6 @@ classDiagram
                 +toEntity(Lectivo) LectivoEntity
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class LectivoController {
                 -LectivoService service
@@ -135,8 +130,6 @@ classDiagram
                 +toDomain(LectivoRequest) Lectivo
                 +toResponse(Lectivo) LectivoResponse
             }
-    }
-    namespace infrastructure {
     }
 
     LectivoService --> GetAllLectivosUseCase : uses

--- a/docs/hexagonal-lectivoTotalImputacion.mmd
+++ b/docs/hexagonal-lectivoTotalImputacion.mmd
@@ -130,8 +130,6 @@ classDiagram
         }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class LectivoTotalImputacionEntity {
                 +Long lectivoTotalImputacionId
@@ -176,9 +174,6 @@ classDiagram
                 +toEntity(LectivoTotalImputacion) LectivoTotalImputacionEntity
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class LectivoTotalImputacionController {
                 -LectivoTotalImputacionService service
@@ -217,8 +212,6 @@ classDiagram
                 +toDomain(LectivoTotalImputacionRequest) LectivoTotalImputacion
                 +toResponse(LectivoTotalImputacion) LectivoTotalImputacionResponse
             }
-    }
-    namespace infrastructure {
     }
 
     LectivoTotalImputacion --> Facultad : has

--- a/docs/hexagonal-mercadoPagoContext.mmd
+++ b/docs/hexagonal-mercadoPagoContext.mmd
@@ -105,8 +105,6 @@ classDiagram
         class MercadoPagoContextException
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class MercadoPagoContextEntity {
                 +Long mercadoPagoContextId
@@ -156,9 +154,6 @@ classDiagram
                 +toDomain(MercadoPagoContextEntity) MercadoPagoContext
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class MercadoPagoContextController {
                 -MercadoPagoContextService service
@@ -194,8 +189,6 @@ classDiagram
                 +toDomain(MercadoPagoContextRequest) MercadoPagoContext
                 +toResponse(MercadoPagoContext) MercadoPagoContextResponse
             }
-    }
-    namespace infrastructure {
     }
 
     MercadoPagoContextService --> AddMercadoPagoContextUseCase : uses

--- a/docs/hexagonal-persona.mmd
+++ b/docs/hexagonal-persona.mmd
@@ -93,8 +93,6 @@ classDiagram
         class GetInscripcionFullUseCase { <<interface>> }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class PersonaEntity {
                 +Long uniqueId
@@ -127,9 +125,6 @@ classDiagram
                 +toDomain(PersonaEntity) Persona
             }
     }
-    namespace infrastructure {
-
-    }
     namespace infrastructure_web {
             class PersonaController {
                 -PersonaService personaService
@@ -154,8 +149,6 @@ classDiagram
                 +toDomain(PersonaRequest) Persona
                 +toResponse(Persona) PersonaResponse
             }
-    }
-    namespace infrastructure {
     }
 
     PersonaService --> GetPersonaByUniqueUseCase : uses

--- a/docs/hexagonal-politicaArancelaria.mmd
+++ b/docs/hexagonal-politicaArancelaria.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo PoliticaArancelaria (v3.37.0)
+title: Arquitectura Hexagonal - Módulo PoliticaArancelaria (v3.38.0)
 ---
 
 classDiagram
@@ -8,14 +8,14 @@ classDiagram
     namespace application {
         class PoliticaArancelariaService {
             -RecalculateCuotaByUniqueIndexUseCase findPoliticaArancelariaUseCase
-            +recalculateCuotaByUniqueIndex(Integer, Integer, Long, Integer, Integer, Integer) ChequeraCuota
+            +recalculateCuotaByUniqueIndex(Integer, Integer, Long, Integer, Integer, Integer, Integer) ChequeraCuota
         }
 
     }
     namespace application_usecases {
             class RecalculateCuotaByUniqueIndexUseCaseImpl {
                 -ChequeraCuotaService chequeraCuotaService
-                +recalculateCuota(Integer, Integer, Long, Integer, Integer, Integer) ChequeraCuota
+                +recalculateCuota(Integer, Integer, Long, Integer, Integer, Integer, Integer) ChequeraCuota
             }
     }
     namespace application {
@@ -26,7 +26,42 @@ classDiagram
     namespace infrastructure_web {
             class PoliticaArancelariaController {
                 -PoliticaArancelariaService service
-                +recalculateCuotaByUnique(Integer, Integer, Long, Integer, Integer, Integer) ResponseEntity
+                -PoliticaArancelariaDtoMapper politicaArancelariaDtoMapper
+                +recalculateCuotaByUnique(Integer, Integer, Long, Integer, Integer, Integer, Integer) ResponseEntity
+            }
+
+            class PoliticaArancelariaResponse {
+                +Long chequeraCuotaId
+                +Long chequeraId
+                +Integer facultadId
+                +Integer tipoChequeraId
+                +Long chequeraSerieId
+                +Integer productoId
+                +Integer alternativaId
+                +Integer cuotaId
+                +Integer mes
+                +Integer anho
+                +Integer arancelTipoId
+                +OffsetDateTime vencimiento1
+                +BigDecimal importe1
+                +BigDecimal importe1Original
+                +OffsetDateTime vencimiento2
+                +BigDecimal importe2
+                +BigDecimal importe2Original
+                +OffsetDateTime vencimiento3
+                +BigDecimal importe3
+                +BigDecimal importe3Original
+                +String codigoBarras
+                +String i2Of5
+                +Byte pagado
+                +Byte baja
+                +Byte manual
+                +Byte compensada
+                +Integer tramoId
+            }
+
+            class PoliticaArancelariaDtoMapper {
+                +toResponse(ChequeraCuota) PoliticaArancelariaResponse
             }
     }
 
@@ -37,10 +72,13 @@ classDiagram
     RecalculateCuotaByUniqueIndexUseCaseImpl --> ChequeraCuotaService : uses
 
     PoliticaArancelariaController --> PoliticaArancelariaService : calls
+    PoliticaArancelariaController --> PoliticaArancelariaDtoMapper : uses
+    PoliticaArancelariaDtoMapper --> PoliticaArancelariaResponse : maps
 
     class ChequeraCuotaService {
         <<external>>
         +findByUnique(Integer, Integer, Long, Integer, Integer, Integer) ChequeraCuota
+        +getCuotaActual(Integer, Integer, Long, Integer, Integer, OffsetDateTime) ChequeraCuota
     }
 
     class ChequeraCuota {

--- a/docs/hexagonal-reservaVacante.mmd
+++ b/docs/hexagonal-reservaVacante.mmd
@@ -78,8 +78,6 @@ classDiagram
         }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class ReservaVacanteEntity {
                 +UUID reservaVacanteId
@@ -109,9 +107,6 @@ classDiagram
                 +toEntity(ReservaVacante) ReservaVacanteEntity
                 +toDomainModel(ReservaVacanteEntity) ReservaVacante
             }
-    }
-    namespace infrastructure {
-
     }
     namespace infrastructure_web {
             class ReservaVacanteController {
@@ -152,8 +147,6 @@ classDiagram
                 +toDomain(ReservaVacanteRequest) ReservaVacante
                 +toResponse(ReservaVacante) ReservaVacanteResponse
             }
-    }
-    namespace infrastructure {
     }
 
     ReservaVacanteService --> CreateReservaVacanteUseCase : uses

--- a/docs/hexagonal-usuario.mmd
+++ b/docs/hexagonal-usuario.mmd
@@ -68,8 +68,6 @@ classDiagram
         class UpdateUsuarioUseCase { <<interface>> }
     }
 
-    namespace infrastructure {
-    }
     namespace infrastructure_persistence {
             class UsuarioEntity {
                 +Long userId
@@ -111,9 +109,6 @@ classDiagram
                 +toDomain(UsuarioEntity) Usuario
                 +toEntity(Usuario) UsuarioEntity
             }
-    }
-    namespace infrastructure {
-
     }
     namespace infrastructure_web {
             class UsuarioController {
@@ -160,8 +155,6 @@ classDiagram
                 +toDomain(UsuarioRequest) Usuario
                 +toResponse(Usuario) UsuarioResponse
             }
-    }
-    namespace infrastructure {
     }
 
     UsuarioService --> CreateUsuarioUseCase : uses

--- a/docs/script.js
+++ b/docs/script.js
@@ -139,6 +139,7 @@ diagrams.forEach(diag => {
     })
     .then(data => {
       let content = data.startsWith('---') ? data.substring(data.indexOf('---', 3) + 3).trim() : data;
+      content = content.replace(/[ \t]*namespace\s+[\w_-]+\s*\{\s*\}[ \t]*\r?\n?/g, '');
       const valid = /^(flowchart|sequenceDiagram|erDiagram|classDiagram|stateDiagram|gantt|pie|journey|requirementDiagram|gitGraph|mindmap|timeline|quadrantChart)/.test(content);
       
       const container = document.getElementById(diag.id);

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.37.0</version>
+    <version>3.38.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/controller/facade/MercadoPagoCoreController.java
+++ b/src/main/java/um/tesoreria/core/controller/facade/MercadoPagoCoreController.java
@@ -1,5 +1,7 @@
 package um.tesoreria.core.controller.facade;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,9 +28,23 @@ public class MercadoPagoCoreController {
         }
     }
 
+    @GetMapping("/makeContextsChequera/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{alternativaId}")
+    public ResponseEntity<List<UMPreferenceMPDto>> makeContextsChequera(@PathVariable Integer facultadId, @PathVariable Integer tipoChequeraId, @PathVariable Long chequeraSerieId, @PathVariable Integer alternativaId) {
+        try {
+            return ResponseEntity.ok(service.makeContextsChequera(facultadId, tipoChequeraId, chequeraSerieId, alternativaId));
+        } catch (MercadoPagoContextException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+    }
+
     @PutMapping("/updateContext/{mercadoPagoContextId}")
     public ResponseEntity<MercadoPagoContext> updateContext(@RequestBody MercadoPagoContext mercadoPagoContext, @PathVariable Long mercadoPagoContextId) {
         return ResponseEntity.ok(service.updateContext(mercadoPagoContext, mercadoPagoContextId));
+    }
+
+    @PutMapping("/updateContexts")
+    public ResponseEntity<List<MercadoPagoContext>> updateContexts(@RequestBody List<MercadoPagoContext> contexts) {
+        return ResponseEntity.ok(service.updateContexts(contexts));
     }
 
     @GetMapping("/find/context/{mercadoPagoContextId}")

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/exception/ChequeraCuotaException.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/exception/ChequeraCuotaException.java
@@ -29,4 +29,10 @@ public class ChequeraCuotaException extends RuntimeException {
 		super(MessageFormat.format("Cannot find ChequeraCuota {0}/{1}/{2}/{3}", facultadId, tipoChequeraId,
 				chequeraSerieId, alternativaId));
     }
+
+    public ChequeraCuotaException(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId,
+			Integer productoId, Integer alternativaId) {
+		super(MessageFormat.format("Cannot find ChequeraCuota {0}/{1}/{2}/{3}/{4}", facultadId, tipoChequeraId,
+				chequeraSerieId, productoId, alternativaId));
+	}
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/service/ChequeraCuotaService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/service/ChequeraCuotaService.java
@@ -34,6 +34,7 @@ public class ChequeraCuotaService {
     private final FindAllPeriodosLectivoUseCase findAllPeriodosLectivoUseCase;
     private final FindAllByChequeraIdsUseCase findAllByChequeraIdsUseCase;
     private final FindAllByFacultadTipoChequeraSerieIdsUseCase findAllByFacultadTipoChequeraSerieIdsUseCase;
+    private final GetCuotaActualUseCase getCuotaActualUseCase;
 
     public List<ChequeraCuota> findAllByChequera(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId) {
         return findAllByChequeraUseCase.findAllByChequera(facultadId, tipoChequeraId, chequeraSerieId);
@@ -123,6 +124,12 @@ public class ChequeraCuotaService {
 
     public List<ChequeraCuota> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIds(Integer facultadId, Integer tipoChequeraId, List<Long> chequeraSerieIds) {
         return findAllByFacultadTipoChequeraSerieIdsUseCase.findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIds(facultadId, tipoChequeraId, chequeraSerieIds);
+    }
+
+    public ChequeraCuota getCuotaActual(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId,
+                                         Integer productoId, Integer alternativaId, OffsetDateTime fechaActual) {
+        return getCuotaActualUseCase.getCuotaActual(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, fechaActual)
+                .orElseThrow(() -> new ChequeraCuotaException(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId));
     }
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/usecases/GetCuotaActualUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/usecases/GetCuotaActualUseCaseImpl.java
@@ -1,0 +1,44 @@
+package um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.ports.in.GetCuotaActualUseCase;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.ports.out.ChequeraCuotaRepository;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.service.ChequeraSerieService;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class GetCuotaActualUseCaseImpl implements GetCuotaActualUseCase {
+
+    private final ChequeraCuotaRepository repository;
+    private final ChequeraSerieService chequeraSerieService;
+
+    @Override
+    public Optional<ChequeraCuota> getCuotaActual(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId,
+                                                   Integer productoId, Integer alternativaId, OffsetDateTime fechaActual) {
+        var cuotas = repository.findAllByChequeraAlternativa(facultadId, tipoChequeraId, chequeraSerieId, alternativaId);
+        Optional<ChequeraCuota> cuotaActual = cuotas.stream()
+                .filter(cuota -> isBeforeAnyVencimiento(fechaActual, cuota))
+                .findFirst();
+        if (cuotaActual.isPresent()) {
+            ChequeraCuota chequeraCuota = cuotaActual.get();
+            if (chequeraCuota.getChequeraId() == null) {
+                ChequeraSerie chequeraSerie = chequeraSerieService.findByUnique(facultadId, tipoChequeraId, chequeraSerieId);
+                chequeraCuota.setChequeraId(chequeraSerie.getChequeraId());
+                chequeraCuota = repository.save(chequeraCuota);
+            }
+            return Optional.of(chequeraCuota);
+        }
+        return Optional.empty();
+    }
+
+    private boolean isBeforeAnyVencimiento(OffsetDateTime fechaActual, ChequeraCuota cuota) {
+        return (cuota.getVencimiento1() != null && fechaActual.isBefore(cuota.getVencimiento1()))
+                || (cuota.getVencimiento2() != null && fechaActual.isBefore(cuota.getVencimiento2()));
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/domain/ports/in/GetCuotaActualUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/domain/ports/in/GetCuotaActualUseCase.java
@@ -1,0 +1,11 @@
+package um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public interface GetCuotaActualUseCase {
+    Optional<ChequeraCuota> getCuotaActual(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId,
+                                           Integer productoId, Integer alternativaId, OffsetDateTime fechaActual);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/persistence/adapter/JpaChequeraCuotaRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/persistence/adapter/JpaChequeraCuotaRepositoryAdapter.java
@@ -84,7 +84,7 @@ public class JpaChequeraCuotaRepositoryAdapter implements ChequeraCuotaRepositor
                 facultadId, tipoChequeraId, chequeraSerieId, alternativaId, Sort.by("vencimiento1").ascending()
                         .and(Sort.by("productoId").ascending().and(Sort.by("cuotaId").ascending()))
         );
-        log.debug("\n\nJpaChequeraCuotaRepositoryAdapter.findAllByChequeraAlternativa.cuotas -> {}\n\n", Jsonifier.builder(cuotas).build());
+//        log.debug("\n\nJpaChequeraCuotaRepositoryAdapter.findAllByChequeraAlternativa.cuotas -> {}\n\n", Jsonifier.builder(cuotas).build());
         return cuotas.stream().map(mapper::toDomain).toList();
     }
 

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/persistence/repository/JpaChequeraCuotaRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/persistence/repository/JpaChequeraCuotaRepository.java
@@ -25,7 +25,14 @@ public interface JpaChequeraCuotaRepository extends JpaRepository<ChequeraCuotaE
 
 	List<ChequeraCuotaEntity> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieId(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId);
 
-	@EntityGraph(attributePaths = {"producto", "chequeraSerie", "facultad", "tipoChequera"})
+	@EntityGraph(attributePaths = {
+		"producto", "facultad",
+		"tipoChequera", "tipoChequera.geografica", "tipoChequera.claseChequera",
+		"chequeraSerie", "chequeraSerie.facultad", "chequeraSerie.tipoChequera",
+		"chequeraSerie.tipoChequera.geografica", "chequeraSerie.tipoChequera.claseChequera",
+		"chequeraSerie.persona", "chequeraSerie.domicilio",
+		"chequeraSerie.lectivo", "chequeraSerie.arancelTipo", "chequeraSerie.geografica"
+	})
 	List<ChequeraCuotaEntity> findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaId(
 			Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer alternativaId, Sort sort);
 

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/web/controller/ChequeraCuotaController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/web/controller/ChequeraCuotaController.java
@@ -135,4 +135,18 @@ public class ChequeraCuotaController {
         return ResponseEntity.ok(service.findAllPeriodosLectivo(lectivoId));
     }
 
+    @GetMapping("/cuotaActual/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{productoId}/{alternativaId}")
+    public ResponseEntity<ChequeraCuotaResponse> getCuotaActual(@PathVariable Integer facultadId,
+                                                                 @PathVariable Integer tipoChequeraId,
+                                                                 @PathVariable Long chequeraSerieId,
+                                                                 @PathVariable Integer productoId,
+                                                                 @PathVariable Integer alternativaId) {
+        try {
+            var domain = service.getCuotaActual(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, OffsetDateTime.now());
+            return ResponseEntity.ok(chequeraCuotaDtoMapper.toResponse(domain));
+        } catch (ChequeraCuotaException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+    }
+
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/application/service/PoliticaArancelariaService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/application/service/PoliticaArancelariaService.java
@@ -12,8 +12,8 @@ public class PoliticaArancelariaService {
     private final RecalculateCuotaByUniqueIndexUseCase findPoliticaArancelariaUseCase;
 
     public ChequeraCuota recalculateCuotaByUniqueIndex(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId,
-                              Integer productoId, Integer alternativaId, Integer cuotaId) {
+                              Integer productoId, Integer alternativaId, Integer cuotaId, Integer plazo) {
         return findPoliticaArancelariaUseCase.recalculateCuota(facultadId, tipoChequeraId, chequeraSerieId,
-                productoId, alternativaId, cuotaId);
+                productoId, alternativaId, cuotaId, plazo);
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/application/usecases/RecalculateCuotaByUniqueIndexUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/application/usecases/RecalculateCuotaByUniqueIndexUseCaseImpl.java
@@ -1,21 +1,49 @@
 package um.tesoreria.core.hexagonal.chequera.politicaArancelaria.application.usecases;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.exception.ChequeraCuotaException;
 import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
 import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
 import um.tesoreria.core.hexagonal.chequera.politicaArancelaria.domain.ports.in.RecalculateCuotaByUniqueIndexUseCase;
+import um.tesoreria.core.util.Tool;
+
+import java.time.OffsetDateTime;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class RecalculateCuotaByUniqueIndexUseCaseImpl implements RecalculateCuotaByUniqueIndexUseCase {
 
     private final ChequeraCuotaService chequeraCuotaService;
 
     @Override
-    public ChequeraCuota recalculateCuota(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Integer cuotaId) {
-        var cuota = chequeraCuotaService.findByUnique(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaId);
-        return cuota;
+    public ChequeraCuota recalculateCuota(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Integer cuotaId, Integer plazo) {
+        var cuotaEnRevision = chequeraCuotaService.findByUnique(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaId);
+        log.debug("Cuota en revision: {}", cuotaEnRevision.jsonify());
+        // Si todavía no pasa la segunda fecha de mora no hay nada que hacer
+        if (cuotaEnRevision.getVencimiento3().isAfter(OffsetDateTime.now())) {
+            return cuotaEnRevision;
+        }
+        ChequeraCuota cuotaReferencia;
+        try {
+            cuotaReferencia = chequeraCuotaService.getCuotaActual(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, OffsetDateTime.now());
+        } catch (ChequeraCuotaException e) {
+            cuotaReferencia = ChequeraCuota.builder()
+                    .importe1(cuotaEnRevision.getImporte3())
+                    .build();
+        }
+        log.debug("Cuota referencia: {}", cuotaReferencia.jsonify());
+        var importeReferencia = cuotaReferencia.getImporte1();
+        if (cuotaEnRevision.getImporte3().compareTo(importeReferencia) > 0) {
+            importeReferencia = cuotaReferencia.getImporte3();
+        }
+        var fechaReferencia = Tool.firstTime(OffsetDateTime.now()).plusDays(plazo);
+        cuotaEnRevision.setImporte3(importeReferencia);
+        cuotaEnRevision.setVencimiento3(fechaReferencia);
+        log.debug("Cuota nueva: {}", cuotaEnRevision.jsonify());
+        return cuotaEnRevision;
     }
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/domain/ports/in/RecalculateCuotaByUniqueIndexUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/domain/ports/in/RecalculateCuotaByUniqueIndexUseCase.java
@@ -4,5 +4,5 @@ import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraC
 
 public interface RecalculateCuotaByUniqueIndexUseCase {
     ChequeraCuota recalculateCuota(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId,
-                       Integer productoId, Integer alternativaId, Integer cuotaId);
+                       Integer productoId, Integer alternativaId, Integer cuotaId, Integer plazo);
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/infrastructure/web/controller/PoliticaArancelariaController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/infrastructure/web/controller/PoliticaArancelariaController.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import um.tesoreria.core.hexagonal.chequera.politicaArancelaria.application.service.PoliticaArancelariaService;
+import um.tesoreria.core.hexagonal.chequera.politicaArancelaria.infrastructure.web.dto.PoliticaArancelariaResponse;
+import um.tesoreria.core.hexagonal.chequera.politicaArancelaria.infrastructure.web.mapper.PoliticaArancelariaDtoMapper;
 
 @RestController
 @RequestMapping("/api/tesoreria/core/politicaArancelaria")
@@ -11,15 +13,18 @@ import um.tesoreria.core.hexagonal.chequera.politicaArancelaria.application.serv
 public class PoliticaArancelariaController {
 
     private final PoliticaArancelariaService service;
+    private final PoliticaArancelariaDtoMapper politicaArancelariaDtoMapper;
 
-    @GetMapping("/recalculate/cuota/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{productoId}/{alternativaId}/{cuotaId}")
-    public ResponseEntity<?> recalculateCuotaByUnique(
+    @GetMapping("/recalculate/cuota/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{productoId}/{alternativaId}/{cuotaId}/plazo/{dias}")
+    public ResponseEntity<PoliticaArancelariaResponse> recalculateCuotaByUnique(
             @PathVariable Integer facultadId,
             @PathVariable Integer tipoChequeraId,
             @PathVariable Long chequeraSerieId,
             @PathVariable Integer productoId,
             @PathVariable Integer alternativaId,
-            @PathVariable Integer cuotaId) {
-        return ResponseEntity.ok(service.recalculateCuotaByUniqueIndex(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaId));
+            @PathVariable Integer cuotaId,
+            @PathVariable Integer dias) {
+        var domain = service.recalculateCuotaByUniqueIndex(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaId, dias);
+        return ResponseEntity.ok(politicaArancelariaDtoMapper.toResponse(domain));
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/infrastructure/web/dto/PoliticaArancelariaResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/infrastructure/web/dto/PoliticaArancelariaResponse.java
@@ -1,0 +1,57 @@
+package um.tesoreria.core.hexagonal.chequera.politicaArancelaria.infrastructure.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PoliticaArancelariaResponse {
+
+    private Long chequeraCuotaId;
+    private Long chequeraId;
+    private Integer facultadId;
+    private Integer tipoChequeraId;
+    private Long chequeraSerieId;
+    private Integer productoId;
+    private Integer alternativaId;
+    private Integer cuotaId;
+    private Integer mes;
+    private Integer anho;
+    private Integer arancelTipoId;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
+    private OffsetDateTime vencimiento1;
+
+    private BigDecimal importe1;
+    private BigDecimal importe1Original;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
+    private OffsetDateTime vencimiento2;
+
+    private BigDecimal importe2;
+    private BigDecimal importe2Original;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
+    private OffsetDateTime vencimiento3;
+
+    private BigDecimal importe3;
+    private BigDecimal importe3Original;
+    private String codigoBarras;
+    private String i2Of5;
+    private Byte pagado;
+    private Byte baja;
+    private Byte manual;
+    private Byte compensada;
+    private Integer tramoId;
+
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/infrastructure/web/mapper/PoliticaArancelariaDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/infrastructure/web/mapper/PoliticaArancelariaDtoMapper.java
@@ -1,0 +1,43 @@
+package um.tesoreria.core.hexagonal.chequera.politicaArancelaria.infrastructure.web.mapper;
+
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
+import um.tesoreria.core.hexagonal.chequera.politicaArancelaria.infrastructure.web.dto.PoliticaArancelariaResponse;
+
+@Component
+public class PoliticaArancelariaDtoMapper {
+
+    public PoliticaArancelariaResponse toResponse(ChequeraCuota domain) {
+        if (domain == null) return null;
+        return PoliticaArancelariaResponse.builder()
+                .chequeraCuotaId(domain.getChequeraCuotaId())
+                .chequeraId(domain.getChequeraId())
+                .facultadId(domain.getFacultadId())
+                .tipoChequeraId(domain.getTipoChequeraId())
+                .chequeraSerieId(domain.getChequeraSerieId())
+                .productoId(domain.getProductoId())
+                .alternativaId(domain.getAlternativaId())
+                .cuotaId(domain.getCuotaId())
+                .mes(domain.getMes())
+                .anho(domain.getAnho())
+                .arancelTipoId(domain.getArancelTipoId())
+                .vencimiento1(domain.getVencimiento1())
+                .importe1(domain.getImporte1())
+                .importe1Original(domain.getImporte1Original())
+                .vencimiento2(domain.getVencimiento2())
+                .importe2(domain.getImporte2())
+                .importe2Original(domain.getImporte2Original())
+                .vencimiento3(domain.getVencimiento3())
+                .importe3(domain.getImporte3())
+                .importe3Original(domain.getImporte3Original())
+                .codigoBarras(domain.getCodigoBarras())
+                .i2Of5(domain.getI2Of5())
+                .pagado(domain.getPagado())
+                .baja(domain.getBaja())
+                .manual(domain.getManual())
+                .compensada(domain.getCompensada())
+                .tramoId(domain.getTramoId())
+                .build();
+    }
+
+}

--- a/src/main/java/um/tesoreria/core/service/facade/MercadoPagoCoreService.java
+++ b/src/main/java/um/tesoreria/core/service/facade/MercadoPagoCoreService.java
@@ -55,6 +55,34 @@ public class MercadoPagoCoreService {
     }
 
     @Transactional
+    public List<UMPreferenceMPDto> makeContextsChequera(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer alternativaId) {
+        log.debug("\n\nProcessing MercadoPagoCoreService.makeContextsChequera\n\n");
+        var today = LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC);
+        List<ChequeraCuota> pendientes = chequeraCuotaService.findAllPendientes(facultadId, tipoChequeraId, chequeraSerieId, alternativaId);
+        List<UMPreferenceMPDto> result = new java.util.ArrayList<>();
+        
+        for (var chequeraCuota : pendientes) {
+            if (chequeraCuota == null || !isCuotaAvailable(chequeraCuota)) continue;
+
+            var vencimiento = determineVencimientoMP(chequeraCuota, today);
+            if (vencimiento.importe().compareTo(BigDecimal.ZERO) == 0) continue;
+            if (vencimiento.fechaVencimiento().isBefore(today)) continue;
+
+            MercadoPagoContext mercadoPagoContext = findExistingContext(chequeraCuota.getChequeraCuotaId());
+            mercadoPagoContext = createOrUpdateContext(mercadoPagoContext, chequeraCuota.getChequeraCuotaId(), vencimiento);
+            var response = buildResponse(mercadoPagoContext, chequeraCuota);
+            result.add(response);
+        }
+        return result;
+    }
+
+    @Transactional
+    public List<MercadoPagoContext> updateContexts(List<MercadoPagoContext> contexts) {
+        log.debug("Processing MercadoPagoCoreService.updateContexts");
+        return mercadoPagoContextService.saveAll(contexts);
+    }
+
+    @Transactional
     public UMPreferenceMPDto makeContextCuota(ChequeraCuota chequeraCuota, MercadoPagoContext existingContext) {
         var today = LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC);
         if (chequeraCuota == null || !isCuotaAvailable(chequeraCuota)) return null;


### PR DESCRIPTION
Closes #293

## Descripción
Version bump **3.37.0 → 3.38.0** con nuevas funcionalidades en ChequeraCuota, PoliticaArancelaria y MercadoPago, corrección de namespaces vacíos en diagramas Mermaid, y mejora de rendimiento JPA.

## Cambios Realizados
- **feat(chequeraCuota):** Nuevo `GetCuotaActualUseCase` que obtiene la cuota activa más próxima según vencimientos, con endpoint `GET /chequeraCuota/cuotaActual/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{productoId}/{alternativaId}`
- **feat(politicaArancelaria):** Parámetro `plazo` (días) en endpoint `/recalculate/cuota/.../plazo/{dias}`, con nuevo `PoliticaArancelariaResponse` DTO y mapper para respuesta enriquecida
- **feat(mercadoPago):** Endpoints batch `makeContextsChequera` (generar contextos para toda una chequera) y `updateContexts` (actualización masiva)
- **fix(docs):** Limpieza de namespaces vacíos en 20+ diagramas Mermaid que causaban `Syntax Error` en Mermaid v10+
- **fix(docs):** Sanitizador en `script.js` para eliminar namespaces vacíos al vuelo
- **fix(chequeraCuota):** Log verbose comentado en `JpaChequeraCuotaRepositoryAdapter`
- **perf(jpa):** `@EntityGraph` enriquecido con 9 asociaciones anidadas en consulta de chequera alternativa para evitar `LazyInitializationException`

## Archivos modificados
- 4 archivos nuevos (GetCuotaActualUseCase, GetCuotaActualUseCaseImpl, PoliticaArancelariaResponse, PoliticaArancelariaDtoMapper)
- 10 archivos modificados (services, controllers, use cases, repositorio, pom.xml)
- 29 diagramas Mermaid corregidos + script.js

## Verificación
- `mvn clean compile` — verifica compilación
- `mvn test` — verifica tests existentes
- Probar endpoints nuevos vía Swagger o curl
