### PR TITLE
feat(tesoreria): incorporar cambios de version 3.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.48.0] - 2026-08-03
+### Added
+- feat(guarani/guaraniPropuestaTipoChequera): Nuevo módulo hexagonal con CRUD REST bajo `/api/tesoreria/core/guaraniPropuestaTipoChequera`.
+  - Persistencia sobre `guarani_propuesta_tipo_chequera`, con restricción única para `propuestaGuarani` y `lectivoId`.
+  - Consulta por propuesta y lectivo, creación, actualización y eliminación.
+- feat(chequera/tipoChequera): Añadido `SearchTipoChequeraUseCase` para la búsqueda `POST /tipoChequera/search`.
+  - La consulta usa `vw_tipo_chequera_search`, aplica las condiciones sobre `search`, ordena por `nombre` y limita a 50 resultados.
+  - La respuesta se mapea a `TipoChequeraSearchResponse`, desacoplando la vista legacy de la API.
+- feat(docs): Añadido `docs/hexagonal-guaraniPropuestaTipoChequera.mmd` y registrado en la documentación generada.
+
+### Changed
+- chore(deps): Actualizado MySQL Connector/J de `9.7.0` a `26.7.0`.
+- chore(deps): Actualizado Springdoc OpenAPI de `3.0.3` a `3.1.0`.
+- refactor(docs): Actualizado el diagrama `hexagonal-chequeraTipoChequera.mmd` con el caso de uso de búsqueda y sus adaptadores.
+
+> Basado en `git diff HEAD`, `git log`, los archivos Java modificados y `pom.xml` (versión `3.47.0` → `3.48.0`).
+
 ## [3.47.0] - 2026-08-02
 ### Added
 - feat(guarani/guaraniUbicacion): Nuevo módulo hexagonal con CRUD REST bajo `/api/tesoreria/core/guaraniUbicacion`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.47.0**
+**Versión actual (SemVer): 3.48.0**
+
+## Novedades 3.48.0 (verificado en código)
+- feat(guarani/guaraniPropuestaTipoChequera): Nuevo módulo hexagonal con CRUD REST bajo `/api/tesoreria/core/guaraniPropuestaTipoChequera`
+  - Persistencia sobre `guarani_propuesta_tipo_chequera`, con unicidad por propuesta Guarani y lectivo
+  - Consulta por `propuestaGuarani` y `lectivoId`, además de creación, actualización y eliminación
+- feat(chequera/tipoChequera): Migrada la búsqueda `POST /tipoChequera/search` al caso de uso hexagonal `SearchTipoChequeraUseCase`
+  - La búsqueda aplica las condiciones sobre la vista `vw_tipo_chequera_search`, ordena por nombre y limita la respuesta a 50 registros
+  - La respuesta REST usa `TipoChequeraSearchResponse` en lugar del tipo de vista legacy
+- chore(deps): Actualizado MySQL Connector/J de `9.7.0` a `26.7.0` y Springdoc OpenAPI de `3.0.3` a `3.1.0`
+- feat(docs): Añadido el diagrama Mermaid `hexagonal-guaraniPropuestaTipoChequera.mmd` y actualizado el diagrama de TipoChequera
+
+> Basado en `git diff HEAD` (31 archivos modificados, +631/-9 líneas), `git log` y el código de los módulos Guarani/TipoChequera. La versión se actualiza de `3.47.0` a `3.48.0` en `pom.xml` por la incorporación de un módulo REST nuevo y una búsqueda hexagonal expuesta por API.
 
 ## Novedades 3.47.0 (verificado en código)
 - feat(guarani/guaraniUbicacion): Nuevo módulo hexagonal con CRUD REST bajo `/api/tesoreria/core/guaraniUbicacion`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.47.0** (actualizada: 2026-08-02)
