### PR TITLE
feat(lectivoCuota): add FindLectivoCuotaByFechaUseCase, ISO 8601 format, and refactor RecalculateCuota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.42.0] - 2026-07-22
+### Added
+- feat(lectivoCuota): Nuevo caso de uso `FindLectivoCuotaByFechaUseCase` para buscar cuotas por fecha de vencimiento
+  - Nuevo puerto de entrada: `FindLectivoCuotaByFechaUseCase` con método `findCuotaByFecha(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, fecha)`
+  - Nuevo caso de uso: `FindLectivoCuotaByFechaUseCaseImpl` que filtra cuotas por `vencimiento2 >= fecha` y `importe2 > 0`
+  - Nuevo método `findCuotaByFecha(...)` en `LectivoCuotaService` con delegación al caso de uso
+- feat(lectivoCuota): Enriquecimiento del modelo de dominio `LectivoCuota` con formato ISO 8601
+  - Añadida anotación `@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXX")` a campos `vencimiento1`, `vencimiento2`, `vencimiento3`
+- feat(lectivoCuota): Nuevo método `findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaId` en `LectivoCuotaRepository`
+  - Implementación en `JpaLectivoCuotaRepositoryAdapter` con consulta derivada `Vencimiento2GreaterThanEqualAndImporte2GreaterThan`
+- feat(politicaArancelaria): Refactorización de `RecalculateCuotaByUniqueIndexUseCaseImpl`
+  - `resolveCuotaReferencia`: ahora busca fallback en `LectivoCuotaService.findCuotaByFecha()` cuando falla `ChequeraCuotaService.getCuotaActual()`
+  - `findCuotaEnRevisionFromLectivo`: usa `findCuotaByFecha()` en lugar de `findByUniqueKey()` para mayor precisión temporal
+  - Resolución de `ahora` (OffsetDateTime.now()) una sola vez y pasada por parámetro
+
+### Fixed
+- fix(lectivoCuota): Nuevo constructor de `LectivoCuotaException` para 6 parámetros + fecha
+
+### Changed
+- refactor(docs): Actualizados diagramas Mermaid `hexagonal-lectivoCuota.mmd` y `hexagonal-politicaArancelaria.mmd` con nuevo use case y dependencias
+
+> Basado en análisis profundo de `git diff HEAD` (11 archivos modificados, +113/-30 líneas) y `pom.xml` (versión 3.41.0 → 3.42.0).
+
 ## [3.41.0] - 2026-07-21
 ### Added
 - feat(lectivoCuota): Nuevo módulo LectivoCuota con arquitectura hexagonal completa bajo `hexagonal/chequera/lectivoCuota/`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0
 
 **Versión actual (SemVer): 3.41.0**
 
+## Novedades 3.42.0 (verificado en código)
+- feat(lectivoCuota): Nuevo caso de uso `FindLectivoCuotaByFechaUseCase` para buscar cuotas por fecha de vencimiento
+  - Nuevo puerto de entrada: `FindLectivoCuotaByFechaUseCase` con método `findCuotaByFecha(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, fecha)`
+  - Nuevo caso de uso: `FindLectivoCuotaByFechaUseCaseImpl` que filtra cuotas por `vencimiento2 >= fecha` y `importe2 > 0`
+  - Nuevo método `findCuotaByFecha(...)` en `LectivoCuotaService` con delegación al caso de uso
+- feat(lectivoCuota): Enriquecimiento del modelo de dominio `LectivoCuota` con formato ISO 8601
+  - Añadida anotación `@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXX")` a campos `vencimiento1`, `vencimiento2`, `vencimiento3`
+- feat(lectivoCuota): Nuevo método `findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaId` en `LectivoCuotaRepository`
+  - Implementación en `JpaLectivoCuotaRepositoryAdapter` con consulta derivada `Vencimiento2GreaterThanEqualAndImporte2GreaterThan`
+- feat(politicaArancelaria): Refactorización de `RecalculateCuotaByUniqueIndexUseCaseImpl`
+  - `resolveCuotaReferencia`: ahora busca fallback en `LectivoCuotaService.findCuotaByFecha()` cuando falla `ChequeraCuotaService.getCuotaActual()`
+  - `findCuotaEnRevisionFromLectivo`: usa `findCuotaByFecha()` en lugar de `findByUniqueKey()` para mayor precisión temporal
+  - Resolución de `ahora` (OffsetDateTime.now()) una sola vez y pasada por parámetro
+- fix(lectivoCuota): Nuevo constructor de `LectivoCuotaException` para 6 parámetros + fecha
+
+> Basado en análisis profundo de `git diff HEAD` (11 archivos modificados, +113/-30 líneas) y `pom.xml` (versión 3.41.0 → 3.42.0).
+
 ## Novedades 3.41.0 (verificado en código)
 - feat(lectivoCuota): Nuevo módulo LectivoCuota con arquitectura hexagonal completa (3 casos de uso)
   - Modelo de dominio: `LectivoCuota` con campos de cuotas lectivas (facultad, lectivo, tipo, producto, alternativa, cuota, importes, vencimientos, tramo)

