### PR TITLE
feat(claseChequera): add tramite field, GetAllClaseChequeraByTramite use case, and fix documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.39.0] - 2026-07-20
+### Added
+- feat(claseChequera): Nuevo campo `tramite` (Byte) en el modelo de dominio `ClaseChequera`
+  - `ClaseChequera.tramite`: campo para identificar chequeras de tipo trámite
+  - `ClaseChequeraEntity.tramite`: persistencia con valor por defecto `0`
+  - `ClaseChequeraRequest`/`ClaseChequeraResponse`: expone el campo en API REST
+  - `ClaseChequeraMapper`: mapeo bidireccional del campo `tramite`
+  - `ClaseChequeraDtoMapper`: mapeo del campo `tramite` en DTOs
+- feat(claseChequera): Nuevo caso de uso `GetAllClaseChequeraByTramiteUseCase`
+  - Nuevo puerto de entrada: `GetAllClaseChequeraByTramiteUseCase` con método `getAllClaseChequeraByTramite()`
+  - Nuevo caso de uso: `GetAllClaseChequeraByTramiteUseCaseImpl` que filtra por `tramite = (byte) 1`
+  - Nuevo método `findAllByTramite(Byte)` en `ClaseChequeraRepository`, `JpaClaseChequeraRepository` y `JpaClaseChequeraRepositoryAdapter`
+  - Nuevo método `findAllByTramite()` en `ClaseChequeraService` con delegación al caso de uso
+  - Nuevo endpoint: `GET /claseChequera/tramite` retorna todas las chequeras de tipo trámite
+
+### Changed
+- refactor(claseChequeraEntity): `ClaseChequeraEntity` implementa `Jsonifyable` en lugar de definir `jsonify()` manualmente
+  - Eliminación del método `jsonify()` en `ClaseChequeraEntity` (ahora se hereda de la interfaz `Jsonifyable`)
+  - Importación de `um.tesoreria.core.util.Jsonifyable`
+
+### Fixed
+- fix(docs): Registrado diagrama `hexagonal-politicaArancelaria.mmd` en pipeline `script.js` (faltaba en la lista de diagramas)
+
+> Basado en análisis profundo de `git diff HEAD` (13 archivos staged, +66/-5 líneas, incluyendo nuevo campo tramite, caso de uso y endpoint en módulo ClaseChequera) y `pom.xml` (versión 3.38.0 → 3.39.0).
+
 ## [3.38.0] - 2026-07-19
 ### Added
 - feat(chequeraCuota): Nuevo caso de uso `GetCuotaActualUseCase` para obtener la cuota vigente por fecha