+**Versión actual del servicio: 3.48.0** (actualizada: 2026-08-03)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -30,7 +30,8 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-baja.mmd`: Arquitectura hexagonal del módulo Baja (gestión de bajas de chequeras) - v3.36.0 (reubicado bajo `chequera/`).
 - `hexagonal-campanha.mmd`: Arquitectura hexagonal del módulo Campanha (gestión de campañas UM Hub) - v3.24.0.
 - `hexagonal-chequeraProducto.mmd`: Arquitectura hexagonal del módulo Producto (gestión de productos chequera) - v3.30.0 (nuevo módulo).
-- `hexagonal-chequeraTipoChequera.mmd`: Arquitectura hexagonal del módulo TipoChequera (tipos de chequera con 11 casos de uso) - v3.30.0 (nuevo módulo).
+- `hexagonal-chequeraTipoChequera.mmd`: Arquitectura hexagonal del módulo TipoChequera (tipos de chequera con 12 casos de uso) - v3.48.0 (incluye búsqueda por condiciones).
+- `hexagonal-guaraniPropuestaTipoChequera.mmd`: Arquitectura hexagonal del módulo GuaraniPropuestaTipoChequera (asignación de tipo de chequera a propuesta y lectivo) - v3.48.0 (nuevo módulo).
 - `hexagonal-claseChequera.mmd`: Arquitectura hexagonal del módulo ClaseChequera (clasificación de chequeras) - v3.39.0 (nuevo campo `tramite`, caso de uso `GetAllClaseChequeraByTramiteUseCase`, `ClaseChequeraEntity` implementa `Jsonifyable`).
 - `hexagonal-lectivo.mmd`: Arquitectura hexagonal del módulo Lectivo (gestión de lectivos con 8 casos de uso) - v3.30.0 (nuevo módulo).
 - `hexagonal-reservaVacante.mmd`: Arquitectura hexagonal del módulo ReservaVacante (gestión de reservas de vacantes UM Hub) - v3.32.0 (nuevo UpdateReservaVacanteUseCase con integración de pago MercadoPago).

--- a/docs/hexagonal-chequeraTipoChequera.mmd
+++ b/docs/hexagonal-chequeraTipoChequera.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo TipoChequera (v3.30.0)
+title: Arquitectura Hexagonal - Módulo TipoChequera (v3.48.0)
 ---
 
 classDiagram
@@ -28,6 +28,7 @@ classDiagram
             +findAllByFacultadIdAndGeograficaId(Integer, Integer) List~TipoChequera~
             +findAllByClaseChequeraId(Integer) List~TipoChequera~
             +findAllByClaseChequeraIds(List~Integer~) List~TipoChequera~
+            +findAllByStrings(List~String~) List~TipoChequeraSearch~
             +findById(Integer) Optional~TipoChequera~
             +findLast() Optional~TipoChequera~
             +create(TipoChequera) TipoChequera
@@ -35,6 +36,19 @@ classDiagram
             +deleteById(Integer)
             +unmark()
             +mark(Integer, Byte) TipoChequera
+        }
+
+        class SearchTipoChequeraUseCase {
+            <<interface>>
+            +searchTipoChequeras(List~String~) List~TipoChequeraSearch~
+        }
+
+        class TipoChequeraSearch {
+            +Integer tipoChequeraId
+            +String nombre
+            +String prefijo
+            +Integer geograficaId
+            +Integer claseChequeraId
         }
     }
 
@@ -68,6 +82,7 @@ classDiagram
             class DeleteTipoChequeraUseCaseImpl
             class MarkTipoChequeraUseCaseImpl
             class UnmarkTipoChequeraUseCaseImpl
+            class SearchTipoChequeraUseCaseImpl
     }
     namespace application {
 
@@ -107,6 +122,12 @@ classDiagram
             class TipoChequeraMapper {
                 +toDomainModel(TipoChequeraEntity) TipoChequera
                 +toEntity(TipoChequera) TipoChequeraEntity
+                +toSearchDomain(TipoChequeraSearch) TipoChequeraSearch
+            }
+
+            class TipoChequeraSearchRepository {
+                <<interface>>
+                +findAllByStrings(List~String~) List~TipoChequeraSearch~
             }
     }
     namespace infrastructure_web {
@@ -121,6 +142,7 @@ classDiagram
                 +findAllAsignable(Integer, Integer, Integer, Integer) ResponseEntity~List~TipoChequeraResponse~~
                 +mark(Integer, Byte) ResponseEntity~Void~
                 +unmark() ResponseEntity~Void~
+                +findAllByStrings(List~String~) ResponseEntity~List~TipoChequeraSearchResponse~~
             }
 
             class TipoChequeraRequest {
@@ -152,6 +174,15 @@ classDiagram
             class TipoChequeraDtoMapper {
                 +toDomain(TipoChequeraRequest) TipoChequera
                 +toResponse(TipoChequera) TipoChequeraResponse
+                +toSearchResponse(TipoChequeraSearch) TipoChequeraSearchResponse
+            }
+
+            class TipoChequeraSearchResponse {
+                +Integer tipoChequeraId
+                +String nombre
+                +String prefijo
+                +Integer geograficaId
+                +Integer claseChequeraId
             }
     }
 
@@ -166,6 +197,7 @@ classDiagram
     TipoChequeraService --> DeleteTipoChequeraUseCase : uses
     TipoChequeraService --> MarkTipoChequeraUseCase : uses
     TipoChequeraService --> UnmarkTipoChequeraUseCase : uses
+    TipoChequeraService --> SearchTipoChequeraUseCase : uses
 
     GetAllTipoChequeraUseCaseImpl ..|> GetAllTipoChequeraUseCase : implements
     GetAllTipoChequeraAsignableUseCaseImpl ..|> GetAllTipoChequeraAsignableUseCase : implements
@@ -178,6 +210,7 @@ classDiagram
     DeleteTipoChequeraUseCaseImpl ..|> DeleteTipoChequeraUseCase : implements
     MarkTipoChequeraUseCaseImpl ..|> MarkTipoChequeraUseCase : implements
     UnmarkTipoChequeraUseCaseImpl ..|> UnmarkTipoChequeraUseCase : implements
+    SearchTipoChequeraUseCaseImpl ..|> SearchTipoChequeraUseCase : implements
 
     GetAllTipoChequeraUseCaseImpl --> TipoChequeraRepository : uses
     GetAllTipoChequeraAsignableUseCaseImpl --> TipoChequeraRepository : uses
@@ -190,10 +223,12 @@ classDiagram
     DeleteTipoChequeraUseCaseImpl --> TipoChequeraRepository : uses
     MarkTipoChequeraUseCaseImpl --> TipoChequeraRepository : uses
     UnmarkTipoChequeraUseCaseImpl --> TipoChequeraRepository : uses
+    SearchTipoChequeraUseCaseImpl --> TipoChequeraRepository : uses
 
     JpaTipoChequeraRepositoryAdapter ..|> TipoChequeraRepository : implements
     JpaTipoChequeraRepositoryAdapter --> JpaTipoChequeraRepository : uses
     JpaTipoChequeraRepositoryAdapter --> TipoChequeraMapper : uses
+    JpaTipoChequeraRepositoryAdapter --> TipoChequeraSearchRepository : uses
 
     TipoChequeraMapper --> TipoChequera : maps
     TipoChequeraMapper --> TipoChequeraEntity : maps

--- a/docs/hexagonal-guaraniPropuestaTipoChequera.mmd
+++ b/docs/hexagonal-guaraniPropuestaTipoChequera.mmd
@@ -1,0 +1,81 @@
+---
+title: Arquitectura Hexagonal - Módulo GuaraniPropuestaTipoChequera (v3.48.0)
+---
+
+classDiagram
+    direction TB
+
+    namespace domain {
+        class GuaraniPropuestaTipoChequera {
+            +Integer guaraniPropuestaTipoChequeraId
+            +Integer propuestaGuarani
+            +Integer lectivoId
+            +Integer tipoChequeraId
+        }
+
+        class GuaraniPropuestaTipoChequeraRepository {
+            <<interface>>
+            +findByPropuestaGuaraniAndLectivoId(Integer, Integer) Optional~GuaraniPropuestaTipoChequera~
+            +save(GuaraniPropuestaTipoChequera) GuaraniPropuestaTipoChequera
+            +existsById(Integer) boolean
+            +deleteById(Integer) void
+        }
+    }
+
+    namespace application {
+        class GuaraniPropuestaTipoChequeraService {
+            +create(GuaraniPropuestaTipoChequera) GuaraniPropuestaTipoChequera
+            +update(GuaraniPropuestaTipoChequera) GuaraniPropuestaTipoChequera
+            +findByPropuestaAndLectivo(Integer, Integer) GuaraniPropuestaTipoChequera
+            +delete(Integer) void
+        }
+    }
+
+    namespace application_usecases {
+        class CreateGuaraniPropuestaTipoChequeraUseCaseImpl
+        class UpdateGuaraniPropuestaTipoChequeraUseCaseImpl
+        class GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCaseImpl
+        class DeleteGuaraniPropuestaTipoChequeraUseCaseImpl
+    }
+
+    namespace infrastructure_persistence {
+        class GuaraniPropuestaTipoChequeraEntity {
+            +Integer guaraniPropuestaTipoChequeraId
+            +Integer propuestaGuarani
+            +Integer lectivoId
+            +Integer tipoChequeraId
+        }
+
+        class JpaGuaraniPropuestaTipoChequeraRepository {
+            <<interface>>
+            +findByPropuestaGuaraniAndLectivoId(Integer, Integer) Optional~GuaraniPropuestaTipoChequeraEntity~
+        }
+
+        class JpaGuaraniPropuestaTipoChequeraRepositoryAdapter
+        class GuaraniPropuestaTipoChequeraMapper
+    }
+
+    namespace infrastructure_web {
+        class GuaraniPropuestaTipoChequeraController {
+            +findByPropuestaAndLectivo(Integer, Integer) ResponseEntity~GuaraniPropuestaTipoChequeraResponse~
+            +add(GuaraniPropuestaTipoChequeraRequest) ResponseEntity~GuaraniPropuestaTipoChequeraResponse~
+            +update(Integer, GuaraniPropuestaTipoChequeraRequest) ResponseEntity~GuaraniPropuestaTipoChequeraResponse~
+            +delete(Integer) ResponseEntity~Void~
+        }
+
+        class GuaraniPropuestaTipoChequeraRequest
+        class GuaraniPropuestaTipoChequeraResponse
+        class GuaraniPropuestaTipoChequeraDtoMapper
+    }
+
+    GuaraniPropuestaTipoChequeraService --> GuaraniPropuestaTipoChequeraRepository : uses
+    CreateGuaraniPropuestaTipoChequeraUseCaseImpl --> GuaraniPropuestaTipoChequeraRepository : uses
+    UpdateGuaraniPropuestaTipoChequeraUseCaseImpl --> GuaraniPropuestaTipoChequeraRepository : uses
+    GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCaseImpl --> GuaraniPropuestaTipoChequeraRepository : uses
+    DeleteGuaraniPropuestaTipoChequeraUseCaseImpl --> GuaraniPropuestaTipoChequeraRepository : uses
+    JpaGuaraniPropuestaTipoChequeraRepositoryAdapter ..|> GuaraniPropuestaTipoChequeraRepository : implements
+    JpaGuaraniPropuestaTipoChequeraRepositoryAdapter --> JpaGuaraniPropuestaTipoChequeraRepository : uses
+    JpaGuaraniPropuestaTipoChequeraRepositoryAdapter --> GuaraniPropuestaTipoChequeraMapper : uses
+    JpaGuaraniPropuestaTipoChequeraRepository --> GuaraniPropuestaTipoChequeraEntity : persists
+    GuaraniPropuestaTipoChequeraController --> GuaraniPropuestaTipoChequeraService : calls
+    GuaraniPropuestaTipoChequeraController --> GuaraniPropuestaTipoChequeraDtoMapper : uses

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,6 +60,7 @@
     <div id="hexagonal-guaraniBeneficio" class="section"></div>
     <div id="hexagonal-tesoreriaEstado" class="section"></div>
     <div id="hexagonal-guaraniUbicacion" class="section"></div>
+    <div id="hexagonal-guaraniPropuestaTipoChequera" class="section"></div>
   <div id="dependencies-diagram" class="section"></div>
   <div id="erd-diagram" class="section"></div>
   <div id="deployment-diagram" class="section"></div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -123,6 +123,7 @@ const diagrams = [
   { id: 'hexagonal-guaraniBeneficio', file: 'hexagonal-guaraniBeneficio.mmd', title: 'Arquitectura Hexagonal - GuaraniBeneficio' },
   { id: 'hexagonal-tesoreriaEstado', file: 'hexagonal-tesoreriaEstado.mmd', title: 'Arquitectura Hexagonal - TesoreriaEstado' },
   { id: 'hexagonal-guaraniUbicacion', file: 'hexagonal-guaraniUbicacion.mmd', title: 'Arquitectura Hexagonal - GuaraniUbicacion' },
+  { id: 'hexagonal-guaraniPropuestaTipoChequera', file: 'hexagonal-guaraniPropuestaTipoChequera.mmd', title: 'Arquitectura Hexagonal - GuaraniPropuestaTipoChequera' },
   { id: 'dependencies-diagram', file: 'dependencies.mmd', title: 'Diagrama de Dependencias' },
   { id: 'erd-diagram', file: 'entities.mmd', title: 'Diagrama de Entidad-Relacion (Simplificado)' },
   { id: 'deployment-diagram', file: 'deployment.mmd', title: 'Diagrama de Despliegue' },

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.47.0</version>
+    <version>3.48.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>
@@ -57,7 +57,7 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
-            <version>9.7.0</version>
+            <version>26.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.3</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.librepdf</groupId>

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/application/service/TipoChequeraService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/application/service/TipoChequeraService.java
@@ -5,9 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.application.exception.TipoChequeraException;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequeraSearch;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.ports.in.*;
-import um.tesoreria.core.model.view.TipoChequeraSearch;
-import um.tesoreria.core.service.view.TipoChequeraSearchService;
 
 import java.util.List;
 
@@ -27,11 +26,11 @@ public class TipoChequeraService {
     private final DeleteTipoChequeraUseCase deleteTipoChequeraUseCase;
     private final MarkTipoChequeraUseCase markTipoChequeraUseCase;
     private final UnmarkTipoChequeraUseCase unmarkTipoChequeraUseCase;
-    private final TipoChequeraSearchService tipoChequeraSearchService;
+    private final SearchTipoChequeraUseCase searchTipoChequeraUseCase;
 
     public List<TipoChequeraSearch> findAllByStrings(List<String> conditions) {
         log.debug("Processing findAllByStrings");
-        return tipoChequeraSearchService.findAllByStrings(conditions);
+        return searchTipoChequeraUseCase.searchTipoChequeras(conditions);
     }
 
     public List<TipoChequera> findAll() {

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/application/usecases/SearchTipoChequeraUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/application/usecases/SearchTipoChequeraUseCaseImpl.java
@@ -1,0 +1,21 @@
+package um.tesoreria.core.hexagonal.chequera.tipoChequera.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequeraSearch;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.ports.in.SearchTipoChequeraUseCase;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.ports.out.TipoChequeraRepository;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class SearchTipoChequeraUseCaseImpl implements SearchTipoChequeraUseCase {
+
+    private final TipoChequeraRepository repository;
+
+    @Override
+    public List<TipoChequeraSearch> searchTipoChequeras(List<String> conditions) {
+        return repository.findAllByStrings(conditions);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/model/TipoChequeraSearch.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/model/TipoChequeraSearch.java
@@ -1,0 +1,30 @@
+package um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TipoChequeraSearch {
+
+    private Integer tipoChequeraId;
+    private String nombre;
+    private String prefijo;
+    private Integer geograficaId;
+    private Integer claseChequeraId;
+    private Byte imprimir;
+    private Byte contado;
+    private Byte multiple;
+    private String emailCopia;
+    private String search;
+    private LocalDateTime created;
+    private LocalDateTime updated;
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/ports/in/SearchTipoChequeraUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/ports/in/SearchTipoChequeraUseCase.java
@@ -1,0 +1,9 @@
+package um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequeraSearch;
+
+import java.util.List;
+
+public interface SearchTipoChequeraUseCase {
+    List<TipoChequeraSearch> searchTipoChequeras(List<String> conditions);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/ports/out/TipoChequeraRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/ports/out/TipoChequeraRepository.java
@@ -1,6 +1,7 @@
 package um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.ports.out;
 
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequeraSearch;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +12,7 @@ public interface TipoChequeraRepository {
     List<TipoChequera> findAllByFacultadIdAndGeograficaId(Integer facultadId, Integer geograficaId);
     List<TipoChequera> findAllByClaseChequeraId(Integer claseChequeraId);
     List<TipoChequera> findAllByClaseChequeraIds(List<Integer> claseChequeraIds);
+    List<TipoChequeraSearch> findAllByStrings(List<String> conditions);
     Optional<TipoChequera> findById(Integer tipoChequeraId);
     Optional<TipoChequera> findLast();
     TipoChequera create(TipoChequera tipoChequera);

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/persistence/adapter/JpaTipoChequeraRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/persistence/adapter/JpaTipoChequeraRepositoryAdapter.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequeraSearch;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.ports.out.TipoChequeraRepository;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.entity.TipoChequeraEntity;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.mapper.TipoChequeraMapper;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.repository.JpaTipoChequeraRepository;
+import um.tesoreria.core.repository.view.TipoChequeraSearchRepository;
 import um.tesoreria.core.service.LectivoTotalService;
 import um.tesoreria.core.model.LectivoTotal;
 
@@ -20,6 +22,7 @@ import java.util.stream.Collectors;
 public class JpaTipoChequeraRepositoryAdapter implements TipoChequeraRepository {
 
     private final JpaTipoChequeraRepository jpaTipoChequeraRepository;
+    private final TipoChequeraSearchRepository tipoChequeraSearchRepository;
     private final LectivoTotalService lectivoTotalService;
     private final TipoChequeraMapper tipoChequeraMapper;
 
@@ -27,6 +30,13 @@ public class JpaTipoChequeraRepositoryAdapter implements TipoChequeraRepository 
     public List<TipoChequera> findAll() {
         return jpaTipoChequeraRepository.findAll().stream()
                 .map(tipoChequeraMapper::toDomainModel)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<TipoChequeraSearch> findAllByStrings(List<String> conditions) {
+        return tipoChequeraSearchRepository.findAllByStrings(conditions).stream()
+                .map(tipoChequeraMapper::toSearchDomain)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/persistence/mapper/TipoChequeraMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/persistence/mapper/TipoChequeraMapper.java
@@ -6,6 +6,7 @@ import um.tesoreria.core.hexagonal.chequera.claseChequera.infrastructure.persist
 import um.tesoreria.core.hexagonal.geografica.domain.model.Geografica;
 import um.tesoreria.core.hexagonal.geografica.infrastructure.persistence.mapper.GeograficaMapper;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequeraSearch;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.entity.TipoChequeraEntity;
 
 @Component
@@ -53,5 +54,23 @@ public class TipoChequeraMapper {
         if (domain.getMultiple() != null) builder.multiple(domain.getMultiple());
         
         return builder.build();
+    }
+
+    public TipoChequeraSearch toSearchDomain(um.tesoreria.core.model.view.TipoChequeraSearch entity) {
+        if (entity == null) return null;
+        return TipoChequeraSearch.builder()
+                .tipoChequeraId(entity.getTipoChequeraId())
+                .nombre(entity.getNombre())
+                .prefijo(entity.getPrefijo())
+                .geograficaId(entity.getGeograficaId())
+                .claseChequeraId(entity.getClaseChequeraId())
+                .imprimir(entity.getImprimir())
+                .contado(entity.getContado())
+                .multiple(entity.getMultiple())
+                .emailCopia(entity.getEmailCopia())
+                .search(entity.getSearch())
+                .created(entity.getCreated())
+                .updated(entity.getUpdated())
+                .build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/web/controller/TipoChequeraController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/web/controller/TipoChequeraController.java
@@ -10,8 +10,8 @@ import um.tesoreria.core.hexagonal.chequera.tipoChequera.application.service.Tip
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.dto.TipoChequeraRequest;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.dto.TipoChequeraResponse;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.dto.TipoChequeraSearchResponse;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.mapper.TipoChequeraDtoMapper;
-import um.tesoreria.core.model.view.TipoChequeraSearch;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -33,8 +33,11 @@ public class TipoChequeraController {
     }
 
     @PostMapping("/search")
-    public ResponseEntity<List<TipoChequeraSearch>> findAllByStrings(@RequestBody List<String> conditions) {
-        return ResponseEntity.ok(service.findAllByStrings(conditions));
+    public ResponseEntity<List<TipoChequeraSearchResponse>> findAllByStrings(@RequestBody List<String> conditions) {
+        List<TipoChequeraSearchResponse> responses = service.findAllByStrings(conditions).stream()
+                .map(tipoChequeraDtoMapper::toSearchResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
     }
 
     @GetMapping("/asignable/{facultadId}/{lectivoId}/{geograficaId}/{claseChequeraId}")

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/web/dto/TipoChequeraSearchResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/web/dto/TipoChequeraSearchResponse.java
@@ -1,0 +1,28 @@
+package um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TipoChequeraSearchResponse {
+
+    private Integer tipoChequeraId;
+    private String nombre;
+    private String prefijo;
+    private Integer geograficaId;
+    private Integer claseChequeraId;
+    private Byte imprimir;
+    private Byte contado;
+    private Byte multiple;
+    private String emailCopia;
+    private String search;
+    private LocalDateTime created;
+    private LocalDateTime updated;
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/web/mapper/TipoChequeraDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/web/mapper/TipoChequeraDtoMapper.java
@@ -4,8 +4,10 @@ import org.springframework.stereotype.Component;
 import um.tesoreria.core.hexagonal.chequera.claseChequera.infrastructure.web.mapper.ClaseChequeraDtoMapper;
 import um.tesoreria.core.hexagonal.geografica.infrastructure.web.mapper.GeograficaDtoMapper;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequeraSearch;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.dto.TipoChequeraRequest;
 import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.dto.TipoChequeraResponse;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.dto.TipoChequeraSearchResponse;
 
 @Component
 public class TipoChequeraDtoMapper {
@@ -47,6 +49,24 @@ public class TipoChequeraDtoMapper {
                 .emailCopia(domain.getEmailCopia())
                 .geografica(geograficaDtoMapper.toResponse(domain.getGeografica()))
                 .claseChequera(claseChequeraDtoMapper.toResponse(domain.getClaseChequera()))
+                .build();
+    }
+
+    public TipoChequeraSearchResponse toSearchResponse(TipoChequeraSearch domain) {
+        if (domain == null) return null;
+        return TipoChequeraSearchResponse.builder()
+                .tipoChequeraId(domain.getTipoChequeraId())
+                .nombre(domain.getNombre())
+                .prefijo(domain.getPrefijo())
+                .geograficaId(domain.getGeograficaId())
+                .claseChequeraId(domain.getClaseChequeraId())
+                .imprimir(domain.getImprimir())
+                .contado(domain.getContado())
+                .multiple(domain.getMultiple())
+                .emailCopia(domain.getEmailCopia())
+                .search(domain.getSearch())
+                .created(domain.getCreated())
+                .updated(domain.getUpdated())
                 .build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/exception/GuaraniPropuestaTipoChequeraException.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/exception/GuaraniPropuestaTipoChequeraException.java
@@ -1,0 +1,12 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.application.exception;
+
+public class GuaraniPropuestaTipoChequeraException extends RuntimeException {
+    public GuaraniPropuestaTipoChequeraException(Integer id) {
+        super("No se encontró GuaraniPropuestaTipoChequera con id: " + id);
+    }
+
+    public GuaraniPropuestaTipoChequeraException(Integer propuestaGuarani, Integer lectivoId) {
+        super("No se encontró GuaraniPropuestaTipoChequera para propuesta "
+                + propuestaGuarani + " y lectivo " + lectivoId);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/service/GuaraniPropuestaTipoChequeraService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/service/GuaraniPropuestaTipoChequeraService.java
@@ -1,0 +1,45 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.application.exception.GuaraniPropuestaTipoChequeraException;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in.CreateGuaraniPropuestaTipoChequeraUseCase;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in.DeleteGuaraniPropuestaTipoChequeraUseCase;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in.GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCase;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in.UpdateGuaraniPropuestaTipoChequeraUseCase;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.out.GuaraniPropuestaTipoChequeraRepository;
+
+@Service
+@RequiredArgsConstructor
+public class GuaraniPropuestaTipoChequeraService {
+    private final GuaraniPropuestaTipoChequeraRepository repository;
+    private final CreateGuaraniPropuestaTipoChequeraUseCase createUseCase;
+    private final UpdateGuaraniPropuestaTipoChequeraUseCase updateUseCase;
+    private final DeleteGuaraniPropuestaTipoChequeraUseCase deleteUseCase;
+    private final GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCase getByPropuestaAndLectivoUseCase;
+
+    public GuaraniPropuestaTipoChequera create(GuaraniPropuestaTipoChequera data) {
+        return createUseCase.create(data);
+    }
+
+    public GuaraniPropuestaTipoChequera update(GuaraniPropuestaTipoChequera data) {
+        if (data.getGuaraniPropuestaTipoChequeraId() == null
+                || !repository.existsById(data.getGuaraniPropuestaTipoChequeraId())) {
+            throw new GuaraniPropuestaTipoChequeraException(data.getGuaraniPropuestaTipoChequeraId());
+        }
+        return updateUseCase.update(data);
+    }
+
+    public void delete(Integer id) {
+        if (!repository.existsById(id)) {
+            throw new GuaraniPropuestaTipoChequeraException(id);
+        }
+        deleteUseCase.delete(id);
+    }
+
+    public GuaraniPropuestaTipoChequera findByPropuestaAndLectivo(Integer propuestaGuarani, Integer lectivoId) {
+        return getByPropuestaAndLectivoUseCase.getByPropuestaAndLectivo(propuestaGuarani, lectivoId)
+                .orElseThrow(() -> new GuaraniPropuestaTipoChequeraException(propuestaGuarani, lectivoId));
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/usecases/CreateGuaraniPropuestaTipoChequeraUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/usecases/CreateGuaraniPropuestaTipoChequeraUseCaseImpl.java
@@ -1,0 +1,18 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in.CreateGuaraniPropuestaTipoChequeraUseCase;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.out.GuaraniPropuestaTipoChequeraRepository;
+
+@Component
+@RequiredArgsConstructor
+public class CreateGuaraniPropuestaTipoChequeraUseCaseImpl implements CreateGuaraniPropuestaTipoChequeraUseCase {
+    private final GuaraniPropuestaTipoChequeraRepository repository;
+
+    @Override
+    public GuaraniPropuestaTipoChequera create(GuaraniPropuestaTipoChequera data) {
+        return repository.save(data);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/usecases/DeleteGuaraniPropuestaTipoChequeraUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/usecases/DeleteGuaraniPropuestaTipoChequeraUseCaseImpl.java
@@ -1,0 +1,17 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in.DeleteGuaraniPropuestaTipoChequeraUseCase;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.out.GuaraniPropuestaTipoChequeraRepository;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteGuaraniPropuestaTipoChequeraUseCaseImpl implements DeleteGuaraniPropuestaTipoChequeraUseCase {
+    private final GuaraniPropuestaTipoChequeraRepository repository;
+
+    @Override
+    public void delete(Integer id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/usecases/GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/usecases/GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCaseImpl.java
@@ -1,0 +1,22 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.application.usecases;
+
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in.GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCase;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.out.GuaraniPropuestaTipoChequeraRepository;
+
+@Component
+@RequiredArgsConstructor
+public class GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCaseImpl
+        implements GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCase {
+    private final GuaraniPropuestaTipoChequeraRepository repository;
+
+    @Override
+    public Optional<GuaraniPropuestaTipoChequera> getByPropuestaAndLectivo(
+            Integer propuestaGuarani, Integer lectivoId) {
+        return repository.findByPropuestaGuaraniAndLectivoId(propuestaGuarani, lectivoId);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/usecases/UpdateGuaraniPropuestaTipoChequeraUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/application/usecases/UpdateGuaraniPropuestaTipoChequeraUseCaseImpl.java
@@ -1,0 +1,18 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.application.usecases;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in.UpdateGuaraniPropuestaTipoChequeraUseCase;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.out.GuaraniPropuestaTipoChequeraRepository;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateGuaraniPropuestaTipoChequeraUseCaseImpl implements UpdateGuaraniPropuestaTipoChequeraUseCase {
+    private final GuaraniPropuestaTipoChequeraRepository repository;
+
+    @Override
+    public GuaraniPropuestaTipoChequera update(GuaraniPropuestaTipoChequera data) {
+        return repository.save(data);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/model/GuaraniPropuestaTipoChequera.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/model/GuaraniPropuestaTipoChequera.java
@@ -1,0 +1,19 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuaraniPropuestaTipoChequera {
+    private Integer guaraniPropuestaTipoChequeraId;
+    private Integer propuestaGuarani;
+    private Integer lectivoId;
+    private Integer tipoChequeraId;
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/in/CreateGuaraniPropuestaTipoChequeraUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/in/CreateGuaraniPropuestaTipoChequeraUseCase.java
@@ -1,0 +1,7 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+
+public interface CreateGuaraniPropuestaTipoChequeraUseCase {
+    GuaraniPropuestaTipoChequera create(GuaraniPropuestaTipoChequera data);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/in/DeleteGuaraniPropuestaTipoChequeraUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/in/DeleteGuaraniPropuestaTipoChequeraUseCase.java
@@ -1,0 +1,5 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in;
+
+public interface DeleteGuaraniPropuestaTipoChequeraUseCase {
+    void delete(Integer id);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/in/GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/in/GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCase.java
@@ -1,0 +1,10 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in;
+
+import java.util.Optional;
+
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+
+public interface GetGuaraniPropuestaTipoChequeraByPropuestaAndLectivoUseCase {
+    Optional<GuaraniPropuestaTipoChequera> getByPropuestaAndLectivo(
+            Integer propuestaGuarani, Integer lectivoId);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/in/UpdateGuaraniPropuestaTipoChequeraUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/in/UpdateGuaraniPropuestaTipoChequeraUseCase.java
@@ -1,0 +1,7 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.in;
+
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+
+public interface UpdateGuaraniPropuestaTipoChequeraUseCase {
+    GuaraniPropuestaTipoChequera update(GuaraniPropuestaTipoChequera data);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/out/GuaraniPropuestaTipoChequeraRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/ports/out/GuaraniPropuestaTipoChequeraRepository.java
@@ -1,0 +1,18 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.out;
+
+import java.util.Optional;
+
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+
+public interface GuaraniPropuestaTipoChequeraRepository {
+    Optional<GuaraniPropuestaTipoChequera> findById(Integer id);
+
+    Optional<GuaraniPropuestaTipoChequera> findByPropuestaGuaraniAndLectivoId(
+            Integer propuestaGuarani, Integer lectivoId);
+
+    GuaraniPropuestaTipoChequera save(GuaraniPropuestaTipoChequera guaraniPropuestaTipoChequera);
+
+    boolean existsById(Integer id);
+
+    void deleteById(Integer id);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/adapter/JpaGuaraniPropuestaTipoChequeraRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/adapter/JpaGuaraniPropuestaTipoChequeraRepositoryAdapter.java
@@ -1,0 +1,46 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.adapter;
+
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.ports.out.GuaraniPropuestaTipoChequeraRepository;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.entity.GuaraniPropuestaTipoChequeraEntity;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.mapper.GuaraniPropuestaTipoChequeraMapper;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.repository.JpaGuaraniPropuestaTipoChequeraRepository;
+
+@Component
+@RequiredArgsConstructor
+public class JpaGuaraniPropuestaTipoChequeraRepositoryAdapter implements GuaraniPropuestaTipoChequeraRepository {
+    private final JpaGuaraniPropuestaTipoChequeraRepository repository;
+    private final GuaraniPropuestaTipoChequeraMapper mapper;
+
+    @Override
+    public Optional<GuaraniPropuestaTipoChequera> findById(Integer id) {
+        return repository.findById(id).map(mapper::toDomainModel);
+    }
+
+    @Override
+    public Optional<GuaraniPropuestaTipoChequera> findByPropuestaGuaraniAndLectivoId(
+            Integer propuestaGuarani, Integer lectivoId) {
+        return repository.findByPropuestaGuaraniAndLectivoId(propuestaGuarani, lectivoId)
+                .map(mapper::toDomainModel);
+    }
+
+    @Override
+    public GuaraniPropuestaTipoChequera save(GuaraniPropuestaTipoChequera domain) {
+        GuaraniPropuestaTipoChequeraEntity entity = mapper.toEntity(domain);
+        return mapper.toDomainModel(repository.save(entity));
+    }
+
+    @Override
+    public boolean existsById(Integer id) {
+        return repository.existsById(id);
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/entity/GuaraniPropuestaTipoChequeraEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/entity/GuaraniPropuestaTipoChequeraEntity.java
@@ -1,0 +1,54 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.entity.TipoChequeraEntity;
+import um.tesoreria.core.hexagonal.lectivo.infrastructure.persistence.entity.LectivoEntity;
+import um.tesoreria.core.model.Auditable;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "guarani_propuesta_tipo_chequera", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"propuesta_guarani", "lectivo_id"})
+})
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GuaraniPropuestaTipoChequeraEntity extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "guarani_propuesta_tipo_chequera_id")
+    private Integer guaraniPropuestaTipoChequeraId;
+
+    @Column(name = "propuesta_guarani")
+    private Integer propuestaGuarani;
+
+    @Column(name = "lectivo_id")
+    private Integer lectivoId;
+
+    @Column(name = "tipo_chequera_id")
+    private Integer tipoChequeraId;
+
+    @OneToOne(optional = true)
+    @JoinColumn(name = "lectivo_id", insertable = false, updatable = false)
+    private LectivoEntity lectivo;
+
+    @OneToOne(optional = true)
+    @JoinColumn(name = "tipo_chequera_id", insertable = false, updatable = false)
+    private TipoChequeraEntity tipoChequera;
+
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/mapper/GuaraniPropuestaTipoChequeraMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/mapper/GuaraniPropuestaTipoChequeraMapper.java
@@ -1,0 +1,32 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.mapper;
+
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.entity.GuaraniPropuestaTipoChequeraEntity;
+
+@Component
+public class GuaraniPropuestaTipoChequeraMapper {
+    public GuaraniPropuestaTipoChequera toDomainModel(GuaraniPropuestaTipoChequeraEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return GuaraniPropuestaTipoChequera.builder()
+                .guaraniPropuestaTipoChequeraId(entity.getGuaraniPropuestaTipoChequeraId())
+                .propuestaGuarani(entity.getPropuestaGuarani())
+                .lectivoId(entity.getLectivoId())
+                .tipoChequeraId(entity.getTipoChequeraId())
+                .build();
+    }
+
+    public GuaraniPropuestaTipoChequeraEntity toEntity(GuaraniPropuestaTipoChequera domain) {
+        if (domain == null) {
+            return null;
+        }
+        return GuaraniPropuestaTipoChequeraEntity.builder()
+                .guaraniPropuestaTipoChequeraId(domain.getGuaraniPropuestaTipoChequeraId())
+                .propuestaGuarani(domain.getPropuestaGuarani())
+                .lectivoId(domain.getLectivoId())
+                .tipoChequeraId(domain.getTipoChequeraId())
+                .build();
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/repository/JpaGuaraniPropuestaTipoChequeraRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/repository/JpaGuaraniPropuestaTipoChequeraRepository.java
@@ -1,0 +1,14 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.entity.GuaraniPropuestaTipoChequeraEntity;
+
+@Repository
+public interface JpaGuaraniPropuestaTipoChequeraRepository
+        extends JpaRepository<GuaraniPropuestaTipoChequeraEntity, Integer> {
+    Optional<GuaraniPropuestaTipoChequeraEntity> findByPropuestaGuaraniAndLectivoId(
+            Integer propuestaGuarani, Integer lectivoId);
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/controller/GuaraniPropuestaTipoChequeraController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/controller/GuaraniPropuestaTipoChequeraController.java
@@ -1,0 +1,68 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.application.exception.GuaraniPropuestaTipoChequeraException;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.application.service.GuaraniPropuestaTipoChequeraService;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.dto.GuaraniPropuestaTipoChequeraRequest;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.dto.GuaraniPropuestaTipoChequeraResponse;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.mapper.GuaraniPropuestaTipoChequeraDtoMapper;
+
+@RestController
+@RequestMapping("/api/tesoreria/core/guaraniPropuestaTipoChequera")
+@RequiredArgsConstructor
+public class GuaraniPropuestaTipoChequeraController {
+    private final GuaraniPropuestaTipoChequeraService service;
+    private final GuaraniPropuestaTipoChequeraDtoMapper dtoMapper;
+
+    @GetMapping("/propuesta/{propuestaGuarani}/lectivo/{lectivoId}")
+    public ResponseEntity<GuaraniPropuestaTipoChequeraResponse> findByPropuestaAndLectivo(
+            @PathVariable Integer propuestaGuarani, @PathVariable Integer lectivoId) {
+        try {
+            return ResponseEntity.ok(dtoMapper.toResponse(
+                    service.findByPropuestaAndLectivo(propuestaGuarani, lectivoId)));
+        } catch (GuaraniPropuestaTipoChequeraException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @PostMapping({"", "/"})
+    public ResponseEntity<GuaraniPropuestaTipoChequeraResponse> add(
+            @RequestBody GuaraniPropuestaTipoChequeraRequest request) {
+        GuaraniPropuestaTipoChequera created = service.create(dtoMapper.toDomain(request));
+        return ResponseEntity.ok(dtoMapper.toResponse(created));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<GuaraniPropuestaTipoChequeraResponse> update(
+            @PathVariable Integer id, @RequestBody GuaraniPropuestaTipoChequeraRequest request) {
+        GuaraniPropuestaTipoChequera domain = dtoMapper.toDomain(request);
+        domain.setGuaraniPropuestaTipoChequeraId(id);
+        try {
+            return ResponseEntity.ok(dtoMapper.toResponse(service.update(domain)));
+        } catch (GuaraniPropuestaTipoChequeraException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+        try {
+            service.delete(id);
+            return ResponseEntity.noContent().build();
+        } catch (GuaraniPropuestaTipoChequeraException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/dto/GuaraniPropuestaTipoChequeraRequest.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/dto/GuaraniPropuestaTipoChequeraRequest.java
@@ -1,0 +1,18 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuaraniPropuestaTipoChequeraRequest {
+    private Integer propuestaGuarani;
+    private Integer lectivoId;
+    private Integer tipoChequeraId;
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/dto/GuaraniPropuestaTipoChequeraResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/dto/GuaraniPropuestaTipoChequeraResponse.java
@@ -1,0 +1,19 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuaraniPropuestaTipoChequeraResponse {
+    private Integer guaraniPropuestaTipoChequeraId;
+    private Integer propuestaGuarani;
+    private Integer lectivoId;
+    private Integer tipoChequeraId;
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/mapper/GuaraniPropuestaTipoChequeraDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/mapper/GuaraniPropuestaTipoChequeraDtoMapper.java
@@ -1,0 +1,32 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.mapper;
+
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.dto.GuaraniPropuestaTipoChequeraRequest;
+import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.dto.GuaraniPropuestaTipoChequeraResponse;
+
+@Component
+public class GuaraniPropuestaTipoChequeraDtoMapper {
+    public GuaraniPropuestaTipoChequera toDomain(GuaraniPropuestaTipoChequeraRequest request) {
+        if (request == null) {
+            return null;
+        }
+        return GuaraniPropuestaTipoChequera.builder()
+                .propuestaGuarani(request.getPropuestaGuarani())
+                .lectivoId(request.getLectivoId())
+                .tipoChequeraId(request.getTipoChequeraId())
+                .build();
+    }
+
+    public GuaraniPropuestaTipoChequeraResponse toResponse(GuaraniPropuestaTipoChequera domain) {
+        if (domain == null) {
+            return null;
+        }
+        return GuaraniPropuestaTipoChequeraResponse.builder()
+                .guaraniPropuestaTipoChequeraId(domain.getGuaraniPropuestaTipoChequeraId())
+                .propuestaGuarani(domain.getPropuestaGuarani())
+                .lectivoId(domain.getLectivoId())
+                .tipoChequeraId(domain.getTipoChequeraId())
+                .build();
+    }
+}


### PR DESCRIPTION
Closes #317

## Descripción
Se incorporan los cambios de la versión 3.48.0: el módulo hexagonal `GuaraniPropuestaTipoChequera`, la migración de búsqueda de `TipoChequera` al caso de uso hexagonal, la documentación asociada y la actualización de dependencias.

## Cambios Realizados
- [x] Añadido el CRUD REST y la persistencia de `GuaraniPropuestaTipoChequera`, incluida la consulta por propuesta y lectivo.
- [x] Migrada la búsqueda de `TipoChequera` a `SearchTipoChequeraUseCase`, con dominio, adaptador y DTO de respuesta.
- [x] Actualizados README, documentación y diagramas Mermaid.
- [x] Actualizada la versión del proyecto a `3.48.0` y las dependencias MySQL Connector/J y Springdoc OpenAPI.

## Verificación
- [x] Ejecutado `mvn test`: 58 tests, 0 fallos, 0 errores.
- [ ] Validar manualmente los endpoints de búsqueda de `TipoChequera` y CRUD de `GuaraniPropuestaTipoChequera`.