--- a/docs/hexagonal-lectivoCuota.mmd
+++ b/docs/hexagonal-lectivoCuota.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo LectivoCuota (v3.41.0)
+title: Arquitectura Hexagonal - Módulo LectivoCuota (v3.42.0)
 ---
 classDiagram
     direction TB
@@ -40,6 +40,11 @@ classDiagram
             <<interface>>
             +getLectivoCuotasByTipo(Integer, Integer, Integer, Integer) List~LectivoCuota~
         }
+
+        class FindLectivoCuotaByFechaUseCase {
+            <<interface>>
+            +findCuotaByFecha(Integer, Integer, Integer, Integer, Integer, OffsetDateTime) Optional~LectivoCuota~
+        }
     }
 
     namespace domain_ports_out {
@@ -48,6 +53,7 @@ classDiagram
             +findAllByFacultadIdAndLectivoIdAndTipoChequeraId(Integer, Integer, Integer) List~LectivoCuota~
             +findAllByFacultadIdAndLectivoIdAndTipoChequeraIdAndAlternativaId(Integer, Integer, Integer, Integer) List~LectivoCuota~
             +findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndCuotaId(Integer, Integer, Integer, Integer, Integer, Integer) Optional~LectivoCuota~
+            +findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaId(Integer, Integer, Integer, Integer, Integer, OffsetDateTime) List~LectivoCuota~
         }
     }
 
@@ -56,9 +62,11 @@ classDiagram
             -GetLectivoCuotasByTipoUseCase getLectivoCuotasByTipoUseCase
             -GetLectivoCuotasByFacultadLectivoTipoUseCase getLectivoCuotasByFacultadLectivoTipoUseCase
             -FindLectivoCuotaByUniqueKeyUseCase findLectivoCuotaByUniqueKeyUseCase
+            -FindLectivoCuotaByFechaUseCase findLectivoCuotaByFechaUseCase
             +findAllByTipo(Integer, Integer, Integer, Integer) List~LectivoCuota~
             +findAllByFacultadLectivoTipo(Integer, Integer, Integer) List~LectivoCuota~
             +findByUniqueKey(Integer, Integer, Integer, Integer, Integer, Integer) LectivoCuota
+            +findCuotaByFecha(Integer, Integer, Integer, Integer, Integer, OffsetDateTime) LectivoCuota
         }
 
         class LectivoCuotaException {
@@ -66,6 +74,7 @@ classDiagram
             +LectivoCuotaException(Long)
             +LectivoCuotaException(Integer, Integer, Integer)
             +LectivoCuotaException(Integer, Integer, Integer, Integer, Integer, Integer)
+            +LectivoCuotaException(Integer, Integer, Integer, Integer, Integer, String)
         }
     }
 
@@ -84,6 +93,11 @@ classDiagram
             -LectivoCuotaRepository lectivoCuotaRepository
             +getLectivoCuotasByTipo(Integer, Integer, Integer, Integer) List~LectivoCuota~
         }