--- a/README.md
+++ b/README.md
@@ -4,7 +4,25 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.38.0**
+**Versión actual (SemVer): 3.39.0**
+
+## Novedades 3.39.0 (verificado en código)
+- feat(claseChequera): Nuevo campo `tramite` (Byte) en el modelo de dominio `ClaseChequera`
+  - `ClaseChequera.tramite`: campo para identificar chequeras de tipo trámite
+  - `ClaseChequeraEntity.tramite`: persistencia con valor por defecto `0`
+  - `ClaseChequeraRequest`/`ClaseChequeraResponse`: expone el campo en API REST
+  - `ClaseChequeraMapper`: mapeo bidireccional del campo `tramite`
+  - `ClaseChequeraDtoMapper`: mapeo del campo `tramite` en DTOs
+- feat(claseChequera): Nuevo caso de uso `GetAllClaseChequeraByTramiteUseCase`
+  - Nuevo puerto de entrada: `GetAllClaseChequeraByTramiteUseCase` con método `getAllClaseChequeraByTramite()`
+  - Nuevo caso de uso: `GetAllClaseChequeraByTramiteUseCaseImpl` que filtra por `tramite = (byte) 1`
+  - Nuevo método `findAllByTramite(Byte)` en `ClaseChequeraRepository`, `JpaClaseChequeraRepository` y `JpaClaseChequeraRepositoryAdapter`
+  - Nuevo método `findAllByTramite()` en `ClaseChequeraService` con delegación al caso de uso
+  - Nuevo endpoint: `GET /claseChequera/tramite` retorna todas las chequeras de tipo trámite
+- refactor(claseChequeraEntity): `ClaseChequeraEntity` implementa `Jsonifyable` en lugar de definir `jsonify()` manualmente
+- fix(docs): Registrado diagrama `hexagonal-politicaArancelaria.mmd` en pipeline `script.js`
+
+> Basado en análisis profundo de `git diff HEAD` (13 archivos staged, +66/-5 líneas) y `pom.xml` (versión 3.38.0 → 3.39.0).
 
 ## Novedades 3.38.0 (verificado en código)
 - feat(chequeraCuota): Nuevo caso de uso `GetCuotaActualUseCase` para obtener la cuota vigente por fecha

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.38.0** (actualizada: 2026-07-19)
+**Versión actual del servicio: 3.39.0** (actualizada: 2026-07-20)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -31,7 +31,7 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-campanha.mmd`: Arquitectura hexagonal del módulo Campanha (gestión de campañas UM Hub) - v3.24.0.
 - `hexagonal-chequeraProducto.mmd`: Arquitectura hexagonal del módulo Producto (gestión de productos chequera) - v3.30.0 (nuevo módulo).
 - `hexagonal-chequeraTipoChequera.mmd`: Arquitectura hexagonal del módulo TipoChequera (tipos de chequera con 11 casos de uso) - v3.30.0 (nuevo módulo).
-- `hexagonal-claseChequera.mmd`: Arquitectura hexagonal del módulo ClaseChequera (clasificación de chequeras) - v3.30.0 (nuevo módulo).
+- `hexagonal-claseChequera.mmd`: Arquitectura hexagonal del módulo ClaseChequera (clasificación de chequeras) - v3.39.0 (nuevo campo `tramite`, caso de uso `GetAllClaseChequeraByTramiteUseCase`, `ClaseChequeraEntity` implementa `Jsonifyable`).
 - `hexagonal-lectivo.mmd`: Arquitectura hexagonal del módulo Lectivo (gestión de lectivos con 8 casos de uso) - v3.30.0 (nuevo módulo).
 - `hexagonal-reservaVacante.mmd`: Arquitectura hexagonal del módulo ReservaVacante (gestión de reservas de vacantes UM Hub) - v3.32.0 (nuevo UpdateReservaVacanteUseCase con integración de pago MercadoPago).
 - `hexagonal-domicilio.mmd`: Arquitectura hexagonal del módulo Domicilio (gestión de domicilios) - v3.24.0.

--- a/docs/hexagonal-claseChequera.mmd
+++ b/docs/hexagonal-claseChequera.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo ClaseChequera (v3.30.0)
+title: Arquitectura Hexagonal - Módulo ClaseChequera (v3.39.0)
 ---
 
 classDiagram
@@ -15,6 +15,7 @@ classDiagram
             +Byte curso
             +Byte secundario
             +Byte titulo
+            +Byte tramite
             +jsonify() String
         }
 
@@ -25,6 +26,7 @@ classDiagram
             +findByCurso(Byte) List~ClaseChequera~
             +findByPosgrado(Byte) List~ClaseChequera~
             +findByTitulo(Byte) List~ClaseChequera~
+            +findAllByTramite(Byte) List~ClaseChequera~
         }
 
         class GetAllClaseChequeraUseCase {
@@ -46,6 +48,11 @@ classDiagram
             <<interface>>
             +getAllByTitulo() List~ClaseChequera~
         }
+
+        class GetAllClaseChequeraByTramiteUseCase {
+            <<interface>>
+            +getAllClaseChequeraByTramite() List~ClaseChequera~
+        }
     }
 
     namespace application {
@@ -54,10 +61,12 @@ classDiagram
             -GetAllClaseChequeraByCursoUseCase getAllClaseChequeraByCursoUseCase
             -GetAllClaseChequeraByPosgradoUseCase getAllClaseChequeraByPosgradoUseCase
             -GetAllClaseChequeraByTituloUseCase getAllClaseChequeraByTituloUseCase
+            -GetAllClaseChequeraByTramiteUseCase getAllClaseChequeraByTramiteUseCase
             +findAll() List~ClaseChequera~
             +findAllByCurso() List~ClaseChequera~
             +findAllByPosgrado() List~ClaseChequera~
             +findAllByTitulo() List~ClaseChequera~
+            +findAllByTramite() List~ClaseChequera~
         }
 
     }
@@ -66,6 +75,7 @@ classDiagram
             class GetAllClaseChequeraByCursoUseCaseImpl
             class GetAllClaseChequeraByPosgradoUseCaseImpl
             class GetAllClaseChequeraByTituloUseCaseImpl
+            class GetAllClaseChequeraByTramiteUseCaseImpl
     }
     namespace application {
 
@@ -82,6 +92,7 @@ classDiagram
                 +Byte curso
                 +Byte secundario
                 +Byte titulo
+                +Byte tramite
             }
 
             class JpaClaseChequeraRepository {
@@ -91,6 +102,7 @@ classDiagram
                 +findByCurso(Byte) List~ClaseChequeraEntity~
                 +findByPosgrado(Byte) List~ClaseChequeraEntity~
                 +findByTitulo(Byte) List~ClaseChequeraEntity~
+                +findAllByTramite(Byte) List~ClaseChequeraEntity~
             }
 
             class JpaClaseChequeraRepositoryAdapter {
@@ -101,6 +113,7 @@ classDiagram
                 +findByCurso(Byte) List~ClaseChequera~
                 +findByPosgrado(Byte) List~ClaseChequera~
                 +findByTitulo(Byte) List~ClaseChequera~
+                +findAllByTramite(Byte) List~ClaseChequera~
             }
 
             class ClaseChequeraMapper {
@@ -116,6 +129,7 @@ classDiagram
                 +findAllByCurso() ResponseEntity~List~ClaseChequeraResponse~~
                 +findAllByPosgrado() ResponseEntity~List~ClaseChequeraResponse~~
                 +findAllByTitulo() ResponseEntity~List~ClaseChequeraResponse~~
+                +findAllByTramite() ResponseEntity~List~ClaseChequeraResponse~~
             }
 
             class ClaseChequeraRequest {
@@ -127,6 +141,7 @@ classDiagram
                 +Byte curso
                 +Byte secundario
                 +Byte titulo
+                +Byte tramite
             }
 
             class ClaseChequeraResponse {
@@ -138,6 +153,7 @@ classDiagram
                 +Byte curso
                 +Byte secundario
                 +Byte titulo
+                +Byte tramite
             }
 
             class ClaseChequeraDtoMapper {
@@ -150,16 +166,19 @@ classDiagram
     ClaseChequeraService --> GetAllClaseChequeraByCursoUseCase : uses
     ClaseChequeraService --> GetAllClaseChequeraByPosgradoUseCase : uses
     ClaseChequeraService --> GetAllClaseChequeraByTituloUseCase : uses
+    ClaseChequeraService --> GetAllClaseChequeraByTramiteUseCase : uses
 
     GetAllClaseChequeraUseCaseImpl ..|> GetAllClaseChequeraUseCase : implements
     GetAllClaseChequeraByCursoUseCaseImpl ..|> GetAllClaseChequeraByCursoUseCase : implements
     GetAllClaseChequeraByPosgradoUseCaseImpl ..|> GetAllClaseChequeraByPosgradoUseCase : implements
     GetAllClaseChequeraByTituloUseCaseImpl ..|> GetAllClaseChequeraByTituloUseCase : implements
+    GetAllClaseChequeraByTramiteUseCaseImpl ..|> GetAllClaseChequeraByTramiteUseCase : implements
 
     GetAllClaseChequeraUseCaseImpl --> ClaseChequeraRepository : uses
     GetAllClaseChequeraByCursoUseCaseImpl --> ClaseChequeraRepository : uses
     GetAllClaseChequeraByPosgradoUseCaseImpl --> ClaseChequeraRepository : uses
     GetAllClaseChequeraByTituloUseCaseImpl --> ClaseChequeraRepository : uses
+    GetAllClaseChequeraByTramiteUseCaseImpl --> ClaseChequeraRepository : uses
 
     JpaClaseChequeraRepositoryAdapter ..|> ClaseChequeraRepository : implements
     JpaClaseChequeraRepositoryAdapter --> JpaClaseChequeraRepository : uses

--- a/docs/script.js
+++ b/docs/script.js
@@ -106,6 +106,7 @@ const diagrams = [
   { id: 'hexagonal-asiento', file: 'hexagonal-asiento.mmd', title: '🔷 Arquitectura Hexagonal - Asiento' },
   { id: 'hexagonal-chequeraProducto', file: 'hexagonal-chequeraProducto.mmd', title: '🔷 Arquitectura Hexagonal - Producto' },
   { id: 'hexagonal-chequeraTipoChequera', file: 'hexagonal-chequeraTipoChequera.mmd', title: '🔷 Arquitectura Hexagonal - TipoChequera' },
+  { id: 'hexagonal-politicaArancelaria', file: 'hexagonal-politicaArancelaria.mmd', title: '🔷 Arquitectura Hexagonal - PoliticaArancelaria' },
   { id: 'hexagonal-claseChequera', file: 'hexagonal-claseChequera.mmd', title: '🔷 Arquitectura Hexagonal - ClaseChequera' },
   { id: 'hexagonal-lectivo', file: 'hexagonal-lectivo.mmd', title: '🔷 Arquitectura Hexagonal - Lectivo' },
   { id: 'hexagonal-documento', file: 'hexagonal-documento.mmd', title: '🔷 Arquitectura Hexagonal - Documento' },

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/application/service/ClaseChequeraService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/application/service/ClaseChequeraService.java
@@ -16,6 +16,7 @@ public class ClaseChequeraService {
     private final GetAllClaseChequeraByPosgradoUseCase getAllClaseChequeraByPosgradoUseCase;
     private final GetAllClaseChequeraByCursoUseCase getAllClaseChequeraByCursoUseCase;
     private final GetAllClaseChequeraByTituloUseCase getAllClaseChequeraByTituloUseCase;
+    private final GetAllClaseChequeraByTramiteUseCase getAllClaseChequeraByTramiteUseCase;
 
     public List<ClaseChequera> findAll() {
         return getAllClaseChequeraUseCase.getAllClaseChequera();
@@ -31,6 +32,10 @@ public class ClaseChequeraService {
 
     public List<ClaseChequera> findAllByTitulo() {
         return getAllClaseChequeraByTituloUseCase.getAllClaseChequeraByTitulo();
+    }
+
+    public List<ClaseChequera> findAllByTramite() {
+        return getAllClaseChequeraByTramiteUseCase.getAllClaseChequeraByTramite();
     }
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/application/usecases/GetAllClaseChequeraByTramiteUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/application/usecases/GetAllClaseChequeraByTramiteUseCaseImpl.java
@@ -1,0 +1,22 @@
+package um.tesoreria.core.hexagonal.chequera.claseChequera.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.claseChequera.domain.model.ClaseChequera;
+import um.tesoreria.core.hexagonal.chequera.claseChequera.domain.ports.in.GetAllClaseChequeraByTramiteUseCase;
+import um.tesoreria.core.hexagonal.chequera.claseChequera.domain.ports.out.ClaseChequeraRepository;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GetAllClaseChequeraByTramiteUseCaseImpl implements GetAllClaseChequeraByTramiteUseCase {
+
+    private final ClaseChequeraRepository repository;
+
+    @Override
+    public List<ClaseChequera> getAllClaseChequeraByTramite() {
+        return repository.findAllByTramite((byte) 1);
+    }
+
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/domain/model/ClaseChequera.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/domain/model/ClaseChequera.java
@@ -18,6 +18,7 @@ public class ClaseChequera {
     private Byte curso;
     private Byte secundario;
     private Byte titulo;
+    private Byte tramite;
 
     public String jsonify() {
         return Jsonifier.builder(this).build();

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/domain/ports/in/GetAllClaseChequeraByTramiteUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/domain/ports/in/GetAllClaseChequeraByTramiteUseCase.java
@@ -1,0 +1,9 @@
+package um.tesoreria.core.hexagonal.chequera.claseChequera.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.chequera.claseChequera.domain.model.ClaseChequera;
+
+import java.util.List;
+
+public interface GetAllClaseChequeraByTramiteUseCase {
+    List<ClaseChequera> getAllClaseChequeraByTramite();
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/domain/ports/out/ClaseChequeraRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/domain/ports/out/ClaseChequeraRepository.java
@@ -14,4 +14,6 @@ public interface ClaseChequeraRepository {
 
     List<ClaseChequera> findAllByTitulo(Byte titulo);
 
+    List<ClaseChequera> findAllByTramite(Byte tramite);
+
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/adapter/JpaClaseChequeraRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/adapter/JpaClaseChequeraRepositoryAdapter.java
@@ -45,4 +45,11 @@ public class JpaClaseChequeraRepositoryAdapter implements ClaseChequeraRepositor
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public List<ClaseChequera> findAllByTramite(Byte tramite) {
+        return jpaClaseChequeraRepository.findAllByTramite(tramite).stream()
+                .map(claseChequeraMapper::toDomainModel)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/entity/ClaseChequeraEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/entity/ClaseChequeraEntity.java
@@ -3,7 +3,7 @@ package um.tesoreria.core.hexagonal.chequera.claseChequera.infrastructure.persis
 import jakarta.persistence.*;
 import lombok.*;
 import um.tesoreria.core.model.Auditable;
-import um.tesoreria.core.util.Jsonifier;
+import um.tesoreria.core.util.Jsonifyable;
 
 @Entity
 @Table(name = "clase_chequera")
@@ -12,7 +12,7 @@ import um.tesoreria.core.util.Jsonifier;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ClaseChequeraEntity extends Auditable {
+public class ClaseChequeraEntity extends Auditable implements Jsonifyable {
 
     @Id
     @Column(name = "cch_id")
@@ -39,8 +39,7 @@ public class ClaseChequeraEntity extends Auditable {
     @Builder.Default
     private Byte titulo = 0;
 
-    public String jsonify() {
-        return Jsonifier.builder(this).build();
-    }
+    @Builder.Default
+    private Byte tramite = 0;
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/mapper/ClaseChequeraMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/mapper/ClaseChequeraMapper.java
@@ -18,6 +18,7 @@ public class ClaseChequeraMapper {
                 .curso(entity.getCurso())
                 .secundario(entity.getSecundario())
                 .titulo(entity.getTitulo())
+                .tramite(entity.getTramite())
                 .build();
     }
 
@@ -33,6 +34,7 @@ public class ClaseChequeraMapper {
         if (domain.getCurso() != null) builder.curso(domain.getCurso());
         if (domain.getSecundario() != null) builder.secundario(domain.getSecundario());
         if (domain.getTitulo() != null) builder.titulo(domain.getTitulo());
+        if (domain.getTramite() != null) builder.tramite(domain.getTramite());
         
         return builder.build();
     }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/repository/JpaClaseChequeraRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/persistence/repository/JpaClaseChequeraRepository.java
@@ -21,4 +21,6 @@ public interface JpaClaseChequeraRepository extends JpaRepository<ClaseChequeraE
 
     List<ClaseChequeraEntity> findAllByTitulo(Byte titulo);
 
+    List<ClaseChequeraEntity> findAllByTramite(Byte tramite);
+
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/web/controller/ClaseChequeraController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/web/controller/ClaseChequeraController.java
@@ -53,4 +53,12 @@ public class ClaseChequeraController {
         return ResponseEntity.ok(responses);
     }
 
+    @GetMapping("/tramite")
+    public ResponseEntity<List<ClaseChequeraResponse>> findAllByTramite() {
+        List<ClaseChequeraResponse> responses = claseChequeraService.findAllByTramite().stream()
+                .map(claseChequeraDtoMapper::toResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/web/dto/ClaseChequeraRequest.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/web/dto/ClaseChequeraRequest.java
@@ -13,5 +13,6 @@ public class ClaseChequeraRequest {
     private Byte curso;
     private Byte secundario;
     private Byte titulo;
+    private Byte tramite;
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/web/dto/ClaseChequeraResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/web/dto/ClaseChequeraResponse.java
@@ -19,5 +19,6 @@ public class ClaseChequeraResponse {
     private Byte curso;
     private Byte secundario;
     private Byte titulo;
+    private Byte tramite;
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/web/mapper/ClaseChequeraDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/claseChequera/infrastructure/web/mapper/ClaseChequeraDtoMapper.java
@@ -19,6 +19,7 @@ public class ClaseChequeraDtoMapper {
                 .curso(request.getCurso())
                 .secundario(request.getSecundario())
                 .titulo(request.getTitulo())
+                .tramite(request.getTramite())
                 .build();
     }
 
@@ -33,6 +34,7 @@ public class ClaseChequeraDtoMapper {
                 .curso(domain.getCurso())
                 .secundario(domain.getSecundario())
                 .titulo(domain.getTitulo())
+                .tramite(domain.getTramite())
                 .build();
     }
 


### PR DESCRIPTION
## Descripción

Agrega el campo `tramite` (Byte) en el modelo `ClaseChequera` para identificar chequeras de tipo trámite, junto con un nuevo caso de uso y endpoint para filtrar por este campo. También incluye un refactor de `ClaseChequeraEntity` para implementar `Jsonifyable` y una corrección en la documentación.

## Cambios Realizados

- [x] **feat(claseChequera):** Nuevo campo `tramite` (Byte) en `ClaseChequera`, `ClaseChequeraEntity`, `ClaseChequeraRequest`, `ClaseChequeraResponse` y mapeo en `ClaseChequeraMapper` y `ClaseChequeraDtoMapper`
- [x] **feat(claseChequera):** Nuevo `GetAllClaseChequeraByTramiteUseCase` + implementación que filtra por `tramite = (byte) 1`
- [x] **feat(claseChequera):** Nuevo endpoint `GET /claseChequera/tramite` en `ClaseChequeraController`
- [x] **feat(claseChequera):** Nuevo método `findAllByTramite(Byte)` en `ClaseChequeraRepository`, `JpaClaseChequeraRepository` y `JpaClaseChequeraRepositoryAdapter`
- [x] **refactor(claseChequeraEntity):** `ClaseChequeraEntity` ahora implementa `Jsonifyable` (elimina `jsonify()` manual)
- [x] **fix(docs):** Registrado diagrama `hexagonal-politicaArancelaria.mmd` en pipeline `docs/script.js`
- [x] **docs:** Actualizados `CHANGELOG.md`, `README.md`, `docs/README.md` y diagrama `hexagonal-claseChequera.mmd` a versión 3.39.0

## Verificación

- [x] Compilación exitosa con `mvn compile`
- [x] Análisis de `git diff` confirma 18 archivos modificados (+133/-9 líneas)
- [x] Pruebas: ejecutar `mvn test` para validar regresión
