### PR TITLE
feat(tipo-chequera): add geographic search and enriched responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.49.0] - 2026-08-04
+### Added
+- feat(chequera/tipoChequera): Añadida la búsqueda `POST /tipoChequera/search/{geograficaId}`.
+  - Reutiliza las condiciones de búsqueda, filtra por `geograficaId`, ordena por nombre y limita la respuesta a 50 registros.
+- feat(guarani/guaraniPropuestaTipoChequera): Enriquecida la respuesta con el objeto `tipoChequera` relacionado, incluyendo el mapeo de persistencia y DTO.
+- feat(docs): Actualizados los diagramas Mermaid de TipoChequera y GuaraniPropuestaTipoChequera a `v3.49.0`.
+
+### Changed
+- chore(observability): Añadidos logs de depuración en la consulta de estado de tesorería y en la obtención de deuda de examen.
+
+> Basado en `git diff HEAD`, `git log`, el código Java modificado y `pom.xml` (versión `3.48.0` → `3.49.0`).
+
 ## [3.48.0] - 2026-08-03
 ### Added
 - feat(guarani/guaraniPropuestaTipoChequera): Nuevo módulo hexagonal con CRUD REST bajo `/api/tesoreria/core/guaraniPropuestaTipoChequera`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.48.0**
+**Versión actual (SemVer): 3.49.0**
+
+## Novedades 3.49.0 (verificado en código)
+- feat(chequera/tipoChequera): Añadida la búsqueda `POST /tipoChequera/search/{geograficaId}`.
+  - Reutiliza las condiciones de búsqueda, filtra por `geograficaId`, ordena por nombre y limita la respuesta a 50 registros.
+- feat(guarani/guaraniPropuestaTipoChequera): Enriquecida la respuesta con el objeto `tipoChequera` relacionado, incluyendo su mapeo de persistencia y DTO.
+- chore(observability): Añadidos logs de depuración en la consulta de estado de tesorería y en la obtención de deuda de examen.
+- feat(docs): Actualizados los diagramas Mermaid de TipoChequera y GuaraniPropuestaTipoChequera a `v3.49.0`.
+
+> Basado en `git diff HEAD`, `git log`, el código Java modificado y `pom.xml` (versión `3.48.0` → `3.49.0`). El cambio es compatible hacia atrás y añade funcionalidad REST, por lo que corresponde un incremento minor de SemVer.
 
 ## Novedades 3.48.0 (verificado en código)
 - feat(guarani/guaraniPropuestaTipoChequera): Nuevo módulo hexagonal con CRUD REST bajo `/api/tesoreria/core/guaraniPropuestaTipoChequera`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.48.0** (actualizada: 2026-08-03)