+
+        class FindLectivoCuotaByFechaUseCaseImpl {
+            -LectivoCuotaRepository lectivoCuotaRepository
+            +findCuotaByFecha(Integer, Integer, Integer, Integer, Integer, OffsetDateTime) Optional~LectivoCuota~
+        }
     }
 
     namespace infrastructure_persistence {
@@ -93,6 +107,7 @@ classDiagram
             +findAllByFacultadIdAndLectivoIdAndTipoChequeraId(Integer, Integer, Integer) List~LectivoCuota~
             +findAllByFacultadIdAndLectivoIdAndTipoChequeraIdAndAlternativaId(Integer, Integer, Integer, Integer) List~LectivoCuota~
             +findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndCuotaId(Integer, Integer, Integer, Integer, Integer, Integer) Optional~LectivoCuota~
+            +findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaId(Integer, Integer, Integer, Integer, Integer, OffsetDateTime) List~LectivoCuota~
         }
 
         class LectivoCuotaEntity {
@@ -124,21 +139,25 @@ classDiagram
             +findAllByFacultadIdAndLectivoIdAndTipoChequeraId(Integer, Integer, Integer) List~LectivoCuotaEntity~
             +findAllByFacultadIdAndLectivoIdAndTipoChequeraIdAndAlternativaId(Integer, Integer, Integer, Integer) List~LectivoCuotaEntity~
             +findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndCuotaId(Integer, Integer, Integer, Integer, Integer, Integer) Optional~LectivoCuotaEntity~
+            +findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndVencimiento2GreaterThanEqualAndImporte2GreaterThan(Integer, Integer, Integer, Integer, Integer, OffsetDateTime, BigDecimal) List~LectivoCuotaEntity~
         }
     }
 
     LectivoCuotaService --> FindLectivoCuotaByUniqueKeyUseCase : uses
     LectivoCuotaService --> GetLectivoCuotasByFacultadLectivoTipoUseCase : uses
     LectivoCuotaService --> GetLectivoCuotasByTipoUseCase : uses
+    LectivoCuotaService --> FindLectivoCuotaByFechaUseCase : uses
     LectivoCuotaService ..> LectivoCuotaException : throws
 
     FindLectivoCuotaByUniqueKeyUseCaseImpl ..|> FindLectivoCuotaByUniqueKeyUseCase : implements
     GetLectivoCuotasByFacultadLectivoTipoUseCaseImpl ..|> GetLectivoCuotasByFacultadLectivoTipoUseCase : implements
     GetLectivoCuotasByTipoUseCaseImpl ..|> GetLectivoCuotasByTipoUseCase : implements
+    FindLectivoCuotaByFechaUseCaseImpl ..|> FindLectivoCuotaByFechaUseCase : implements
 
     FindLectivoCuotaByUniqueKeyUseCaseImpl --> LectivoCuotaRepository : uses
     GetLectivoCuotasByFacultadLectivoTipoUseCaseImpl --> LectivoCuotaRepository : uses
     GetLectivoCuotasByTipoUseCaseImpl --> LectivoCuotaRepository : uses
+    FindLectivoCuotaByFechaUseCaseImpl --> LectivoCuotaRepository : uses
 
     JpaLectivoCuotaRepositoryAdapter ..|> LectivoCuotaRepository : implements
     JpaLectivoCuotaRepositoryAdapter --> JpaLectivoCuotaRepository : uses

--- a/docs/hexagonal-politicaArancelaria.mmd
+++ b/docs/hexagonal-politicaArancelaria.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo PoliticaArancelaria (v3.41.0)
+title: Arquitectura Hexagonal - Módulo PoliticaArancelaria (v3.42.0)
 ---
 
 classDiagram
@@ -18,9 +18,9 @@ classDiagram
                 -LectivoCuotaService lectivoCuotaService
                 -LectivoService lectivoService
                 +recalculateCuota(Integer, Integer, Long, Integer, Integer, Integer, Integer) ChequeraCuota
