### PR TITLE
feat(auth): expose geographic ID in login response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [3.51.0] - 2026-08-08
+### Added
+- feat(auth): Añadido `geograficaId` a `LoginResponse` y completado su mapeo desde `UsuarioAuth`, permitiendo a los clientes identificar la geográfica del usuario autenticado.
+- test(auth): Añadidas pruebas para el mapeo completo, el dominio nulo y la geográfica no encontrada.
+
+> Basado en `LoginResponse.java`, `AuthDtoMapper.java`, `AuthDtoMapperTest.java` y `pom.xml` (versión `3.50.1` → `3.51.0`). No se modificaron dependencias principales.
+
 ## [3.50.1] - 2026-08-06
 ### Fixed
 - fix(personas/documento): Restaurada la ruta corta `/documento` junto con `/api/tesoreria/core/documento`, manteniendo ambas rutas para compatibilidad de clientes.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 3.50.1**
+**Versión actual (SemVer): 3.51.0**
+
+## Novedades 3.51.0 (verificado en código)
+- feat(auth): Añadido `geograficaId` a `LoginResponse` y completado su mapeo desde `UsuarioAuth`, permitiendo a los clientes identificar la geográfica del usuario autenticado.
+- test(auth): Añadidas pruebas para el mapeo completo, el dominio nulo y la geográfica no encontrada.
+
+> Basado en `LoginResponse.java`, `AuthDtoMapper.java`, `AuthDtoMapperTest.java` y `pom.xml` (versión `3.50.1` → `3.51.0`). No se modificaron dependencias principales; corresponde un incremento minor de SemVer.
 
 ## Novedades 3.50.1 (verificado en código)
 - fix(personas/documento): Restaurada la ruta corta `/documento` junto con `/api/tesoreria/core/documento`, manteniendo ambas rutas para compatibilidad de clientes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.50.1** (actualizada: 2026-08-06)
+**Versión actual del servicio: 3.51.0** (actualizada: 2026-08-08)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>3.50.1</version>
+    <version>3.51.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/src/main/java/um/tesoreria/core/hexagonal/auth/infrastructure/web/dto/LoginResponse.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/auth/infrastructure/web/dto/LoginResponse.java
@@ -1,15 +1,18 @@
 package um.tesoreria.core.hexagonal.auth.infrastructure.web.dto;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class LoginResponse {
 
     private String token;
     private Long userId;
     private String nombre;
+    private Integer geograficaId;
     private String sede;
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/auth/infrastructure/web/mapper/AuthDtoMapper.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/auth/infrastructure/web/mapper/AuthDtoMapper.java
@@ -19,6 +19,7 @@ public class AuthDtoMapper {
                 .token("dummy-jwt-token-replace-later")
                 .userId(domain.getUserId())
                 .nombre(domain.getNombre())
+                .geograficaId(domain.getGeograficaId())
                 .sede(geograficaService.findByGeograficaId(domain.getGeograficaId())
                         .map(Geografica::getNombre)
                         .orElse("Sede no encontrada"))

--- a/src/test/java/um/tesoreria/core/hexagonal/auth/infrastructure/web/mapper/AuthDtoMapperTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/auth/infrastructure/web/mapper/AuthDtoMapperTest.java
@@ -1,0 +1,68 @@
+package um.tesoreria.core.hexagonal.auth.infrastructure.web.mapper;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.auth.domain.model.UsuarioAuth;
+import um.tesoreria.core.hexagonal.geografica.application.service.GeograficaService;
+import um.tesoreria.core.hexagonal.geografica.domain.model.Geografica;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthDtoMapperTest {
+
+    @Mock
+    private GeograficaService geograficaService;
+
+    @InjectMocks
+    private AuthDtoMapper mapper;
+
+    @Test
+    void toResponse_whenDomainIsNull_returnsNull() {
+        assertThat(mapper.toResponse(null)).isNull();
+    }
+
+    @Test
+    void toResponse_mapsAllFields() {
+        var geografica = new Geografica();
+        geografica.setGeograficaId(7);
+        geografica.setNombre("Sede Centro");
+        when(geograficaService.findByGeograficaId(7)).thenReturn(Optional.of(geografica));
+
+        var usuario = new UsuarioAuth();
+        usuario.setUserId(1L);
+        usuario.setNombre("Daniel");
+        usuario.setGeograficaId(7);
+
+        var response = mapper.toResponse(usuario);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getToken()).isNotBlank();
+        assertThat(response.getUserId()).isEqualTo(1L);
+        assertThat(response.getNombre()).isEqualTo("Daniel");
+        assertThat(response.getGeograficaId()).isEqualTo(7);
+        assertThat(response.getSede()).isEqualTo("Sede Centro");
+    }
+
+    @Test
+    void toResponse_whenGeograficaNotFound_usesFallbackSede() {
+        when(geograficaService.findByGeograficaId(7)).thenReturn(Optional.empty());
+
+        var usuario = new UsuarioAuth();
+        usuario.setUserId(1L);
+        usuario.setGeograficaId(7);
+
+        var response = mapper.toResponse(usuario);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getGeograficaId()).isEqualTo(7);
+        assertThat(response.getSede()).isEqualTo("Sede no encontrada");
+    }
+
+}


### PR DESCRIPTION
Closes #325

## Descripción
Expone `geograficaId` en la respuesta de autenticación y completa su mapeo desde `UsuarioAuth`. Incluye pruebas del mapper y actualiza la versión del servicio a `3.51.0` junto con la documentación.

## Cambios Realizados
- [x] Añadido `geograficaId` a `LoginResponse` y mapeado en `AuthDtoMapper`.
- [x] Añadidas pruebas para mapeo completo, dominio nulo y geográfica no encontrada.
- [x] Actualizados `pom.xml`, `README.md`, `CHANGELOG.md` y `docs/README.md` a `3.51.0`.

## Verificación
- [x] `mvn test` ejecutado correctamente: 61 pruebas, 0 fallos, 0 errores.
- [x] Revisado el diff contra `main`; no incluye workflows ni acciones de GitHub.
- [ ] Los proyectos de GitHub no pudieron validarse porque el token no tiene el alcance `read:project`; no se incluye ese metadato.
