### PR TITLE
ci(staging): add deployment and bump version 4.1.1

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,85 @@
+name: Deploy staging
+
+on:
+  pull_request:
+    branches: ["staging"]
+  push:
+    branches: ["staging"]
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify application
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: temurin
+          cache: maven
+
+      - name: Verify with Maven
+        run: mvn -B verify
+
+  build-image:
+    name: Build and publish staging image
+    needs: verify
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha,scope=staging
+          cache-to: type=gha,scope=staging,mode=max
+
+  deploy:
+    name: Deploy staging service
+    needs: build-image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    runs-on: [self-hosted, linux, staging]
+    environment:
+      name: staging
+    permissions:
+      contents: read
+
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Deploy tesoreria core service
+        run: /data/docker/env-staging/deploy-tesoreria-core-staging.sh "${GITHUB_SHA}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [4.1.1] - 2026-08-17
+### Changed
+- fix(ci): Limitado el despliegue del servicio de develop a eventos `push` sobre la rama `develop`.
+- feat(ci): Añadido workflow para verificar, construir, publicar y desplegar la imagen del servicio en staging.
+
+> Basado en los workflows `.github/workflows/deploy-develop.yml` y `.github/workflows/deploy-staging.yml`, `git diff HEAD` y `pom.xml` (versión `4.1.0` → `4.1.1`). Los cambios son internos de CI/CD y no modifican contratos ni comportamiento de la API; corresponden a un incremento patch de SemVer.
+
 ## [4.1.0] - 2026-08-13
 ### Added
 - feat(guarani/guaraniBeneficio): Añadida la consulta de beneficios por múltiples requisitos mediante `POST /api/tesoreria/core/guaraniBeneficio/requisitos`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 Servicio core para la gestión de tesorería, implementado con Spring Boot 4.1.0.
 
-**Versión actual (SemVer): 4.1.0**
+**Versión actual (SemVer): 4.1.1**
+
+## Novedades 4.1.1 (verificado en código)
+- fix(ci): Limitado el despliegue del servicio de develop a eventos `push` sobre la rama `develop`.
+- feat(ci): Añadido workflow para verificar, construir, publicar y desplegar la imagen del servicio en staging.
+
+> Basado en los workflows `.github/workflows/deploy-develop.yml` y `.github/workflows/deploy-staging.yml`, `git diff HEAD` y `pom.xml` (versión `4.1.0` → `4.1.1`). Los cambios son internos de CI/CD y corresponden a un incremento patch de SemVer.
 
 ## Novedades 4.1.0 (verificado en código)
 - feat(guarani/guaraniBeneficio): Añadida la consulta de beneficios por múltiples requisitos mediante `POST /api/tesoreria/core/guaraniBeneficio/requisitos`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 3.51.0** (actualizada: 2026-08-08)
+**Versión actual del servicio: 4.1.1** (actualizada: 2026-08-17)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.1</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>


### PR DESCRIPTION
Closes #334

## Descripción
Implementa los cambios de CI/CD y documentación de la issue #334 para preparar la versión 4.1.1 y habilitar el despliegue de staging.

## Cambios Realizados
- [x] Añadido `.github/workflows/deploy-staging.yml` para verificar con Maven, construir y publicar la imagen Docker y desplegar el servicio en staging.
- [x] Actualizada la documentación de CI/CD y la versión 4.1.1 en `README.md`, `CHANGELOG.md` y `docs/README.md`.
- [x] Actualizada la versión del proyecto de 4.1.0 a 4.1.1 en `pom.xml`.

## Verificación
- [x] `mvn -B verify` ejecutado correctamente: 62 tests, 0 fallos, 0 errores.
- [x] Revisado manualmente el workflow: permisos de solo lectura, jobs encadenados mediante `needs`, despliegue restringido a eventos `push` sobre `staging` y secretos usados mediante `secrets.*`.
- [ ] `actionlint` y `yamllint` no ejecutados: no están instalados en el entorno.
- [x] Revisadas ejecuciones recientes de GitHub Actions: las ejecuciones de staging, develop y main consultadas finalizaron correctamente, salvo una ejecución cancelada previa de develop.