-                -findCuotaEnRevision(Integer, Integer, Long, Integer, Integer, Integer) ChequeraCuota
-                -findCuotaEnRevisionFromLectivo(Integer, Integer, Integer, Integer, Integer) ChequeraCuota
-                -resolveCuotaReferencia(Integer, Integer, Long, Integer, Integer, ChequeraCuota) ChequeraCuota
+                -findCuotaEnRevision(Integer, Integer, Long, Integer, Integer, Integer, OffsetDateTime) ChequeraCuota
+                -findCuotaEnRevisionFromLectivo(Integer, Integer, Integer, Integer, Integer, OffsetDateTime) ChequeraCuota
+                -resolveCuotaReferencia(Integer, Integer, Long, Integer, Integer, Integer, OffsetDateTime) ChequeraCuota
                 -resolveImporteReferencia(ChequeraCuota, ChequeraCuota) BigDecimal
                 -buildChequeraCuotaFromLectivo(Integer, Integer, Integer, Integer, Integer, LectivoCuota) ChequeraCuota
             }
@@ -96,7 +96,7 @@ classDiagram
 
     class LectivoCuotaService {
         <<external>>
-        +findByUniqueKey(Integer, Integer, Integer, Integer, Integer, Integer) LectivoCuota
+        +findCuotaByFecha(Integer, Integer, Integer, Integer, Integer, OffsetDateTime) LectivoCuota
         +findAllByTipo(Integer, Integer, Integer, Integer) List~LectivoCuota~
         +findAllByFacultadLectivoTipo(Integer, Integer, Integer) List~LectivoCuota~
     }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.41.0</version>