+**Versión actual del servicio: 3.49.0** (actualizada: 2026-08-04)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -30,8 +30,8 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-baja.mmd`: Arquitectura hexagonal del módulo Baja (gestión de bajas de chequeras) - v3.36.0 (reubicado bajo `chequera/`).
 - `hexagonal-campanha.mmd`: Arquitectura hexagonal del módulo Campanha (gestión de campañas UM Hub) - v3.24.0.
 - `hexagonal-chequeraProducto.mmd`: Arquitectura hexagonal del módulo Producto (gestión de productos chequera) - v3.30.0 (nuevo módulo).
-- `hexagonal-chequeraTipoChequera.mmd`: Arquitectura hexagonal del módulo TipoChequera (tipos de chequera con 12 casos de uso) - v3.48.0 (incluye búsqueda por condiciones).
-- `hexagonal-guaraniPropuestaTipoChequera.mmd`: Arquitectura hexagonal del módulo GuaraniPropuestaTipoChequera (asignación de tipo de chequera a propuesta y lectivo) - v3.48.0 (nuevo módulo).
+- `hexagonal-chequeraTipoChequera.mmd`: Arquitectura hexagonal del módulo TipoChequera (tipos de chequera con búsqueda por condiciones y geográfica) - v3.49.0.
+- `hexagonal-guaraniPropuestaTipoChequera.mmd`: Arquitectura hexagonal del módulo GuaraniPropuestaTipoChequera (asignación de tipo de chequera a propuesta y lectivo, con tipo de chequera enriquecido) - v3.49.0.
 - `hexagonal-claseChequera.mmd`: Arquitectura hexagonal del módulo ClaseChequera (clasificación de chequeras) - v3.39.0 (nuevo campo `tramite`, caso de uso `GetAllClaseChequeraByTramiteUseCase`, `ClaseChequeraEntity` implementa `Jsonifyable`).
 - `hexagonal-lectivo.mmd`: Arquitectura hexagonal del módulo Lectivo (gestión de lectivos con 8 casos de uso) - v3.30.0 (nuevo módulo).
 - `hexagonal-reservaVacante.mmd`: Arquitectura hexagonal del módulo ReservaVacante (gestión de reservas de vacantes UM Hub) - v3.32.0 (nuevo UpdateReservaVacanteUseCase con integración de pago MercadoPago).

--- a/docs/hexagonal-chequeraTipoChequera.mmd
+++ b/docs/hexagonal-chequeraTipoChequera.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo TipoChequera (v3.48.0)
+title: Arquitectura Hexagonal - Módulo TipoChequera (v3.49.0)
 ---
 
 classDiagram
@@ -29,6 +29,7 @@ classDiagram
             +findAllByClaseChequeraId(Integer) List~TipoChequera~
             +findAllByClaseChequeraIds(List~Integer~) List~TipoChequera~
             +findAllByStrings(List~String~) List~TipoChequeraSearch~
+            +findAllByStringsAndGeograficaId(List~String~, Integer) List~TipoChequeraSearch~
             +findById(Integer) Optional~TipoChequera~
             +findLast() Optional~TipoChequera~
             +create(TipoChequera) TipoChequera
@@ -41,6 +42,7 @@ classDiagram
         class SearchTipoChequeraUseCase {
             <<interface>>
             +searchTipoChequeras(List~String~) List~TipoChequeraSearch~
+            +searchTipoChequerasByGeograficaId(List~String~, Integer) List~TipoChequeraSearch~
         }
 
         class TipoChequeraSearch {
@@ -67,6 +69,7 @@ classDiagram
             +unmark()
             +mark(Integer, Byte) TipoChequera
             +findAllByStrings(List~String~) List~TipoChequeraSearch~
+            +findAllByStringsAndGeograficaId(List~String~, Integer) List~TipoChequeraSearch~
         }
 
     }
@@ -128,6 +131,7 @@ classDiagram
             class TipoChequeraSearchRepository {
                 <<interface>>
                 +findAllByStrings(List~String~) List~TipoChequeraSearch~
+                +findAllByStringsAndGeograficaId(List~String~, Integer) List~TipoChequeraSearch~
             }
     }
     namespace infrastructure_web {
@@ -143,6 +147,7 @@ classDiagram
                 +mark(Integer, Byte) ResponseEntity~Void~
                 +unmark() ResponseEntity~Void~
                 +findAllByStrings(List~String~) ResponseEntity~List~TipoChequeraSearchResponse~~
+                +findAllByStringsAndGeograficaId(List~String~, Integer) ResponseEntity~List~TipoChequeraSearchResponse~~
             }
 
             class TipoChequeraRequest {

--- a/docs/hexagonal-guaraniPropuestaTipoChequera.mmd
+++ b/docs/hexagonal-guaraniPropuestaTipoChequera.mmd
@@ -1,5 +1,5 @@
 ---
-title: Arquitectura Hexagonal - Módulo GuaraniPropuestaTipoChequera (v3.48.0)
+title: Arquitectura Hexagonal - Módulo GuaraniPropuestaTipoChequera (v3.49.0)
 ---
 
 classDiagram
@@ -11,6 +11,13 @@ classDiagram
             +Integer propuestaGuarani
             +Integer lectivoId
             +Integer tipoChequeraId
+            +TipoChequera tipoChequera
+        }
+
+        class TipoChequera {
+            +Integer tipoChequeraId
+            +String nombre
+            +Integer geograficaId
         }
 
         class GuaraniPropuestaTipoChequeraRepository {
@@ -44,6 +51,13 @@ classDiagram
             +Integer propuestaGuarani
             +Integer lectivoId
             +Integer tipoChequeraId
+            +TipoChequeraEntity tipoChequera
+        }
+
+        class TipoChequeraEntity {
+            +Integer tipoChequeraId
+            +String nombre
+            +Integer geograficaId
         }
 
         class JpaGuaraniPropuestaTipoChequeraRepository {
@@ -65,6 +79,7 @@ classDiagram
 
         class GuaraniPropuestaTipoChequeraRequest
         class GuaraniPropuestaTipoChequeraResponse
+        class TipoChequeraResponse
         class GuaraniPropuestaTipoChequeraDtoMapper
     }
 
@@ -79,3 +94,6 @@ classDiagram
     JpaGuaraniPropuestaTipoChequeraRepository --> GuaraniPropuestaTipoChequeraEntity : persists
     GuaraniPropuestaTipoChequeraController --> GuaraniPropuestaTipoChequeraService : calls
     GuaraniPropuestaTipoChequeraController --> GuaraniPropuestaTipoChequeraDtoMapper : uses
+    GuaraniPropuestaTipoChequera --> TipoChequera : references
+    GuaraniPropuestaTipoChequeraEntity --> TipoChequeraEntity : loads
+    GuaraniPropuestaTipoChequeraResponse --> TipoChequeraResponse : includes

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.48.0</version>
+    <version>3.49.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/application/service/TipoChequeraService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/application/service/TipoChequeraService.java
@@ -33,6 +33,11 @@ public class TipoChequeraService {
         return searchTipoChequeraUseCase.searchTipoChequeras(conditions);
     }
 
+    public List<TipoChequeraSearch> findAllByStringsAndGeograficaId(List<String> conditions, Integer geograficaId) {
+        log.debug("Processing findAllByStringsAndGeograficaId");
+        return searchTipoChequeraUseCase.searchTipoChequerasByGeograficaId(conditions, geograficaId);
+    }
+
     public List<TipoChequera> findAll() {
         return getAllTipoChequeraUseCase.getAllTipoChequera();
     }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/application/usecases/SearchTipoChequeraUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/application/usecases/SearchTipoChequeraUseCaseImpl.java
@@ -18,4 +18,9 @@ public class SearchTipoChequeraUseCaseImpl implements SearchTipoChequeraUseCase 
     public List<TipoChequeraSearch> searchTipoChequeras(List<String> conditions) {
         return repository.findAllByStrings(conditions);
     }
+
+    @Override
+    public List<TipoChequeraSearch> searchTipoChequerasByGeograficaId(List<String> conditions, Integer geograficaId) {
+        return repository.findAllByStringsAndGeograficaId(conditions, geograficaId);
+    }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/ports/in/SearchTipoChequeraUseCase.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/ports/in/SearchTipoChequeraUseCase.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface SearchTipoChequeraUseCase {
     List<TipoChequeraSearch> searchTipoChequeras(List<String> conditions);
+    List<TipoChequeraSearch> searchTipoChequerasByGeograficaId(List<String> conditions, Integer geograficaId);
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/ports/out/TipoChequeraRepository.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/domain/ports/out/TipoChequeraRepository.java
@@ -13,6 +13,7 @@ public interface TipoChequeraRepository {
     List<TipoChequera> findAllByClaseChequeraId(Integer claseChequeraId);
     List<TipoChequera> findAllByClaseChequeraIds(List<Integer> claseChequeraIds);
     List<TipoChequeraSearch> findAllByStrings(List<String> conditions);
+    List<TipoChequeraSearch> findAllByStringsAndGeograficaId(List<String> conditions, Integer geograficaId);
     Optional<TipoChequera> findById(Integer tipoChequeraId);
     Optional<TipoChequera> findLast();
     TipoChequera create(TipoChequera tipoChequera);

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/persistence/adapter/JpaTipoChequeraRepositoryAdapter.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/persistence/adapter/JpaTipoChequeraRepositoryAdapter.java
@@ -41,6 +41,13 @@ public class JpaTipoChequeraRepositoryAdapter implements TipoChequeraRepository 
     }
 
     @Override
+    public List<TipoChequeraSearch> findAllByStringsAndGeograficaId(List<String> conditions, Integer geograficaId) {
+        return tipoChequeraSearchRepository.findAllByStringsAndGeograficaId(conditions, geograficaId).stream()
+                .map(tipoChequeraMapper::toSearchDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public List<TipoChequera> findAllAsignable(Integer facultadId, Integer lectivoId, Integer geograficaId, Integer claseChequeraId) {
         List<Integer> tipoChequeraIds = lectivoTotalService.findAllByLectivo(facultadId, lectivoId).stream()
                 .map(LectivoTotal::getTipoChequeraId).distinct().collect(Collectors.toList());

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/web/controller/TipoChequeraController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/tipoChequera/infrastructure/web/controller/TipoChequeraController.java
@@ -40,6 +40,15 @@ public class TipoChequeraController {
         return ResponseEntity.ok(responses);
     }
 
+    @PostMapping("/search/{geograficaId}")
+    public ResponseEntity<List<TipoChequeraSearchResponse>> findAllByStringsAndGeograficaId(
+            @RequestBody List<String> conditions, @PathVariable Integer geograficaId) {
+        List<TipoChequeraSearchResponse> responses = service.findAllByStringsAndGeograficaId(conditions, geograficaId).stream()
+                .map(tipoChequeraDtoMapper::toSearchResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
     @GetMapping("/asignable/{facultadId}/{lectivoId}/{geograficaId}/{claseChequeraId}")
     public ResponseEntity<List<TipoChequeraResponse>> findAllAsignable(@PathVariable Integer facultadId,
                                                                        @PathVariable Integer lectivoId,

--- a/src/main/java/um/tesoreria/core/hexagonal/extern/facultad/tesoreriaEstado/domain/model/TesoreriaEstadoFacultad.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/extern/facultad/tesoreriaEstado/domain/model/TesoreriaEstadoFacultad.java
@@ -1,6 +1,7 @@
 package um.tesoreria.core.hexagonal.extern.facultad.tesoreriaEstado.domain.model;
 
 import lombok.*;
+import um.tesoreria.core.util.Jsonifyable;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -10,7 +11,7 @@ import java.time.OffsetDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TesoreriaEstadoFacultad {
+public class TesoreriaEstadoFacultad implements Jsonifyable {
 
     private Long tesoreriaEstadoId;
     private Integer facultadId;
@@ -31,4 +32,5 @@ public class TesoreriaEstadoFacultad {
 
     @Builder.Default
     private String uuid = "";
+
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/extern/facultad/tesoreriaEstado/infrastructure/web/consumer/TesoreriaEstadoFacultadConsumer.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/extern/facultad/tesoreriaEstado/infrastructure/web/consumer/TesoreriaEstadoFacultadConsumer.java
@@ -1,6 +1,7 @@
 package um.tesoreria.core.hexagonal.extern.facultad.tesoreriaEstado.infrastructure.web.consumer;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -16,6 +17,7 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class TesoreriaEstadoFacultadConsumer implements TesoreriaEstadoRepository {
 
     private final RestClient restClient;
@@ -26,7 +28,9 @@ public class TesoreriaEstadoFacultadConsumer implements TesoreriaEstadoRepositor
     public Optional<TesoreriaEstadoFacultad> findByUnique(Integer facultadId,
                                                           BigDecimal personaId,
                                                           Integer documentoId) {
+        log.debug("Processing TesoreriaEstadoFacultadConsumer.findByUnique");
         String baseUrl = urlResolver.getBaseUrl(facultadId);
+        log.debug("\n\nbaseUrl: {}\n\n", baseUrl);
         TesoreriaEstadoFacultadResponse response;
         try {
             response = restClient.get()

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/model/GuaraniPropuestaTipoChequera.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/domain/model/GuaraniPropuestaTipoChequera.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.domain.model.TipoChequera;
 
 @Getter
 @Setter
@@ -16,4 +17,5 @@ public class GuaraniPropuestaTipoChequera {
     private Integer propuestaGuarani;
     private Integer lectivoId;
     private Integer tipoChequeraId;
+    private TipoChequera tipoChequera;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/mapper/GuaraniPropuestaTipoChequeraMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/persistence/mapper/GuaraniPropuestaTipoChequeraMapper.java
@@ -1,11 +1,18 @@
 package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.mapper;
 
 import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.persistence.mapper.TipoChequeraMapper;
 import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
 import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.persistence.entity.GuaraniPropuestaTipoChequeraEntity;
 
 @Component
 public class GuaraniPropuestaTipoChequeraMapper {
+    private final TipoChequeraMapper tipoChequeraMapper;
+
+    public GuaraniPropuestaTipoChequeraMapper(TipoChequeraMapper tipoChequeraMapper) {
+        this.tipoChequeraMapper = tipoChequeraMapper;
+    }
+
     public GuaraniPropuestaTipoChequera toDomainModel(GuaraniPropuestaTipoChequeraEntity entity) {
         if (entity == null) {
             return null;
@@ -15,6 +22,7 @@ public class GuaraniPropuestaTipoChequeraMapper {
                 .propuestaGuarani(entity.getPropuestaGuarani())
                 .lectivoId(entity.getLectivoId())
                 .tipoChequeraId(entity.getTipoChequeraId())
+                .tipoChequera(tipoChequeraMapper.toDomainModel(entity.getTipoChequera()))
                 .build();
     }
 

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/dto/GuaraniPropuestaTipoChequeraResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/dto/GuaraniPropuestaTipoChequeraResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.dto.TipoChequeraResponse;
 
 @Getter
 @Setter
@@ -16,4 +17,5 @@ public class GuaraniPropuestaTipoChequeraResponse {
     private Integer propuestaGuarani;
     private Integer lectivoId;
     private Integer tipoChequeraId;
+    private TipoChequeraResponse tipoChequera;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/mapper/GuaraniPropuestaTipoChequeraDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniPropuestaTipoChequera/infrastructure/web/mapper/GuaraniPropuestaTipoChequeraDtoMapper.java
@@ -1,12 +1,19 @@
 package um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.mapper;
 
 import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.tipoChequera.infrastructure.web.mapper.TipoChequeraDtoMapper;
 import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.domain.model.GuaraniPropuestaTipoChequera;
 import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.dto.GuaraniPropuestaTipoChequeraRequest;
 import um.tesoreria.core.hexagonal.guarani.guaraniPropuestaTipoChequera.infrastructure.web.dto.GuaraniPropuestaTipoChequeraResponse;
 
 @Component
 public class GuaraniPropuestaTipoChequeraDtoMapper {
+    private final TipoChequeraDtoMapper tipoChequeraDtoMapper;
+
+    public GuaraniPropuestaTipoChequeraDtoMapper(TipoChequeraDtoMapper tipoChequeraDtoMapper) {
+        this.tipoChequeraDtoMapper = tipoChequeraDtoMapper;
+    }
+
     public GuaraniPropuestaTipoChequera toDomain(GuaraniPropuestaTipoChequeraRequest request) {
         if (request == null) {
             return null;
@@ -27,6 +34,7 @@ public class GuaraniPropuestaTipoChequeraDtoMapper {
                 .propuestaGuarani(domain.getPropuestaGuarani())
                 .lectivoId(domain.getLectivoId())
                 .tipoChequeraId(domain.getTipoChequeraId())
+                .tipoChequera(tipoChequeraDtoMapper.toResponse(domain.getTipoChequera()))
                 .build();
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/persona/application/usecases/GetDeudaExamenUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/persona/application/usecases/GetDeudaExamenUseCaseImpl.java
@@ -1,6 +1,7 @@
 package um.tesoreria.core.hexagonal.persona.application.usecases;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.service.ChequeraSerieService;
@@ -17,6 +18,7 @@ import java.time.OffsetDateTime;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class GetDeudaExamenUseCaseImpl implements GetDeudaExamenUseCase {
 
     private static final Integer PRODUCTO_MATRICULA = 2;
@@ -30,6 +32,7 @@ public class GetDeudaExamenUseCaseImpl implements GetDeudaExamenUseCase {
 
     @Override
     public DeudaExamen getDeudaExamenByFacultadAndPersona(Integer facultadId, BigDecimal personaId, Integer documentoId, OffsetDateTime fechaExamen) {
+        log.debug("Processing GetDeudaExamenUseCaseImpl.getDeudaExamenByFacultadAndPersona");
         var lectivo = lectivoService.findByFecha(OffsetDateTime.now());
         TesoreriaEstadoFacultad tesoreriaEstado;
         try {
@@ -40,6 +43,7 @@ public class GetDeudaExamenUseCaseImpl implements GetDeudaExamenUseCase {
                     .fechaTope(OffsetDateTime.now().plusHours(-7))
                     .build();
         }
+        log.debug("Tesoreria estado: {}", tesoreriaEstado.jsonify());
         var chequeras = chequeraSerieService.findAllByPersonaIdAndDocumentoIdAndFacultadIdAndLectivoId(personaId, documentoId, facultadId, lectivo.getLectivoId());
         if (chequeras.isEmpty()) {
             return DeudaExamen.builder()

--- a/src/main/java/um/tesoreria/core/repository/view/TipoChequeraSearchRepositoryCustom.java
+++ b/src/main/java/um/tesoreria/core/repository/view/TipoChequeraSearchRepositoryCustom.java
@@ -7,5 +7,6 @@ import java.util.List;
 public interface TipoChequeraSearchRepositoryCustom {
 
     List<TipoChequeraSearch> findAllByStrings(List<String> conditions);
+    List<TipoChequeraSearch> findAllByStringsAndGeograficaId(List<String> conditions, Integer geograficaId);
 
 }

--- a/src/main/java/um/tesoreria/core/repository/view/impl/TipoChequeraSearchRepositoryCustomImpl.java
+++ b/src/main/java/um/tesoreria/core/repository/view/impl/TipoChequeraSearchRepositoryCustomImpl.java
@@ -37,4 +37,19 @@ public class TipoChequeraSearchRepositoryCustomImpl implements TipoChequeraSearc
         return entityManager.createQuery(criteriaQuery).setMaxResults(50).getResultList();
     }
 
+    @Override
+    public List<TipoChequeraSearch> findAllByStringsAndGeograficaId(List<String> conditions, Integer geograficaId) {
+        CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<TipoChequeraSearch> criteriaQuery = criteriaBuilder.createQuery(TipoChequeraSearch.class);
+        Root<TipoChequeraSearch> root = criteriaQuery.from(TipoChequeraSearch.class);
+
+        List<Predicate> predicates = new ArrayList<>();
+        conditions.forEach(condition ->
+                predicates.add(criteriaBuilder.like(root.get("search"), "%" + condition + "%")));
+        predicates.add(criteriaBuilder.equal(root.get("geograficaId"), geograficaId));
+        criteriaQuery.select(root).where(predicates.toArray(new Predicate[0]));
+        criteriaQuery.orderBy(criteriaBuilder.asc(root.get("nombre")));
+        return entityManager.createQuery(criteriaQuery).setMaxResults(50).getResultList();
+    }
+
 }


### PR DESCRIPTION
Closes #319

## Descripcion
Actualiza el servicio a la version 3.49.0 e incorpora la busqueda de TipoChequera por geografia, el enriquecimiento de las respuestas de GuaraniPropuestaTipoChequera y mejoras de observabilidad y documentacion.

## Cambios Realizados
- [x] Agregado el endpoint `POST /tipoChequera/search/{geograficaId}` con filtrado geografico, orden por nombre y limite de 50 resultados.
- [x] Extendidos los puertos, casos de uso, servicio y adaptadores de persistencia de TipoChequera.
- [x] Incluido el objeto `tipoChequera` relacionado en el modelo y respuesta de GuaraniPropuestaTipoChequera, con sus mapeos.
- [x] Agregados logs de depuracion en la consulta del estado de tesoreria y la obtencion de deuda de examen.
- [x] Actualizados `pom.xml`, `README.md`, `CHANGELOG.md` y diagramas Mermaid a la version `3.49.0`.

## Verificacion
`mvn test` ejecutado correctamente: 58 tests, 0 fallos, 0 errores y 0 omitidos.

No se realizo una prueba manual contra un entorno con datos de integracion.