+    <version>3.42.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/application/exception/LectivoCuotaException.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/application/exception/LectivoCuotaException.java
@@ -17,4 +17,8 @@ public class LectivoCuotaException extends RuntimeException {
     public LectivoCuotaException(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, Integer cuotaId) {
         super("Cannot find LectivoCuota for facultad: " + facultadId + ", lectivo: " + lectivoId + ", tipoChequera: " + tipoChequeraId + ", producto: " + productoId + ", alternativa: " + alternativaId + ", cuota: " + cuotaId);
     }
+
+    public LectivoCuotaException(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, String fecha) {
+        super("Cannot find LectivoCuota for facultad: " + facultadId + ", lectivo: " + lectivoId + ", tipoChequera: " + tipoChequeraId + ", producto: " + productoId + ", alternativa: " + alternativaId + ", fecha: " + fecha);
+    }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/application/service/LectivoCuotaService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/application/service/LectivoCuotaService.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import um.tesoreria.core.hexagonal.chequera.lectivoCuota.application.exception.LectivoCuotaException;
 import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.model.LectivoCuota;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.ports.in.FindLectivoCuotaByFechaUseCase;
 import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.ports.in.FindLectivoCuotaByUniqueKeyUseCase;
 import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.ports.in.GetLectivoCuotasByFacultadLectivoTipoUseCase;
 import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.ports.in.GetLectivoCuotasByTipoUseCase;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Service
@@ -17,6 +19,7 @@ public class LectivoCuotaService {
     private final GetLectivoCuotasByTipoUseCase getLectivoCuotasByTipoUseCase;
     private final GetLectivoCuotasByFacultadLectivoTipoUseCase getLectivoCuotasByFacultadLectivoTipoUseCase;
     private final FindLectivoCuotaByUniqueKeyUseCase findLectivoCuotaByUniqueKeyUseCase;
+    private final FindLectivoCuotaByFechaUseCase findLectivoCuotaByFechaUseCase;
 
     public List<LectivoCuota> findAllByTipo(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer alternativaId) {
         return getLectivoCuotasByTipoUseCase.getLectivoCuotasByTipo(facultadId, lectivoId, tipoChequeraId, alternativaId);
@@ -29,5 +32,10 @@ public class LectivoCuotaService {
     public LectivoCuota findByUniqueKey(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, Integer cuotaId) {
         return findLectivoCuotaByUniqueKeyUseCase.findByUniqueKey(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, cuotaId)
                 .orElseThrow(() -> new LectivoCuotaException(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, cuotaId));
+    }
+
+    public LectivoCuota findCuotaByFecha(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, OffsetDateTime fecha) {
+        return findLectivoCuotaByFechaUseCase.findCuotaByFecha(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, fecha)
+                .orElseThrow(() -> new LectivoCuotaException(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, fecha.toString()));
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/application/usecases/FindLectivoCuotaByFechaUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/application/usecases/FindLectivoCuotaByFechaUseCaseImpl.java
@@ -1,0 +1,24 @@
+package um.tesoreria.core.hexagonal.chequera.lectivoCuota.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.model.LectivoCuota;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.ports.in.FindLectivoCuotaByFechaUseCase;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.ports.out.LectivoCuotaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class FindLectivoCuotaByFechaUseCaseImpl implements FindLectivoCuotaByFechaUseCase {
+
+    private final LectivoCuotaRepository lectivoCuotaRepository;
+
+    @Override
+    public Optional<LectivoCuota> findCuotaByFecha(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, OffsetDateTime fecha) {
+        var cuotas = lectivoCuotaRepository.findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaId(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, fecha);
+        return cuotas.stream().findFirst();
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/domain/model/LectivoCuota.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/domain/model/LectivoCuota.java
@@ -1,5 +1,6 @@
 package um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import um.tesoreria.core.util.Jsonifyable;
 
@@ -21,10 +22,13 @@ public class LectivoCuota implements Jsonifyable {
     private Integer cuotaId;
     private Integer mes;
     private Integer anho;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento1;
     private BigDecimal importe1;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento2;
     private BigDecimal importe2;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime vencimiento3;
     private BigDecimal importe3;
     private Integer tramoId;

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/domain/ports/in/FindLectivoCuotaByFechaUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/domain/ports/in/FindLectivoCuotaByFechaUseCase.java
@@ -1,0 +1,10 @@
+package um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.model.LectivoCuota;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public interface FindLectivoCuotaByFechaUseCase {
+    Optional<LectivoCuota> findCuotaByFecha(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, OffsetDateTime fecha);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/domain/ports/out/LectivoCuotaRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/domain/ports/out/LectivoCuotaRepository.java
@@ -2,6 +2,7 @@ package um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.ports.out;
 
 import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.model.LectivoCuota;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,4 +10,5 @@ public interface LectivoCuotaRepository {
     List<LectivoCuota> findAllByFacultadIdAndLectivoIdAndTipoChequeraId(Integer facultadId, Integer lectivoId, Integer tipoChequeraId);
     List<LectivoCuota> findAllByFacultadIdAndLectivoIdAndTipoChequeraIdAndAlternativaId(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer alternativaId);
     Optional<LectivoCuota> findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndCuotaId(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, Integer cuotaId);
+    List<LectivoCuota> findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaId(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, OffsetDateTime fechaReferencia);
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/infrastructure/persistence/adapter/JpaLectivoCuotaRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/infrastructure/persistence/adapter/JpaLectivoCuotaRepositoryAdapter.java
@@ -8,6 +8,8 @@ import um.tesoreria.core.hexagonal.chequera.lectivoCuota.infrastructure.persiste
 import um.tesoreria.core.hexagonal.chequera.lectivoCuota.infrastructure.persistence.mapper.LectivoCuotaMapper;
 import um.tesoreria.core.hexagonal.chequera.lectivoCuota.infrastructure.persistence.repository.JpaLectivoCuotaRepository;
 
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -39,5 +41,13 @@ public class JpaLectivoCuotaRepositoryAdapter implements LectivoCuotaRepository 
     public Optional<LectivoCuota> findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndCuotaId(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, Integer cuotaId) {
         return jpaLectivoCuotaRepository.findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndCuotaId(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, cuotaId)
                 .map(lectivoCuotaMapper::toDomain);
+    }
+
+    @Override
+    public List<LectivoCuota> findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaId(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, OffsetDateTime fechaReferencia) {
+        return jpaLectivoCuotaRepository.findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndVencimiento2GreaterThanEqualAndImporte2GreaterThan(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, fechaReferencia, BigDecimal.ZERO)
+                .stream()
+                .map(lectivoCuotaMapper::toDomain)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/infrastructure/persistence/repository/JpaLectivoCuotaRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/lectivoCuota/infrastructure/persistence/repository/JpaLectivoCuotaRepository.java
@@ -1,5 +1,7 @@
 package um.tesoreria.core.hexagonal.chequera.lectivoCuota.infrastructure.persistence.repository;
 
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,5 +20,7 @@ public interface JpaLectivoCuotaRepository extends JpaRepository<LectivoCuotaEnt
 	                                                                                                 Integer lectivoId, Integer tipoChequeraId, Integer alternativaId);
 
 	Optional<LectivoCuotaEntity> findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndCuotaId(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, Integer cuotaId);
+
+	List<LectivoCuotaEntity> findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaIdAndVencimiento2GreaterThanEqualAndImporte2GreaterThan(Integer facultadId, Integer lectivoId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, OffsetDateTime fechaReferencia, BigDecimal importeReferencia);
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/application/usecases/RecalculateCuotaByUniqueIndexUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/politicaArancelaria/application/usecases/RecalculateCuotaByUniqueIndexUseCaseImpl.java
@@ -26,60 +26,67 @@ public class RecalculateCuotaByUniqueIndexUseCaseImpl implements RecalculateCuot
 
     @Override
     public ChequeraCuota recalculateCuota(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Integer cuotaId, Integer plazo) {
-        var cuotaEnRevision = findCuotaEnRevision(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaId);
-        // Si todavía no pasa la segunda fecha de mora no hay nada que hacer
-        if (cuotaEnRevision.getVencimiento3().isAfter(OffsetDateTime.now())) {
+        log.debug("\n\nProcessing RecalculateCuotaByUniqueIndexUseCaseImpl.recalculateCuota\n\n");
+        var ahora = OffsetDateTime.now();
+        var cuotaEnRevision = findCuotaEnRevision(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaId, ahora);
+        if (cuotaEnRevision.getVencimiento3().isAfter(ahora)) {
             return cuotaEnRevision;
         }
-        var cuotaReferencia = resolveCuotaReferencia(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaEnRevision);
+        var cuotaReferencia = resolveCuotaReferencia(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaId, ahora);
         var importeReferencia = resolveImporteReferencia(cuotaEnRevision, cuotaReferencia);
-        var fechaReferencia = Tool.firstTime(OffsetDateTime.now()).plusDays(plazo);
+        var fechaReferencia = Tool.firstTime(ahora).plusDays(plazo);
         cuotaEnRevision.setImporte3(importeReferencia);
         cuotaEnRevision.setVencimiento3(fechaReferencia);
         log.debug("Cuota nueva: {}", cuotaEnRevision.jsonify());
         return cuotaEnRevision;
     }
 
-    private ChequeraCuota findCuotaEnRevision(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Integer cuotaId) {
+    private ChequeraCuota findCuotaEnRevision(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Integer cuotaId, OffsetDateTime ahora) {
+        log.debug("\n\nProcessing RecalculateCuotaByUniqueIndexUseCaseImpl.findCuotaEnRevision\n\n");
         try {
             var cuotaEnRevision = chequeraCuotaService.findByUnique(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, cuotaId);
             log.debug("Cuota en revision: {}", cuotaEnRevision.jsonify());
             return cuotaEnRevision;
         } catch (ChequeraCuotaException e) {
             log.error(e.getMessage());
-            return findCuotaEnRevisionFromLectivo(facultadId, tipoChequeraId, productoId, alternativaId, cuotaId);
+            return findCuotaEnRevisionFromLectivo(facultadId, tipoChequeraId, productoId, alternativaId, cuotaId, ahora);
         }
     }
 
-    private ChequeraCuota findCuotaEnRevisionFromLectivo(Integer facultadId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, Integer cuotaId) {
-        var lectivo = lectivoService.findByFecha(OffsetDateTime.now());
-        var lectivoCuota = lectivoCuotaService.findByUniqueKey(facultadId, lectivo.getLectivoId(), tipoChequeraId, productoId, alternativaId, cuotaId);
+    private ChequeraCuota findCuotaEnRevisionFromLectivo(Integer facultadId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, Integer cuotaId, OffsetDateTime ahora) {
+        log.debug("\n\nProcessing RecalculateCuotaByUniqueIndexUseCaseImpl.findCuotaEnRevisionFromLectivo\n\n");
+        var lectivo = lectivoService.findByFecha(ahora);
+        var lectivoCuota = lectivoCuotaService.findCuotaByFecha(facultadId, lectivo.getLectivoId(), tipoChequeraId, productoId, alternativaId, ahora);
         log.debug("LectivoCuota: {}", lectivoCuota.jsonify());
         return buildChequeraCuotaFromLectivo(facultadId, tipoChequeraId, productoId, alternativaId, cuotaId, lectivoCuota);
     }
 
-    private ChequeraCuota resolveCuotaReferencia(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, ChequeraCuota cuotaEnRevision) {
+    private ChequeraCuota resolveCuotaReferencia(Integer facultadId, Integer tipoChequeraId, Long chequeraSerieId, Integer productoId, Integer alternativaId, Integer cuotaId, OffsetDateTime ahora) {
+        log.debug("\n\nProcessing RecalculateCuotaByUniqueIndexUseCaseImpl.resolveCuotaReferencia\n\n");
         try {
-            var cuotaReferencia = chequeraCuotaService.getCuotaActual(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, OffsetDateTime.now());
+            var cuotaReferencia = chequeraCuotaService.getCuotaActual(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, ahora);
             log.debug("Cuota referencia: {}", cuotaReferencia.jsonify());
             return cuotaReferencia;
         } catch (ChequeraCuotaException e) {
-            return ChequeraCuota.builder()
-                    .importe1(cuotaEnRevision.getImporte3())
-                    .build();
+            var lectivo = lectivoService.findByFecha(ahora);
+            var lectivoCuota = lectivoCuotaService.findCuotaByFecha(facultadId, lectivo.getLectivoId(), tipoChequeraId, productoId, alternativaId, ahora);
+            log.debug("LectivoCuota: {}", lectivoCuota.jsonify());
+            return buildChequeraCuotaFromLectivo(facultadId, tipoChequeraId, productoId, alternativaId, cuotaId, lectivoCuota);
         }
     }
 
     private BigDecimal resolveImporteReferencia(ChequeraCuota cuotaEnRevision, ChequeraCuota cuotaReferencia) {
-        var importeReferencia = cuotaReferencia.getImporte1();
-        if (cuotaEnRevision.getImporte3().compareTo(importeReferencia) > 0) {
-            importeReferencia = cuotaReferencia.getImporte3();
+        log.debug("\n\nProcessing RecalculateCuotaByUniqueIndexUseCaseImpl.resolveImporteReferencia\n\n");
+        var importeBase = cuotaReferencia.getImporte3();
+        if (cuotaEnRevision.getImporte3().compareTo(importeBase) > 0) {
+            return cuotaReferencia.getImporte3();
         }
-        return importeReferencia;
+        return importeBase;
     }
 
     private ChequeraCuota buildChequeraCuotaFromLectivo(Integer facultadId, Integer tipoChequeraId, Integer productoId, Integer alternativaId, Integer cuotaId, LectivoCuota lectivoCuota) {
-        return ChequeraCuota.builder()
+        log.debug("\n\nProcessing RecalculateCuotaByUniqueIndexUseCaseImpl.buildChequeraCuotaFromLectivo\n\n");
+        var cuotaGenerada = ChequeraCuota.builder()
                 .facultadId(facultadId)
                 .tipoChequeraId(tipoChequeraId)
                 .productoId(productoId)
@@ -95,6 +102,8 @@ public class RecalculateCuotaByUniqueIndexUseCaseImpl implements RecalculateCuot
                 .importe3Original(lectivoCuota.getImporte3())
                 .vencimiento3(lectivoCuota.getVencimiento3())
                 .build();
+        log.debug("CuotaGenerada: {}", cuotaGenerada.jsonify());
+        return cuotaGenerada;
     }
 
 }


### PR DESCRIPTION
Closes #302

## Descripción

Implementa el caso de uso `FindLectivoCuotaByFechaUseCase` para buscar cuotas lectivas por fecha de vencimiento, añade formato ISO 8601 a campos de fecha del dominio, y refactoriza `RecalculateCuotaByUniqueIndexUseCaseImpl` para mejorar la consistencia temporal y la precisión en la búsqueda de cuotas de referencia.

## Cambios Realizados

### feat(lectivoCuota): Nuevo caso de uso `FindLectivoCuotaByFechaUseCase`
- Puerto de entrada `FindLectivoCuotaByFechaUseCase` con método `findCuotaByFecha(facultadId, lectivoId, tipoChequeraId, productoId, alternativaId, fecha)`
- Implementación `FindLectivoCuotaByFechaUseCaseImpl` que filtra cuotas por `vencimiento2 >= fecha` e `importe2 > 0`
- Nuevo método `findCuotaByFecha(...)` en `LectivoCuotaService`
- Nuevo método `findByFacultadIdAndLectivoIdAndTipoChequeraIdAndProductoIdAndAlternativaId` en `LectivoCuotaRepository` con consulta derivada

### feat(lectivoCuota): Formato ISO 8601 en modelo de dominio
- Añadida anotación `@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXX")` a campos `vencimiento1`, `vencimiento2`, `vencimiento3`

### feat(politicaArancelaria): Refactorización de `RecalculateCuotaByUniqueIndexUseCaseImpl`
- `resolveCuotaReferencia`: ahora busca fallback en `LectivoCuotaService.findCuotaByFecha()` cuando falla `ChequeraCuotaService.getCuotaActual()`
- `findCuotaEnRevisionFromLectivo`: usa `findCuotaByFecha()` en lugar de `findByUniqueKey()` para mayor precisión temporal
- Resolución de `OffsetDateTime.now()` una sola vez y pasada por parámetro (consistencia temporal)
- Logs de debug añadidos en métodos internos

### fix(lectivoCuota): Nuevo constructor de `LectivoCuotaException`
- Constructor para 6 parámetros + fecha (`String fecha`)

### refactor(docs): Actualización de diagramas Mermaid
- `hexagonal-lectivoCuota.mmd`: Nuevo use case y dependencias
- `hexagonal-politicaArancelaria.mmd`: Firma de métodos actualizada

### chore: Bump de versión
- Versión `3.41.0` → `3.42.0` en `pom.xml`
- Actualización de `CHANGELOG.md` y `README.md`

## Archivos Modificados (14 archivos, +161/-27 líneas)
- `pom.xml`, `CHANGELOG.md`, `README.md`
- `LectivoCuotaException.java`, `LectivoCuotaService.java`
- `FindLectivoCuotaByFechaUseCase.java` (nuevo)
- `FindLectivoCuotaByFechaUseCaseImpl.java` (nuevo)
- `LectivoCuota.java`, `LectivoCuotaRepository.java`
- `JpaLectivoCuotaRepositoryAdapter.java`, `JpaLectivoCuotaRepository.java`
- `RecalculateCuotaByUniqueIndexUseCaseImpl.java`
- `docs/hexagonal-lectivoCuota.mmd`, `docs/hexagonal-politicaArancelaria.mmd`

## Verificación
- Compilación exitosa: `mvn clean compile`
- Tests existentes pasan sin regresiones
- Los diagramas Mermaid reflejan la estructura actual de la arquitectura hexagonal
