### PR TITLE
v4.2.0 feat: calcular beneficios de ingreso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
+## [4.2.0] - 2026-08-20
+### Added
+- feat(chequera): Aplicado el beneficio de ingreso más alto sobre las tres cuotas preuniversitarias, conservando los importes de lista y registrando el porcentaje en la chequera.
+- feat(guarani): Validado el alta y la actualización de beneficios entre 0 % y 100 %, con conflicto explícito para requisitos duplicados.
+
+### Changed
+- refactor(chequera): Unificada la creación de cuotas para preuniversitario y Spoter, manteniendo Spoter sin beneficio y recalculando los totales por producto desde las cuotas activas.
+- fix(chequera): El detector de inconsistencias admite cuotas bonificadas y deja de abortar ante datos históricos incompletos.
+- test(chequera): Añadidos escenarios de beneficio, redondeo, totales, código de barras y regresión.
+
 ## [4.1.1] - 2026-08-17
 ### Changed
 - fix(ci): Limitado el despliegue del servicio de develop a eventos `push` sobre la rama `develop`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 
 ## [4.2.0] - 2026-08-20
+### Fixed
+- fix(chequera): Corregida la escala del beneficio a la fracción persistida entre `0.00` y `1.00`, para que `0.50` descuente correctamente el 50 % de cada tramo.
+
 ### Added
 - feat(chequera): Aplicado el beneficio de ingreso más alto sobre las tres cuotas preuniversitarias, conservando los importes de lista y registrando el porcentaje en la chequera.
 - feat(guarani): Validado el alta y la actualización de beneficios entre 0 % y 100 %, con conflicto explícito para requisitos duplicados.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Diagramas de Documentación
 
-**Versión actual del servicio: 4.1.1** (actualizada: 2026-08-17)
+**Versión actual del servicio: 4.2.0** (actualizada: 2026-08-20)
 
 Este directorio contiene los diagramas Mermaid generados automáticamente para la documentación del servicio:
 
@@ -50,7 +50,7 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-setup.mmd`: Arquitectura hexagonal del módulo Setup (configuración de tesorería) - v3.43.0 (nuevo módulo).
 - `hexagonal-deudaExamen.mmd`: Arquitectura hexagonal del módulo DeudaExamen (validación de habilitación para rendir exámenes) - v3.46.0 (integración con TesoreriaEstadoFacultadService para habilitación manual).
 - `hexagonal-guaraniBeneficio.mmd`: Arquitectura hexagonal del módulo GuaraniBeneficio (beneficios de estudiantes Guarani) - v3.47.0 (nuevo listado completo).
-- `hexagonal-beneficioCuota.mmd`: Cableado del beneficio por requisitos de ingreso hasta los importes de cuota preuniversitaria (política MAX, `becaPorcentaje`, factory de cuotas y totales) - v4.1.1.
+- `hexagonal-beneficioCuota.mmd`: Cableado del beneficio por requisitos de ingreso hasta los importes de cuota preuniversitaria (política MAX, `becaPorcentaje`, factory de cuotas y totales) - v4.2.0.
 - `hexagonal-tesoreriaEstado.mmd`: Arquitectura hexagonal del módulo TesoreriaEstado (consulta de estado de tesorería del estudiante en el servicio de facultad) - v3.46.0 (nuevo módulo, consumer REST).
 - `hexagonal-guaraniUbicacion.mmd`: Arquitectura hexagonal del módulo GuaraniUbicacion (CRUD y consulta por ubicación Guaraní) - v3.50.0.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Este directorio contiene los diagramas Mermaid generados automáticamente para l
 - `hexagonal-setup.mmd`: Arquitectura hexagonal del módulo Setup (configuración de tesorería) - v3.43.0 (nuevo módulo).
 - `hexagonal-deudaExamen.mmd`: Arquitectura hexagonal del módulo DeudaExamen (validación de habilitación para rendir exámenes) - v3.46.0 (integración con TesoreriaEstadoFacultadService para habilitación manual).
 - `hexagonal-guaraniBeneficio.mmd`: Arquitectura hexagonal del módulo GuaraniBeneficio (beneficios de estudiantes Guarani) - v3.47.0 (nuevo listado completo).
+- `hexagonal-beneficioCuota.mmd`: Cableado del beneficio por requisitos de ingreso hasta los importes de cuota preuniversitaria (política MAX, `becaPorcentaje`, factory de cuotas y totales) - v4.1.1.
 - `hexagonal-tesoreriaEstado.mmd`: Arquitectura hexagonal del módulo TesoreriaEstado (consulta de estado de tesorería del estudiante en el servicio de facultad) - v3.46.0 (nuevo módulo, consumer REST).
 - `hexagonal-guaraniUbicacion.mmd`: Arquitectura hexagonal del módulo GuaraniUbicacion (CRUD y consulta por ubicación Guaraní) - v3.50.0.
 

--- a/docs/hexagonal-beneficioCuota.mmd
+++ b/docs/hexagonal-beneficioCuota.mmd
@@ -1,5 +1,5 @@
 ---
-title: Beneficio por requisitos de ingreso en cuotas preuniversitarias (v4.1.1)
+title: Beneficio por requisitos de ingreso en cuotas preuniversitarias (v4.2.0)
 ---
 
 classDiagram

--- a/docs/hexagonal-beneficioCuota.mmd
+++ b/docs/hexagonal-beneficioCuota.mmd
@@ -1,0 +1,102 @@
+---
+title: Beneficio por requisitos de ingreso en cuotas preuniversitarias (v4.1.1)
+---
+
+classDiagram
+    direction TB
+
+    namespace domain {
+        class RequisitoPresentadoGuarani {
+            +Integer persona
+            +Integer requisito
+            +RequisitoGuarani requisitoRel
+        }
+
+        class RequisitoGuarani {
+            +Integer requisito
+            +String requisitoIngreso
+            +String activo
+        }
+
+        class GuaraniBeneficio {
+            +Integer guaraniBeneficioId
+            +Integer requisito
+            +BigDecimal porcentajeBeneficio
+        }
+
+        class BeneficioPolicy {
+            +porcentajeEfectivo(List~RequisitoPresentadoGuarani~, List~GuaraniBeneficio~) BigDecimal
+            -esRequisitoElegible(RequisitoPresentadoGuarani) boolean
+        }
+
+        class ChequeraSerie {
+            +Long chequeraSerieId
+            +Integer alternativaId
+            +BigDecimal becaPorcentaje
+        }
+
+        class ChequeraCuota {
+            +Integer productoId
+            +BigDecimal importe1
+            +BigDecimal importe1Original
+            +String codigoBarras
+        }
+
+        class ChequeraTotal {
+            +Integer productoId
+            +BigDecimal total
+            +BigDecimal pagado
+        }
+    }
+
+    namespace application {
+        class PreuniversitarioChequeraService {
+            -GuaraniBeneficioService guaraniBeneficioService
+            -BeneficioPolicy beneficioPolicy
+            +create(PersonalesResponse) ChequeraSerie
+            -resolverBeneficio(PreuniversitarioChequeraData) BigDecimal
+        }
+
+        class PreuniversitarioChequeraDetailsCreator {
+            -LectivoTotalService lectivoTotalService
+            -ChequeraCuotaFactory chequeraCuotaFactory
+            +create(ChequeraSerie) void
+            -createCuotas(ChequeraSerie) List~ChequeraCuota~
+            -createTotals(ChequeraSerie, List~ChequeraCuota~) void
+            -productos(ChequeraSerie, Set~Integer~) Collection~Integer~
+            -sumarActivas(ChequeraSerie, Integer, List~ChequeraCuota~) BigDecimal
+        }
+
+        class ChequeraCuotaFactory {
+            +vencio(LectivoCuota, OffsetDateTime) boolean
+            +crear(ChequeraSerie, LectivoCuota, int, OffsetDateTime) ChequeraCuota
+            -aplicarBeneficio(BigDecimal, BigDecimal, ChequeraSerie, LectivoCuota, int) BigDecimal
+            -calcularCodigoBarras(ChequeraCuota, ChequeraSerie, LectivoCuota) String
+        }
+
+        class SpoterService {
+            -ChequeraCuotaFactory chequeraCuotaFactory
+        }
+
+        class FindAllInconsistenciasUseCaseImpl {
+            +findAllInconsistencias(OffsetDateTime, OffsetDateTime) List~ChequeraCuota~
+            -multiplicadorInvalido(BigDecimal, BigDecimal, BigDecimal) boolean
+        }
+    }
+
+    RequisitoPresentadoGuarani --> RequisitoGuarani : requisitoRel
+    PreuniversitarioChequeraService --> BeneficioPolicy : porcentajeEfectivo
+    BeneficioPolicy ..> RequisitoPresentadoGuarani : filtra ingreso='S' y activo='S'
+    BeneficioPolicy ..> GuaraniBeneficio : MAX(porcentajeBeneficio)
+    PreuniversitarioChequeraService --> ChequeraSerie : congela becaPorcentaje
+    PreuniversitarioChequeraService --> PreuniversitarioChequeraDetailsCreator : create
+    PreuniversitarioChequeraDetailsCreator --> ChequeraCuotaFactory : crear
+    SpoterService --> ChequeraCuotaFactory : crear (becaPorcentaje = 0)
+    ChequeraCuotaFactory ..> ChequeraSerie : lee becaPorcentaje
+    ChequeraCuotaFactory --> ChequeraCuota : importeN con factor, importeNOriginal de lista
+    PreuniversitarioChequeraDetailsCreator --> ChequeraTotal : total = suma importe1 activas
+    FindAllInconsistenciasUseCaseImpl ..> ChequeraCuota : verifica invariantes
+
+    note for BeneficioPolicy "Filtra elegibilidad antes de tomar el maximo. requisitoRel nulo falla cerrado con warn."
+    note for ChequeraCuotaFactory "importeN = importeNLista x (1 - beneficio/100) scale 0 HALF_UP. importeNOriginal conserva el precio de lista. Importe nulo se conserva nulo: no se aplica factor ni se calcula barras."
+    note for PreuniversitarioChequeraDetailsCreator "Orden: alternativas, cuotas, totales. Los productos salen de lectivo_total unidos a los que generaron cuotas, asi un producto sin cuotas en la alternativa conserva su fila en cero."

--- a/docs/hexagonal-beneficioCuota.mmd
+++ b/docs/hexagonal-beneficioCuota.mmd
@@ -98,5 +98,5 @@ classDiagram
     FindAllInconsistenciasUseCaseImpl ..> ChequeraCuota : verifica invariantes
 
     note for BeneficioPolicy "Filtra elegibilidad antes de tomar el maximo. requisitoRel nulo falla cerrado con warn."
-    note for ChequeraCuotaFactory "importeN = importeNLista x (1 - beneficio/100) scale 0 HALF_UP. importeNOriginal conserva el precio de lista. Importe nulo se conserva nulo: no se aplica factor ni se calcula barras."
+    note for ChequeraCuotaFactory "beneficio usa escala fraccional: 0.50 es 50 % y 1.00 es 100 %. importeN = importeNLista x (1 - beneficio), scale 0 HALF_UP. importeNOriginal conserva el precio de lista. Importe nulo se conserva nulo: no se aplica factor ni se calcula barras."
     note for PreuniversitarioChequeraDetailsCreator "Orden: alternativas, cuotas, totales. Los productos salen de lectivo_total unidos a los que generaron cuotas, asi un producto sin cuotas en la alternativa conserva su fila en cero."

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,6 +58,7 @@
     <div id="hexagonal-proveedorMovimiento" class="section"></div>
     <div id="hexagonal-track" class="section"></div>
     <div id="hexagonal-guaraniBeneficio" class="section"></div>
+    <div id="hexagonal-beneficioCuota" class="section"></div>
     <div id="hexagonal-tesoreriaEstado" class="section"></div>
     <div id="hexagonal-guaraniUbicacion" class="section"></div>
     <div id="hexagonal-guaraniPropuestaTipoChequera" class="section"></div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -121,6 +121,7 @@ const diagrams = [
   { id: 'hexagonal-proveedorMovimiento', file: 'hexagonal-proveedorMovimiento.mmd', title: 'Arquitectura Hexagonal - ProveedorMovimiento' },
   { id: 'hexagonal-track', file: 'hexagonal-track.mmd', title: 'Arquitectura Hexagonal - Track' },
   { id: 'hexagonal-guaraniBeneficio', file: 'hexagonal-guaraniBeneficio.mmd', title: 'Arquitectura Hexagonal - GuaraniBeneficio' },
+  { id: 'hexagonal-beneficioCuota', file: 'hexagonal-beneficioCuota.mmd', title: 'Beneficio por Requisitos de Ingreso en Cuotas' },
   { id: 'hexagonal-tesoreriaEstado', file: 'hexagonal-tesoreriaEstado.mmd', title: 'Arquitectura Hexagonal - TesoreriaEstado' },
   { id: 'hexagonal-guaraniUbicacion', file: 'hexagonal-guaraniUbicacion.mmd', title: 'Arquitectura Hexagonal - GuaraniUbicacion' },
   { id: 'hexagonal-guaraniPropuestaTipoChequera', file: 'hexagonal-guaraniPropuestaTipoChequera.mmd', title: 'Arquitectura Hexagonal - GuaraniPropuestaTipoChequera' },

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,34 @@
                             <goal>report</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>beneficio-coverage-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <includes>
+                                        <include>um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.policy.*</include>
+                                        <include>um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.factory.*</include>
+                                        <include>um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.usecases.FindAllInconsistenciasUseCaseImpl</include>
+                                        <include>um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.service.PreuniversitarioChequeraDetailsCreator</include>
+                                        <include>um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.service.PreuniversitarioChequeraService</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.edu</groupId>
     <artifactId>um.tesoreria.core-service</artifactId>
-    <version>4.1.1</version>
+    <version>4.2.0</version>
     <name>UM.tesoreria.core-service</name>
     <description>Tesoreria API REST</description>
     <properties>

--- a/specs/features/beneficio-requisitos-ingreso/decisiones.md
+++ b/specs/features/beneficio-requisitos-ingreso/decisiones.md
@@ -14,7 +14,7 @@
 beneficioAplicado = MAX(porcentajeBeneficio de los requisitos del alumno
                           con requisitoIngreso = 'S' y activo = 'S')
 
-importeN         = importeNLista × (1 - beneficioAplicado/100)
+importeN         = importeNLista × (1 - beneficioAplicado)
                        .setScale(0, RoundingMode.HALF_UP)
 
 importeNOriginal = importeNLista          // sin ningún descuento
@@ -32,7 +32,7 @@ Sin requisitos elegibles → `beneficioAplicado = 0` → importes idénticos al 
 
 Si un alumno presenta varios requisitos de ingreso con beneficio asociado, **se aplica el más alto**. No se suman, no se aplican en cascada.
 
-**Ejemplo:** alumno con tres requisitos elegibles de 10 %, 30 % y 20 % → `beneficioAplicado = 30 %`. Sobre una cuota de lista de $47.350, paga $33.145.
+**Ejemplo:** alumno con tres requisitos elegibles de `0.10`, `0.30` y `0.20` → `beneficioAplicado = 0.30` (30 %). Sobre una cuota de lista de $47.350, paga $33.145.
 
 **Consecuencias técnicas:**
 
@@ -57,15 +57,15 @@ El beneficio **no tiene vencimiento**. La chequera del preuniversitario es un tr
 
 ---
 
-## D3 — Tope: ninguno adicional; rango `[0, 100]` inclusive
+## D3 — Tope: ninguno adicional; rango fraccional `[0, 1]` inclusive
 
-**Decidido el 2026-08-19 por el equipo. Corrige una versión previa que fijaba `[0, 99]`.**
+**Confirmado contra la base real el 2026-08-20.**
 
-Cada `porcentajeBeneficio` individual se valida en `[0, 100]` **inclusive** al cargarse en `guarani_beneficio`. No hay ningún tope adicional en el cálculo.
+Cada `porcentajeBeneficio` individual se valida en `[0, 1]` **inclusive**, con dos decimales, al cargarse en `guarani_beneficio`. `0.50` representa 50 % y `1.00`, 100 %. No hay ningún tope adicional en el cálculo.
 
-**Por qué cambió:** la cota de 99 venía de la propuesta de cascada multiplicativa, donde el 100 % era inalcanzable por construcción. Con `MAX` ese razonamiento no aplica, y **permitir 100 es necesario**: es el caso que dispara el mail de beca completa.
+**Por qué esta escala:** `guarani_beneficio.porcentaje_beneficio` y `chequera_serie.beca_porcentaje` son `DECIMAL(5,2)` y los datos reales se guardan como fracción. Con `MAX`, permitir `1.00` es necesario: es el caso de beneficio completo.
 
-**Ejemplo:** `porcentajeBeneficio = 100` → cuota en cero → el alumno no debe nada.
+**Ejemplo:** `porcentajeBeneficio = 1.00` → cuota en cero → el alumno no debe nada.
 
 **Consecuencias verificadas del caso 100 %:**
 
@@ -213,7 +213,7 @@ Ningún mapper reconstruye `PersonaGuarani` desde la base ni copia campo por cam
 
 ## Abierto — pendiente de definición
 
-1. **Contenido del aviso complementario de beca completa (100 %)** — es la **fase F7** del roadmap, bloqueada por definición, **no está fuera de alcance**. La chequera bonificada se envía siempre con `send-chequera`; falta decidir qué mensaje adicional la acompaña, qué dice y si el disparo es `becaPorcentaje == 100` o deuda total cero. Requiere además un endpoint nuevo en `sender-service`: `ChequeraClient` no expone ninguno que sirva para un mail sin chequera.
+1. **Contenido del aviso complementario de beca completa (100 %)** — es la **fase F7** del roadmap, bloqueada por definición, **no está fuera de alcance**. La chequera bonificada se envía siempre con `send-chequera`; falta decidir qué mensaje adicional la acompaña, qué dice y si el disparo es `becaPorcentaje == 1.00` o deuda total cero. Requiere además un endpoint nuevo en `sender-service`: `ChequeraClient` no expone ninguno que sirva para un mail sin chequera.
 2. **Chequeras ya emitidas** sin beneficio — si se recalculan, se reemplazan, o se ajustan a mano. Declarado como no bloqueante el 2026-08-19.
 3. **Código de barras con importe cero** — confirmar con el banco si un código Gire con importe cero es operativamente válido, más allá de ser sintácticamente correcto.
 4. **`requisitoRel` poblado** — verificar contra un alta real en staging antes de empezar F3 (ver arriba).

--- a/specs/features/beneficio-requisitos-ingreso/decisiones.md
+++ b/specs/features/beneficio-requisitos-ingreso/decisiones.md
@@ -1,0 +1,227 @@
+# Decisiones — Beneficio por requisitos de ingreso de Guaraní
+
+> Registro de las decisiones de negocio que gobiernan el cálculo del beneficio.
+> Cada una con su fecha, quién la tomó y un ejemplo numérico.
+>
+> Alcance: chequera del alumno **preuniversitario** en `UM.tesoreria.core-service`.
+> Fecha de cierre: **2026-08-19** · Versión del servicio: **4.1.1**
+
+---
+
+## Fórmula acordada
+
+```
+beneficioAplicado = MAX(porcentajeBeneficio de los requisitos del alumno
+                          con requisitoIngreso = 'S' y activo = 'S')
+
+importeN         = importeNLista × (1 - beneficioAplicado/100)
+                       .setScale(0, RoundingMode.HALF_UP)
+
+importeNOriginal = importeNLista          // sin ningún descuento
+```
+
+Los tres tramos (`importe1`, `importe2`, `importe3`) reciben **el mismo factor**.
+
+Sin requisitos elegibles → `beneficioAplicado = 0` → importes idénticos al comportamiento actual.
+
+---
+
+## D1 — Acumulación entre requisitos: gana el más alto
+
+**Decidido el 2026-08-19 por el equipo.**
+
+Si un alumno presenta varios requisitos de ingreso con beneficio asociado, **se aplica el más alto**. No se suman, no se aplican en cascada.
+
+**Ejemplo:** alumno con tres requisitos elegibles de 10 %, 30 % y 20 % → `beneficioAplicado = 30 %`. Sobre una cuota de lista de $47.350, paga $33.145.
+
+**Consecuencias técnicas:**
+
+- No hace falta deduplicar la lista de requisitos presentados. `MAX` es idempotente: el mismo requisito repetido no cambia el resultado. `RequisitoPresentadoGuarani` tiene PK propia y no tiene unicidad por `(persona, requisito)`, así que los duplicados son posibles y ahora son inofensivos. Igual se fija con un test, porque es una propiedad de la que dependemos.
+- El resultado nunca supera el mayor de sus entradas, lo que hace innecesario cualquier tope adicional (ver D3).
+
+**Descartado:** acumulación aditiva (10+30+20 = 60 %), porque exige un tope artificial y produce el caso "descuento mayor al precio". Cascada multiplicativa (0,90 × 0,70 × 0,80 = 49,6 % de descuento), porque es más difícil de explicar en un mostrador y acá no aporta nada que `MAX` no resuelva.
+
+---
+
+## D2 — Vigencia: no hay
+
+**Decidido el 2026-08-19 por el equipo.**
+
+El beneficio **no tiene vencimiento**. La chequera del preuniversitario es un trámite puntual, no algo que se reevalúe en el tiempo.
+
+**Consecuencias técnicas:**
+
+- `RequisitoPresentadoGuarani.fechaPresentacion`, `.fechaVencimiento` y `.fechaAlta` **no se leen**.
+- `BeneficioPolicy` no recibe parámetro de fecha. Es puramente funcional sobre `(requisitos, beneficios)`, sin dependencia del reloj — trivial de testear y sin tests que fallen según el día en que corran.
+- El beneficio queda congelado de hecho: se calcula una vez, al crear la chequera.
+
+---
+
+## D3 — Tope: ninguno adicional; rango `[0, 100]` inclusive
+
+**Decidido el 2026-08-19 por el equipo. Corrige una versión previa que fijaba `[0, 99]`.**
+
+Cada `porcentajeBeneficio` individual se valida en `[0, 100]` **inclusive** al cargarse en `guarani_beneficio`. No hay ningún tope adicional en el cálculo.
+
+**Por qué cambió:** la cota de 99 venía de la propuesta de cascada multiplicativa, donde el 100 % era inalcanzable por construcción. Con `MAX` ese razonamiento no aplica, y **permitir 100 es necesario**: es el caso que dispara el mail de beca completa.
+
+**Ejemplo:** `porcentajeBeneficio = 100` → cuota en cero → el alumno no debe nada.
+
+**Consecuencias verificadas del caso 100 %:**
+
+| Componente | Comportamiento con importes en cero |
+|---|---|
+| `FindAllInconsistenciasUseCaseImpl` | No dispara. `importesInvalidos` evalúa `0 > 0` → falso. `multiplicadoresInvalidos` evalúa `importeNOriginal × 49 < 0` → falso, porque el original guarda el precio de lista |
+| `calculateCodigoBarras` | Sintácticamente correcto. `DecimalFormat("0000000").format(0)` → `"0000000"`; diferencias `0 - 0 = 0` → `"00000"`. Sin signo negativo, largo correcto |
+| `importeNOriginal` | Conserva el precio de lista, así que se puede mostrar cuánto se bonificó |
+
+**Pendiente de confirmación externa:** si un código de barras Gire con importe cero es **operativamente** válido para el banco, más allá de ser sintácticamente correcto.
+
+---
+
+## D4 — Tramos: los tres, con el mismo factor
+
+**Decidido el 2026-08-19 por el equipo.**
+
+`importe1`, `importe2` e `importe3` reciben el mismo porcentaje de beneficio.
+
+**Aclaración de vocabulario:** no son tres cuotas. Son los tres tramos de vencimiento de **la misma** cuota, con precio creciente según cuándo se pague (temprano / a término / tardío).
+
+**Por qué el mismo factor:** multiplicar los tres por el mismo `k` preserva automáticamente el orden creciente (`a ≤ b ≤ c` → `ka ≤ kb ≤ kc`), así que `FindAllInconsistenciasUseCaseImpl` no se dispara. Y las diferencias que codifica el código de barras (`importe2 - importe1`, `importe3 - importe2`) también se escalan por `k`: como `k ≤ 1`, **se achican**, nunca desbordan los 5 dígitos ni se vuelven negativas.
+
+**Descartado:** bonificar solo `importe1` agranda la diferencia `importe2 - importe1`, que puede desbordar el campo de 5 dígitos del barcode. Bonificar solo `importe3` rompe el orden creciente, dispara `importesInvalidos`, y produce una diferencia negativa que `calculateCodigoBarras` acepta sin frenar (solo escribe `log.debug`), generando un código corrupto que llega impreso al alumno. Ver H7 en `../../tech-stack.md`.
+
+---
+
+## D5 — `importeNOriginal`: precio de lista, sin ningún descuento
+
+**Decidido el 2026-08-19 por el equipo.**
+
+`importe1Original`, `importe2Original` e `importe3Original` guardan el precio de lista, sin beneficio ni ningún otro descuento.
+
+**Por qué:** es la semántica que el código ya asume en dos lugares independientes. `RecalculateCuotaByUniqueIndexUseCaseImpl` modifica `importe3` y deja `importe3Original` intacto, tratándolo como referencia inmutable. Y `FindAllInconsistenciasUseCaseImpl` chequea `importeNOriginal × 49 < importeN`, que solo tiene sentido si el original es la base contra la que se mide el valor efectivo.
+
+**Beneficio para el mail:** con precio de lista y precio final en la misma fila, el ahorro sale de una resta, sin recalcular nada.
+
+**Nota:** hoy, en creación, `importeN` e `importeNOriginal` nacen idénticos. Esta feature es el primer momento en que divergen de verdad.
+
+---
+
+## D6 — Redondeo: pesos enteros, HALF_UP
+
+**Decidido el 2026-08-19 por el equipo.**
+
+`setScale(0, RoundingMode.HALF_UP)` sobre el importe bonificado.
+
+**Por qué no dos decimales:** el código de barras Gire no tiene decimales. `importe1` se codifica con `DecimalFormat("0000000")` (7 dígitos enteros) y las diferencias con `setScale(0, HALF_UP)`. Guardar centavos genera divergencia entre lo que registra la base y lo que cobra el banco — la moneda efectiva del sistema es el peso entero.
+
+**Por qué HALF_UP y no HALF_EVEN:** alinea con el `setScale(0, HALF_UP)` que ya usan las diferencias en `calculateCodigoBarras`. Existe una inconsistencia latente ahí (`importe1` usa el default HALF_EVEN de `DecimalFormat`); adoptar HALF_UP no la resuelve pero tampoco la propaga. Unificar `calculateCodigoBarras` es trabajo aparte (H8).
+
+**Ejemplo:** cuota de lista $47.350 con 33 % → $47.350 × 0,67 = $31.724,50 → **$31.725**.
+
+---
+
+## D7 — El beneficio se persiste en `ChequeraSerie.becaPorcentaje`
+
+**Decidido el 2026-08-19 por el equipo.**
+
+El porcentaje calculado se guarda en `ChequeraSerie.becaPorcentaje`, usando el hook que ya estaba reservado en `PreuniversitarioChequeraService.java:49-50`:
+
+```java
+// Determina beneficio
+var becaPorcentaje = BigDecimal.ZERO;   // ← acá va la llamada a BeneficioPolicy
+```
+
+**Qué resuelve sin código adicional:**
+
+- **Congelamiento.** Queda grabado al emitir; no se reevalúa. `ChequeraSerie` es el lugar natural: un beneficio por chequera, no por cuota.
+- **Trazabilidad.** `becaResolucion`, `becaFecha` y `becaUserId` ya existen en el modelo para registrar el origen del beneficio.
+- **Impresión.** `ChequeraService.track():190` ya copia `becaPorcentaje` a `ChequeraImpresionCabecera`, así que el dato llega solo a la chequera impresa.
+- **Alcance.** La factory lo lee de `chequeraSerie.getBecaPorcentaje()`. `SpoterService` construye series sin beca, así que queda excluido del beneficio sin necesidad de una rama especial.
+
+---
+
+## D8 — `ChequeraTotal.total` = suma de las cuotas, no factor sobre el total
+
+**Decidido el 2026-08-19 por el equipo:** el total impreso debe coincidir con la suma de las cuotas.
+
+**Aplicar el factor al total no logra eso.** Cada cuota se redondea a entero por separado, así que la suma de cuotas redondeadas no es igual al total redondeado:
+
+```
+Total lista $47.350, tres cuotas de $15.783,33, beneficio 30 %
+
+Factor al total:  47.350 × 0,70                   = $33.145
+Suma de cuotas:   (15.783,33 × 0,70 → 11.048) × 3 = $33.144   ← difieren en $1
+```
+
+**El total se calcula como la suma de `importe1` de las cuotas ya redondeadas.** Coincide por construcción, sin deriva posible.
+
+**No es una invención:** el sistema ya sostiene ese invariante en otro punto del ciclo. `PagoService.calcularPagado():214` reasigna `chequeraTotal.total` con `calculateTotalCuotasActivas(...)`, que suma `importe1` de las cuotas con `baja = 0`. Lo que falta es aplicarlo también **al crear**, no solo al registrar el primer pago.
+
+**Corrige un defecto latente previo a esta feature:** hoy, si `LectivoTotal.total` difiere de `Σ importe1`, el total de la chequera cambia solo cuando entra el primer pago, en silencio. Con beneficio aplicado a las cuotas y no al total, esa diferencia dejaría de ser sutil.
+
+**Requiere invertir el orden** en `PreuniversitarioChequeraDetailsCreator.create()`: hoy `createTotals()` corre antes que `createCuotas()`; pasa a correr después, recibiendo las cuotas guardadas y agrupándolas por `productoId`.
+
+---
+
+## Fuera de alcance
+
+| Tema | Estado |
+|---|---|
+| `RecalculateCuotaByUniqueIndexUseCaseImpl` | No se cablea el beneficio. Segundo camino de determinación de importes, queda inconsistente con el de creación |
+| `ArancelPorcentaje` | Segunda isla de descuentos sin consumidores. No se combina ni se resuelve acá |
+| Recálculo de chequeras ya emitidas | No bloqueante; se decide aparte |
+| VB6 | Sistema externo. Ver H6 |
+| Corrupción del barcode con diferencias negativas | Ver H7. La feature lo evita por construcción, no lo corrige |
+
+---
+
+## Verificación — la cadena de `requisitoRel` (2026-08-19)
+
+Se verificó eslabón por eslabón si `RequisitoPresentadoGuarani.requisitoRel` puede llegar poblado al cálculo. **La plomería está intacta: el core no lo pierde en ningún punto.**
+
+```
+POST /guarani/alumno/create/personales
+  AlumnoGuaraniRequest.personaRel : PersonaGuarani        ← el DTO usa el modelo de dominio directo
+        │
+        │  AlumnoGuaraniDtoMapper.toDomain():40
+        │    .personaRel(request.getPersonaRel())          ← pass-through por referencia
+        ▼
+  AlumnoGuarani.personaRel
+        │
+        │  AlumnoGuaraniDtoMapper.toPersonalesResponse():55
+        │    .alumnoGuarani(alumnoGuarani)                 ← el mismo objeto, sin reconstruir
+        ▼
+  PersonalesResponse.alumnoGuarani.personaRel.requisitosPresentados[].requisitoRel
+        │
+        ▼
+POST /guarani/alumno/create/preuniversitario
+  CreatePreuniversitarioUseCaseImpl(PersonalesResponse)    ← llega completo
+```
+
+Ningún mapper reconstruye `PersonaGuarani` desde la base ni copia campo por campo: se pasa la referencia. Los cuatro niveles de anidamiento (`personaRel` → `requisitosPresentados` → `requisitoRel` → `requisitoIngreso`/`activo`) existen en las clases destino, así que Jackson los deserializa si vienen en el JSON.
+
+**Lo que NO se pudo verificar desde el repositorio:** si Guaraní efectivamente envía `requisitoRel` anidado dentro de cada `requisitosPresentados`. No hay fixtures JSON, ni payloads de ejemplo, ni un cliente Feign hacia Guaraní — el core es **receptor**, no llamador. El dato depende enteramente de lo que arme el emisor.
+
+**Riesgo adicional identificado:** el flujo son **dos** llamadas. El cliente recibe `PersonalesResponse` de la primera y debe reenviarlo a la segunda. Si ese cliente reconstruye el objeto en vez de reenviar lo que recibió, `personaRel` se pierde ahí — fuera de este repositorio y fuera del alcance de cualquier test de core.
+
+**Cómo cerrarlo antes de F3** (10 minutos, no requiere código nuevo): `PersonaGuarani implements Jsonifyable`. Agregar un `log.debug("personaRel -> {}", personaRel.jsonify())` temporal en `CreatePreuniversitarioUseCaseImpl` y disparar un alta real en staging. El log muestra si `requisitosPresentados` llega y si cada elemento trae `requisitoRel`.
+
+**Si viniera nulo:** el filtro de elegibilidad anularía todos los beneficios en silencio, sin errores. El plan B es filtrar contra el catálogo local en vez de contra `requisitoRel`, lo que exige que el core tenga acceso a los requisitos de Guaraní — trabajo que hoy no existe y que cambiaría el tamaño de F3.
+
+---
+
+## Abierto — pendiente de definición
+
+1. **Contenido del aviso complementario de beca completa (100 %)** — es la **fase F7** del roadmap, bloqueada por definición, **no está fuera de alcance**. La chequera bonificada se envía siempre con `send-chequera`; falta decidir qué mensaje adicional la acompaña, qué dice y si el disparo es `becaPorcentaje == 100` o deuda total cero. Requiere además un endpoint nuevo en `sender-service`: `ChequeraClient` no expone ninguno que sirva para un mail sin chequera.
+2. **Chequeras ya emitidas** sin beneficio — si se recalculan, se reemplazan, o se ajustan a mano. Declarado como no bloqueante el 2026-08-19.
+3. **Código de barras con importe cero** — confirmar con el banco si un código Gire con importe cero es operativamente válido, más allá de ser sintácticamente correcto.
+4. **`requisitoRel` poblado** — verificar contra un alta real en staging antes de empezar F3 (ver arriba).
+
+---
+
+## Documentos relacionados
+
+- `spec.md` — contexto, criterios de aceptación y fases de implementación
+- `../../tech-stack.md` — huecos declarados H1–H8
+- `../../mission.md` — propósito y principios

--- a/specs/features/beneficio-requisitos-ingreso/plan-implementacion.md
+++ b/specs/features/beneficio-requisitos-ingreso/plan-implementacion.md
@@ -119,7 +119,7 @@ orden de creación; toda F1 debe seguir verde sin modificaciones.
 5. Hacer que la factory lea `chequeraSerie.becaPorcentaje` y aplique a cada tramo:
 
 ```text
-importe = importeLista * (1 - beca / 100), scale 0, HALF_UP
+importe = importeLista * (1 - beca), scale 0, HALF_UP
 original = importeLista
 ```
 
@@ -127,7 +127,7 @@ original = importeLista
    activas en memoria por `productoId` y sumar `importe1`; no bonificar
    `LectivoTotal.total` por separado.
 7. Mantener en `CreatePreuniversitarioUseCaseImpl` la publicación normal de
-   `send-chequera` también cuando `becaPorcentaje` es 100%. Probar que el evento no se
+   `send-chequera` también cuando `becaPorcentaje` es `1.00` (100 %). Probar que el evento no se
    suprime. La proyección del PDF, sus filas en cero y el contrato de datos son alcance de
    la Issue 2.
 
@@ -172,7 +172,7 @@ por el alta preuniversitaria.
 
 - **Issue 1:** extender `GuaraniBeneficioControllerTest`, probar alta preuniversitaria,
   endpoints de cuotas e inconsistencias, y configurar JaCoCo.
-- **Issue 2:** pruebas de contrato Core → sender, fixtures 0/30/100 y validación del PDF.
+- **Issue 2:** pruebas de contrato Core → sender, fixtures 0 %/30 %/100 % y validación del PDF.
 - Configurar JaCoCo `check` con 80% de líneas, limitado a los paquetes de beneficio,
   cuota y serie afectados; `mvn -B verify` debe fallar si bajan del umbral.
 - Añadir y registrar `docs/hexagonal-beneficioCuota.mmd` si el diagrama de la feature se
@@ -374,13 +374,13 @@ es cero. `SpoterService` pasa una serie con beneficio cero/null normalizado a `B
 
 ```text
 POLÍTICA                         ORQUESTACIÓN                         INTEGRACIONES
-MAX elegible [unit]              requisitos completos [int]          send-chequera 0/30/100 [int]
+MAX elegible [unit]              requisitos completos [int]          send-chequera 0 %/30 %/100 % [int]
 sin elegible [unit]              persona/lista/requisito nulos [unit] MP importe cero -> sin contexto [unit]
 porcentaje nulo [unit]           consulta falla -> 0% + warn [int]    JSON conserva originales [contract]
-0/100/HALF_UP [unit]             serie existente -> sin reenvío [int]  PDF bonificado en staging [manual]
+0 %/100 %/HALF_UP [unit]         serie existente -> sin reenvío [int]  PDF bonificado en staging [manual]
 
 FACTORY Y TOTALES                DETECTOR
-fecha vigente/vencida [unit]     0/beneficio/100 [unit]
+fecha vigente/vencida [unit]     0 %/beneficio/100 % [unit]
 0% idéntico a F1 [regresión]     original nulo -> inconsistencia [unit]
 multi-producto/baja/redondeo [unit] límite multiplicador [unit]
 ```

--- a/specs/features/beneficio-requisitos-ingreso/plan-implementacion.md
+++ b/specs/features/beneficio-requisitos-ingreso/plan-implementacion.md
@@ -1,0 +1,481 @@
+# Plan de implementación — Beneficio por requisitos de ingreso
+
+> Fuente funcional: `spec.md`. Decisiones de negocio: `decisiones.md` (D1–D8).
+> Estado: dividido en dos issues secuenciales: cálculo primero, correo/PDF después.
+
+## División solicitada de issues
+
+| Issue | Fases | Dependencia | Estado |
+|---|---|---|---|
+| 1. Cálculo y persistencia del beneficio | F0–F4 + parte Core de F6 | Validación de payload en staging antes de F3 | [#338](https://github.com/UM-services/UM.tesoreria.core-service/issues/338) |
+| 2. Correo/PDF con información de beneficios | F5 + parte de integración de F6 | Issue 1 desplegado | Pendiente de crear en GitHub |
+
+La Issue 1 mantiene la publicación existente de `send-chequera` como regresión, pero no
+modifica sender-service. La Issue 2 consume las cuotas ya bonificadas y resuelve cómo se
+documentan, incluido el caso 100%; no recalcula beneficios.
+
+## Objetivo y límite
+
+Aplicar a chequeras preuniversitarias el mayor beneficio configurado para los requisitos
+de ingreso activos del alumno. El valor queda congelado al emitir la serie; no se vuelve a
+consultar ni recalcular para chequeras existentes.
+
+No entra en este trabajo:
+
+- Migrar `SpoterService` a arquitectura hexagonal; solo reutiliza la factory.
+- Aplicar `ArancelPorcentaje` ni modificar `RecalculateCuotaByUniqueIndexUseCaseImpl`.
+- Corregir los contratos heredados `generatePdf`/`sendCuota` entre core y sender, fuera del
+  flujo preuniversitario. La Issue 2 sí coordina la proyección documental de una chequera
+  100 %, para que conserve sus filas con importe cero.
+
+## Diseño acordado
+
+```text
+POST /guarani/alumno/create/preuniversitario
+  PersonalesResponse.alumnoGuarani.personaRel.requisitosPresentados
+          |
+          v
+PreuniversitarioChequeraData (propaga requisitos)
+          |
+          v
+GuaraniBeneficioService.findByRequisitos(ids)   [una consulta IN]
+          |
+          v
+BeneficioPolicy.porcentajeEfectivo()            [puro, MAX elegible]
+          |
+          v
+ChequeraSerie.becaPorcentaje                    [congelado]
+          |
+          +--> ChequeraCuotaFactory              [3 tramos, HALF_UP]
+                    |
+                    +--> importeNOriginal = precio de lista
+                    +--> importeN = precio bonificado
+          |
+          +--> ChequeraTotal = SUM(importe1 de cuotas activas)
+```
+
+Reglas no negociables:
+
+- Solo son elegibles `requisitoIngreso='S'` y `activo='S'`, con comparación
+  null-safe y case-insensitive.
+- Gana el porcentaje mayor; 0% y 100% son válidos.
+- Si faltan requisitos, `personaRel`, un porcentaje heredado, o falla la consulta de
+  beneficios, se emite sin bonificación y se registra `warn`; nunca se aborta la emisión.
+- `SpoterService` crea series con beneficio cero y conserva el comportamiento actual.
+- Si el beneficio es 100%, la serie y sus cuotas se emiten en cero y se publica
+  `send-chequera` normalmente, para que el alumno reciba su chequera con los importes
+  bonificados, el porcentaje aplicado y total a pagar cero. No se genera un correo alternativo.
+
+## Fases y PRs
+
+### F0 — Validar configuración de beneficios
+
+Cambiar `GuaraniBeneficioRequest` a `@Getter`/`@Setter` y agregar:
+
+- `@NotNull requisito`.
+- `@NotNull`, `@DecimalMin("0")` y `@DecimalMax("100")` para el porcentaje.
+- `@Valid` en POST y PUT del controller.
+- Detección previa de requisito existente y traducción de la violación única concurrente
+  a una excepción de dominio mapeada a `409 Conflict`.
+
+Pruebas: 0, 50 y 100 válidos; negativos, nulo y mayor a 100 inválidos; POST y PUT;
+duplicado secuencial y traducción de conflicto de persistencia.
+
+### F1 — Caracterizar el comportamiento actual
+
+Antes de producción nueva, cubrir `PreuniversitarioChequeraDetailsCreator` y el bloque
+equivalente de `SpoterService`:
+
+- vencimientos originales y vencidos, offsets y mezcla de ambos;
+- importes y originales idénticos sin beneficio;
+- arancel, código de barras y flags iniciales;
+- cuotas/totales vacíos, varios productos y alternativas.
+
+Estos tests no se cambian en F2: son el contrato de no regresión.
+
+### F2 — Extraer `ChequeraCuotaFactory`
+
+Crear `chequeraCuota/application/factory/ChequeraCuotaFactory` con fecha de referencia
+inyectada por parámetro. Extrae construcción de cuota, vencimientos y código de barras de:
+
+- `PreuniversitarioChequeraDetailsCreator`.
+- `SpoterService`.
+
+La factory es el único punto que aplicará el factor en F3. F2 no cambia importes ni
+orden de creación; toda F1 debe seguir verde sin modificaciones.
+
+### F3 — Resolver y aplicar el beneficio
+
+1. Agregar `requisitosPresentados` a `PreuniversitarioChequeraData` y propagarlo desde
+   `CreatePreuniversitarioUseCaseImpl` por la ruta real
+   `alumnoGuaraniFull.getAlumnoGuarani().getPersonaRel().getRequisitosPresentados()`.
+   La ruta debe ser null-safe y contar con un test de pass-through.
+2. Antes de habilitar la fase en producción, registrar temporalmente el payload en staging
+   y verificar que cada requisito trae `requisitoRel`; si no llega, detener F3 y revisar el alcance.
+3. Crear `BeneficioPolicy` puro. Recibe requisitos y beneficios, filtra elegibles y toma
+   `MAX`; las entradas nulas devuelven cero.
+4. Resolver los beneficios en lote en `PreuniversitarioChequeraService`, persistir el
+   resultado en `ChequeraSerie.becaPorcentaje` y mantener el fallback seguro en cero.
+5. Hacer que la factory lea `chequeraSerie.becaPorcentaje` y aplique a cada tramo:
+
+```text
+importe = importeLista * (1 - beca / 100), scale 0, HALF_UP
+original = importeLista
+```
+
+6. Invertir la creación: alternativas → cuotas guardadas → totales. Agrupar las cuotas
+   activas en memoria por `productoId` y sumar `importe1`; no bonificar
+   `LectivoTotal.total` por separado.
+7. Mantener en `CreatePreuniversitarioUseCaseImpl` la publicación normal de
+   `send-chequera` también cuando `becaPorcentaje` es 100%. Probar que el evento no se
+   suprime. La proyección del PDF, sus filas en cero y el contrato de datos son alcance de
+   la Issue 2.
+
+### F4 — Proteger el detector de inconsistencias
+
+Agregar pruebas a `FindAllInconsistenciasUseCaseImpl` para 0%, todos los tramos
+bonificados, un solo tramo, 100%, originales nulos y límite del multiplicador. Una cuota
+generada correctamente con beneficio no debe ser inconsistente; un original nulo histórico
+debe devolverse como inconsistencia y nunca abortar el endpoint.
+
+Ejecutar el endpoint en staging sobre chequeras nuevas y comprobar que no aparezcan falsos
+positivos atribuibles al beneficio.
+
+### F5 — Issue 2: correo/PDF con beneficios (posterior a F0–F4)
+
+MercadoPago obtiene de Core las cuotas pendientes —que reenvía a Sender en
+`UMPreferenceMPDto.chequeraCuota`— y crea el contexto de pago mediante
+`mercadopago/makeContext`. Sender genera el PDF localmente a partir de esos datos.
+
+- Añadir pruebas JSON para `/chequeraCuota/chequera/pendientes/...` que fijen los
+  importes bonificados y originales: esta es la cuota que llega a Sender y alimenta el PDF.
+- Probar `/mercadopago/makeContext/{chequeraCuotaId}` por separado: el contexto debe usar
+  el importe bonificado que se cobra, sin asumir que sea el objeto de cuota reenviado por
+  MercadoPago a Sender en el flujo normal.
+- Separar proyección documental de cobro: el handler de `send-chequera` debe consumir una
+  proyección que incluya cuotas con `importe1 = 0`; el endpoint de pendientes y MercadoPago
+  conserva su filtro positivo. Coordinar en sender-service el DTO/consulta exactos y una
+  prueba de contrato entre repos. `UMPreferenceMPDto.chequeraCuota` preserva los originales
+  para cobro, sin agregar datos al evento Kafka.
+- En staging, validar el recorrido alta → `send-chequera` → sender → MercadoPago → core →
+  PDF generado.
+- Para beneficio 100 %, verificar por separado que `send-chequera` se publica y el PDF
+  informativo incluye sus filas con importes cero, mientras `MercadoPagoCoreService.makeContext*`
+  no crea contextos de cobro para cuotas de importe cero. Definir con sender/Gire si esas filas
+  muestran barcode cero o ningún barcode antes de producción.
+
+Sender y su plantilla PDF no se modifican en este repositorio. El drift heredado de
+`generatePdf` y `sendCuota` es un trabajo de integración separado: no es el camino usado
+por el alta preuniversitaria.
+
+### F6 — Calidad dividida entre ambos issues
+
+- **Issue 1:** extender `GuaraniBeneficioControllerTest`, probar alta preuniversitaria,
+  endpoints de cuotas e inconsistencias, y configurar JaCoCo.
+- **Issue 2:** pruebas de contrato Core → sender, fixtures 0/30/100 y validación del PDF.
+- Configurar JaCoCo `check` con 80% de líneas, limitado a los paquetes de beneficio,
+  cuota y serie afectados; `mvn -B verify` debe fallar si bajan del umbral.
+- Añadir y registrar `docs/hexagonal-beneficioCuota.mmd` si el diagrama de la feature se
+  incorpora al catálogo de documentación.
+
+## Plan de pruebas
+
+```text
+POLÍTICA                         EMISIÓN Y DATOS                         API
+12 unitarias BeneficioPolicy     11 unitarias factory                    12 controller
+  - MAX / elegibilidad             - fechas, offset, rounding              - validación y 409
+  - nulos / 100%                   - originales / barcode                  - cuotas JSON
+                                  7 unitarias totals                      4 integración alta
+DETECCIÓN                           - por producto / baja / 100%           2 integración Spoter
+6 unitarias inconsistencias
+```
+
+Rutas críticas:
+
+- Requisito elegible → MAX → serie → cuotas → total → Kafka → sender → MercadoPago → PDF.
+- Sin requisito o con datos incompletos → cero, `warn`, emisión exitosa.
+- Beneficio 100% → importes/totales cero, sin inconsistencia y con evento `send-chequera`.
+- Primer pago → el total persiste igual porque ya era la suma de cuotas.
+
+## Fallos y tratamiento
+
+| Falla | Tratamiento | Cobertura |
+|---|---|---|
+| `personaRel` o lista de requisitos nula | beneficio 0 + `warn` | unit/integración |
+| `requisitoRel` nulo | excluir solo ese requisito + `warn` | unit |
+| error al consultar beneficios | beneficio 0 + `warn`, sin abortar | integración |
+| porcentaje legado nulo | tratar como cero | unit |
+| duplicado concurrente | 409, no 500 | controller/integración |
+| redondeo por cuota | sumar cuotas ya redondeadas | unit totals |
+| sender filtra cuotas 100% | proyección documental que incluye importes cero; pendientes/MercadoPago siguen filtrando cobros | contrato entre repos |
+| beneficio 100% no llega al alumno | publicar `send-chequera` normal con cuotas en cero, porcentaje aplicado y total a pagar cero | integración |
+
+## Dependencias y paralelización
+
+| Lane | Trabajo | Depende de |
+|---|---|---|
+| A | F0 — validación y conflicto | — |
+| B | F1 — caracterización | — |
+| A+B | F2 — factory | F1 |
+| C | F3 — beneficio, cuotas y total | F0, F2, validación staging del payload |
+| D | F4 — inconsistencias | F3 |
+| E | Issue 2 / F5 — contrato de correo/PDF | Issue 1 desplegado |
+| F | Calidad de Issue 1 | F0–F4 |
+
+Lanzar F0 y F1 en paralelo. F2–F4 y la calidad de Issue 1 son secuenciales por los mismos
+módulos. F5 comienza sólo después del despliegue de Issue 1.
+
+## Gates de rollout
+
+1. Staging confirma que `personaRel.requisitosPresentados` llega poblado al core.
+2. `mvn -B verify` y los tests de integración pasan.
+3. Altas con beneficio parcial y con 100% publican `send-chequera`; el PDF de 100% conserva
+   sus filas en cero y los canales de pago omiten contextos de cobro inexistentes.
+4. La corrida de inconsistencias no agrega falsos positivos ni falla ante originales nulos.
+5. La conciliación de staging deja registrados fallbacks a cero, beneficios 100 % y cualquier
+   diferencia entre `LectivoTotal` y `SUM(importe1)` por producto.
+
+## Autoplan — Fase 1: revisión CEO
+
+### Premisas y dirección
+
+La meta es correcta: aplicar un beneficio verificable al emitir una chequera nueva, sin
+reescribir las ya emitidas. Se confirmó con negocio que incluso una beca del 100 % publica
+`send-chequera`: el documento informa al alumno que sus cuotas fueron bonificadas.
+
+### Qué ya existe y se reutiliza
+
+| Subproblema | Base existente | Decisión |
+|---|---|---|
+| Resolver beneficios por varios requisitos | `GuaraniBeneficioService.findByRequisitos` y repositorio `findByRequisitoIn` | Reutilizar una consulta IN |
+| Persistir el porcentaje congelado | `ChequeraSerie.becaPorcentaje` y cabecera de impresión | Reutilizar; no crear una segunda fuente de verdad |
+| Publicar la chequera | `MailChequeraService.sendChequera` publica `SendChequeraEvent` | Conservar para todos los porcentajes |
+| Pago online | `MercadoPagoCoreService` rechaza importes cero | Tratar 100 % como chequera informativa sin contexto de pago |
+| Cálculo de total posterior | `PagoService` ya suma cuotas activas | Llevar el mismo invariante a la creación |
+
+### Alternativas evaluadas
+
+| Enfoque | Cobertura | Riesgo | Decisión |
+|---|---:|---|---|
+| Aplicar el descuento sólo al total | 3/10 | El total puede diferir de la suma de cuotas redondeadas | Rechazado |
+| Aplicar el descuento a cada cuota y conservar los originales | 10/10 | Requiere extraer el código duplicado | Elegido |
+| Crear una segunda emisión específica para 100 % | 6/10 | Duplicaría envío y dejaría al alumno sin el PDF estándar | Rechazado |
+
+### Estado objetivo
+
+```text
+HOY: beneficio configurado + series siempre en 0 % + totales potencialmente divergentes
+  -> ESTE PLAN: beneficio inmutable por serie + cuotas/total coherentes + envío normal
+  -> IDEAL: decisión auditable, conciliación de emisiones y documento que explica la bonificación
+```
+
+### Revisión por secciones
+
+1. **Arquitectura.** La factory compartida elimina la duplicación entre preuniversitario y
+   Spoter sin extender el beneficio a Spoter. El porcentaje viaja por la serie, una frontera
+   explícita y reversible para chequeras nuevas.
+2. **Errores y rescate.** Mantener emisión a 0 % para datos de negocio ausentes confirmados,
+   pero registrar `personaId`, `documentoId`, requisitos recibidos y causa. Una falla de la
+   consulta debe aparecer en la conciliación de rollout, no quedar como un `warn` aislado.
+3. **Seguridad e integridad.** La validación `[0,100]`, unicidad y 409 cubren entradas inválidas;
+   se conserva la fuente de configuración actual, sin inventar permisos nuevos en esta feature.
+4. **Datos.** `importeNOriginal` es obligatorio al crear. Si el detector encuentra un original
+   nulo histórico, debe marcar la cuota como inconsistente en vez de lanzar `NullPointerException`.
+5. **Calidad.** La factory debe recibir la fecha de referencia y encapsular el constructor
+   posicional de cuota. No se introducirá una abstracción de descuento genérica para los dos
+   mecanismos que siguen fuera de alcance.
+6. **Pruebas.** F1 protege ambos flujos actuales; F3 agrega política, factor, total y evento;
+   F4 cubre los caminos de datos nulos; F5 cubre el contrato y el caso de pago cero.
+7. **Rendimiento.** Una consulta `IN` reemplaza cualquier potencial consulta por requisito.
+   Las sumas se hacen en memoria sobre las cuotas recién creadas, con tamaño acotado por una serie.
+8. **Observabilidad.** En staging, conciliar diariamente series creadas con beneficio, fallbacks
+   a cero, porcentajes 100 y diferencias entre `LectivoTotal` y la suma de cuotas.
+9. **Rollout.** Primero validar el payload real; después desplegar con F1/F3 verdes y una alta
+   parcial y otra al 100 %. Rollback afecta sólo emisiones futuras; las emitidas se corrigen por
+   baja y reemisión, como hoy.
+10. **Trayectoria.** La decisión queda congelada y trazable por porcentaje. La chequera
+    bonificada es la única comunicación necesaria para confirmar el beneficio.
+
+### Registro de errores y rescate
+
+| Código | Falla | Rescate | Efecto visible | Cobertura |
+|---|---|---|---|---|
+| R1 | requisitos/persona nulos | 0 % + `warn` estructurado | Chequera normal sin bonificación | unit + integración |
+| R2 | consulta de beneficio falla | 0 % + `warn` + conciliación | Chequera normal, caso visible a Tesorería | integración |
+| R3 | original histórico nulo | marcar inconsistencia, no excepción | caso recuperable en detector | unit |
+| R4 | 100 % | publicar chequera, omitir contexto MercadoPago de importe 0 | PDF informativo sin cobro | integración |
+| R5 | duplicado concurrente | excepción de dominio a 409 | error de carga legible | controller + integración |
+
+### Modificaciones CEO incorporadas
+
+- F4 debe hacer null-safe el detector: original nulo se informa como inconsistencia.
+- F5 debe probar explícitamente que 100 % publica `send-chequera`, genera el PDF informativo
+  y no crea un contexto MercadoPago para una cuota de importe cero.
+- El gate de rollout incluye conciliación de fallback a cero y de totales por producto.
+
+### Fuera de alcance, con motivo
+
+- Explicar visualmente ahorro y precio original en la plantilla del PDF: requiere cambio coordinado
+  en sender-service; el contrato Core conserva ambos valores para habilitarlo.
+- Auditoría detallada de cada requisito ganador: `becaPorcentaje` congela el resultado de esta fase;
+  un registro histórico de reglas es una mejora de plataforma separada.
+- Normalizar totales de series ya emitidas: esta emisión sólo crea datos nuevos.
+
+### Modificar F4, F5 y rollout
+
+En F4, tratar `importeNOriginal == null` como una inconsistencia reportable y probar que el
+endpoint no falla. En F5, sumar el caso 100 %: `send-chequera` se publica y
+`MercadoPagoCoreService.makeContext*` devuelve `null`/no agrega contexto para una cuota en cero.
+En el rollout, registrar la cantidad de fallbacks a cero, becas 100 % y diferencias detectadas
+entre el total de configuración y `SUM(importe1)` por producto.
+
+## Autoplan — Fase 3: revisión de ingeniería
+
+### Arquitectura y ejecución
+
+```text
+CreatePreuniversitarioUseCaseImpl
+  -> PreuniversitarioChequeraData(requisitos de alumnoGuarani.personaRel)
+  -> PreuniversitarioChequeraService
+       -> GuaraniBeneficioService.findByRequisitos(ids) [error -> 0 % + warn]
+       -> BeneficioPolicy [MAX, puro]
+       -> ChequeraSerie(becaPorcentaje congelado)
+       -> ChequeraCuotaFactory(referencia, serie, lectivoCuota)
+            -> cuota bonificada + originales + barcode
+       -> save cuotas -> totals = SUM(cuotas activas por producto)
+  -> MailChequeraService.sendChequera [siempre, incluido 100 %]
+```
+
+La ruta real de requisitos es `alumnoGuarani.personaRel`, no `PersonalesResponse.persona`.
+La extracción debe preservar exactamente el orden, offsets y barcode de F1 cuando el porcentaje
+es cero. `SpoterService` pasa una serie con beneficio cero/null normalizado a `BigDecimal.ZERO`.
+
+### Revisión técnica
+
+1. **Datos de entrada.** Añadir el pass-through null-safe al record y probar persona, lista,
+   elemento y `requisitoRel` nulos. No se debe consultar beneficios con una lista vacía.
+2. **Factory.** Recibe una única fecha de referencia por emisión, normaliza beneficio nulo a cero
+   y crea cada tramo con `HALF_UP`; calcula barcode después de fijar los tres importes finales.
+   El formato del barcode para importe cero queda como gate explícito con sender/Gire.
+3. **Transacción.** Guardar cuotas antes de totales es correcto, pero la suma debe usar el valor
+   devuelto por `saveAll` y filtrar `baja == 0`, para no depender de un objeto parcialmente creado.
+4. **Inconsistencias.** Reemplazar accesos a originales, importes y vencimientos por una
+   validación null-safe; cualquier campo requerido nulo es una inconsistencia, no una excepción
+   de lectura masiva.
+5. **Evento y pagos.** No se agrega una rama para suprimir `send-chequera`. El contexto MercadoPago
+   ya omite importe cero y se prueba como ausencia esperada, no como error.
+6. **Configuración.** La prevalidación de duplicado no sustituye capturar `DataIntegrityViolationException`;
+   ambas son necesarias para entregar 409 bajo concurrencia.
+7. **Política.** Intersectar requisitos elegibles recibidos con los beneficios devueltos, deduplicar
+   IDs y no consultar con una lista vacía; un beneficio alto de un requisito no presentado no
+   puede ganar por error.
+
+### Diagrama de cobertura
+
+```text
+POLÍTICA                         ORQUESTACIÓN                         INTEGRACIONES
+MAX elegible [unit]              requisitos completos [int]          send-chequera 0/30/100 [int]
+sin elegible [unit]              persona/lista/requisito nulos [unit] MP importe cero -> sin contexto [unit]
+porcentaje nulo [unit]           consulta falla -> 0% + warn [int]    JSON conserva originales [contract]
+0/100/HALF_UP [unit]             serie existente -> sin reenvío [int]  PDF bonificado en staging [manual]
+
+FACTORY Y TOTALES                DETECTOR
+fecha vigente/vencida [unit]     0/beneficio/100 [unit]
+0% idéntico a F1 [regresión]     original nulo -> inconsistencia [unit]
+multi-producto/baja/redondeo [unit] límite multiplicador [unit]
+```
+
+### Modos de falla
+
+| Código | Modo | Prevención/prueba | Severidad |
+|---|---|---|---|
+| E1 | ruta de requisitos equivocada | test pass-through de `personaRel` | P1 |
+| E2 | porcentaje nulo o fuera de rango | validación API y política defensiva | P1 |
+| E3 | total no coincide por redondeo | suma de cuotas ya redondeadas por producto | P1 |
+| E4 | detector cae con dato legado nulo | inconsistencia reportable | P1 |
+| E5 | pago para cuota cero | no crear contexto MercadoPago | P1 |
+| E6 | doble alta de configuración | consulta previa + traducción de unique constraint | P1 |
+| E7 | PDF 100% sin filas | proyección documental sin filtro `importe1 > 0` | P1 |
+
+### No entra en esta fase
+
+- Corregir el generador de series concurrente existente (`nextChequeraSerieId`): no lo introduce
+  el beneficio y requiere una estrategia de secuencias separada.
+- Cambiar el sender/PDF: Core verifica el contrato y el recorrido de staging.
+
+### Plan de pruebas de ingeniería
+
+Rutas: `POST /guaraniBeneficio/`, `PUT /guaraniBeneficio/requisito/{id}`,
+`POST /guarani/alumno/create/preuniversitario`, cuotas pendientes, `mercadopago/makeContext`
+e inconsistencias. El gate mínimo es `mvn -B verify`, más pruebas de contrato JSON y dos altas
+de staging: 30 % y 100 %.
+
+## Autoplan — Fase 3.5: revisión DX
+
+**Producto:** API/servicio de Tesorería para integradores Guaraní, sender y operación de
+Tesorería. **Persona primaria:** backend integrator que necesita saber qué enviar, qué recibe y
+cómo diagnosticar una emisión sin beneficio.
+
+| Dimensión | Puntaje | Corrección incorporada |
+|---|---:|---|
+| Inicio | 6/10 | Documentar payload mínimo y recorrido de staging |
+| API/contrato | 7/10 | Separar explícitamente documento 100 % de contexto de pago |
+| Errores | 6/10 | `warn` con causa e identificadores; 409 para duplicados |
+| Documentación | 6/10 | Diagrama de flujo y contrato entre Core y sender |
+| Upgrade | 8/10 | Cambio aditivo para series nuevas; rollback definido |
+| Entorno/CI | 7/10 | `mvn -B verify` y contratos como gates |
+| Ecosistema | 5/10 | Coordinación explícita con sender/Gire pendiente |
+| Medición | 6/10 | Conciliación de fallbacks, 100 % y totales en staging |
+
+### Recorrido del integrador
+
+| Etapa | Resultado esperado | Evidencia |
+|---|---|---|
+| Configurar | `POST/PUT guaraniBeneficio` acepta 0..100 o responde 400/409 | controller tests |
+| Enviar personales | `alumnoGuarani.personaRel.requisitosPresentados` llega intacto | fixture/payload staging |
+| Emitir | serie guarda el porcentaje y genera cuotas | tests de integración |
+| Entregar | `send-chequera` publica el evento para 0..100 | prueba Kafka/contrato |
+| Cobrar | sólo cuotas positivas generan MercadoPago | test `makeContext` |
+| Diagnosticar | fallback deja persona/documento/causa trazables | logs y conciliación |
+
+### Checklist DX
+
+- [ ] OpenAPI/README explica rango, 409 y payload de requisitos.
+- [ ] Ejemplo JSON muestra una chequera parcial y otra 100 %.
+- [ ] El contrato documental incluye filas de importe cero; el de pagos no.
+- [ ] Todo fallback incluye problema, causa, identificadores y siguiente acción operativa.
+- [ ] El rollout publica una guía corta de validación y rollback para Tesorería/sender.
+
+**TTHW operacional:** un integrador existente debe validar una alta bonificada en menos de
+cinco minutos con dos fixtures reproducibles y los comandos de `mvn -B verify`.
+
+## Cross-phase themes
+
+- El 100 % es una chequera informativa, no un cobro. CEO, ingeniería y DX coinciden: debe
+  publicarse, incluir sus filas en el documento y quedar fuera de MercadoPago.
+- La visibilidad del fallback a cero es requisito de operación, no un detalle de logging.
+
+## Decision Audit Trail
+
+| # | Phase | Decision | Classification | Principle | Rationale | Rejected |
+|---|---|---|---|---|---|---|
+| 1 | CEO | Mantener `send-chequera` con 100 % | User-confirmed | P1 | El alumno debe recibir la chequera bonificada | Suprimir el evento |
+| 2 | CEO | Tratar 100 % como documento sin cobro | Mechanical | P5 | MercadoPago ya omite importes cero | Crear un pago de $0 |
+| 3 | Eng | Usar `alumnoGuarani.personaRel` | Mechanical | P5 | Es la única ruta real con requisitos | `PersonalesResponse.persona` |
+| 4 | Eng | Hacer null-safe el detector | Mechanical | P1 | Datos legados no pueden tumbar el endpoint | Dejar NPE |
+| 5 | Eng | Separar consulta documental y de cobro | Mechanical | P1 | El PDF 100 % necesita filas cero; pagos no | Reutilizar pendientes positivos |
+| 6 | Eng | Una referencia temporal por emisión | Mechanical | P5 | Evita flakiness y offsets inconsistentes | Múltiples llamadas a reloj |
+| 7 | DX | Conciliar fallbacks y totales en staging | Mechanical | P1 | Detecta sobrecobros y drift antes de producción | Sólo logs dispersos |
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests | 1 | CLEAR | 5 findings folded into the plan |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | Backend scope |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**VERDICT:** ENG CLEARED — ready to implement once rollout gates are satisfied.
+NO UNRESOLVED DECISIONS

--- a/specs/features/beneficio-requisitos-ingreso/spec.md
+++ b/specs/features/beneficio-requisitos-ingreso/spec.md
@@ -13,16 +13,16 @@ cuando se cumple íntegramente su apartado **Listo cuando**.
 
 | Fase | Estado | Evidencia local | Pendiente para cerrar |
 |---|---|---|---|
-| F0 — validación y conflicto | Parcial | Validaciones `@Valid`/rango y 409 implementadas; los tests de controller cubren 0/50/100, fuera de rango, negativo y nulos **sobre POST y PUT**, más el duplicado a 409 en el alta. | Verificar los mensajes HTTP legibles del 400 contra el formato que espera el cliente. |
+| F0 — validación y conflicto | Parcial | Validaciones `@Valid`/rango y 409 implementadas; los tests de controller cubren `0`/`0.50`/`1.00`, fuera de rango, escala mayor a dos decimales, negativo y nulos **sobre POST y PUT**, más el duplicado a 409 en el alta. | Verificar los mensajes HTTP legibles del 400 contra el formato que espera el cliente. |
 | F1 — caracterización | Parcial | `PreuniversitarioChequeraDetailsCreatorTest` cubre precio de lista/originales/barcode, alternativas, total, vencimientos vencidos, offset y lista vacía. | No puede demostrarse retrospectivamente la condición «antes de tocar producción»; faltan T1–T5 y los siete casos equivalentes de Spoter como contrato histórico. El test existente fija el orden **nuevo** (alternativas → cuotas → totales), no el que T4 debía congelar. |
-| F2 — factory | Implementada, pendiente de contrato F1 | `ChequeraCuotaFactory` es usada por preuniversitario y Spoter; pruebas de 0/20/33,33/100 %, HALF_UP, originales, vencimientos y datos incompletos pasan. El predicado de vencimiento (`vencio`) vive en la factory, así que los dos consumidores comparten la misma regla. | Validarla contra la suite histórica completa e inmutable de F1. |
+| F2 — factory | Implementada, pendiente de contrato F1 | `ChequeraCuotaFactory` es usada por preuniversitario y Spoter; pruebas de `0`/`0.20`/`0.33`/`1.00`, HALF_UP, originales, vencimientos y datos incompletos pasan. El predicado de vencimiento (`vencio`) vive en la factory, así que los dos consumidores comparten la misma regla. | Validarla contra la suite histórica completa e inmutable de F1. |
 | F3 — cálculo y persistencia | Implementada localmente, bloqueada para rollout | Política MAX filtrada por ingreso/activo, `becaPorcentaje`, factor en tres tramos, total de cuotas activas y fallbacks con `warn`. Los productos de `chequera_total` salen de `lectivo_total` unidos a los que generaron cuotas, así una alternativa sin cuotas para un producto conserva su fila en cero. | Confirmar en staging que `requisitoRel` llega poblado y ejecutar la matriz 0 %/parcial/100 % con payload real. |
 | F4 — inconsistencias | Completada localmente, bloqueada para rollout | Detector null-safe; pruebas para parcial, un tramo inválido, 0 %, 100 %, máximo y originales nulos, más endpoint local sin falsos positivos. | Ejecutar el endpoint sobre chequeras bonificadas en staging y confirmar que no aparezcan inconsistencias nuevas. **Los campos nulos ahora se reportan como inconsistentes** (antes lanzaban `NullPointerException`): medir el volumen sobre datos históricos antes de exponer el endpoint. |
 | F6-Core — calidad | Parcial | Tests de política, factory, servicio, cinco endpoints de beneficios, `ChequeraCuotaController` (JSON bonificado/original e ISO), inconsistencias, alta 100 % con `send-chequera`, Spoter sin beneficio, productos sin cuotas por alternativa e importes nulos. JaCoCo con `check` efectivo. | Falta la integración `AlumnoGuaraniController` y la regresión end-to-end de alta → cuotas → inconsistencias → evento, que requiere el payload/infraestructura de staging. |
 | Documentación | Completada | `docs/hexagonal-beneficioCuota.mmd`, registrado en `docs/script.js`, `docs/index.html` y `docs/README.md`. | — |
 
 **Resultado de la validación local:** `mvn -B verify` pasó el 2026-08-20 con
-108 tests, 0 fallos y el check JaCoCo activo.
+111 tests, 0 fallos y el check JaCoCo activo.
 
 **Corrección del gate de cobertura (2026-08-20).** La primera versión de la
 `<execution>` usaba `<element>BUNDLE</element>` con `<includes>` en formato de
@@ -107,7 +107,7 @@ ChequeraSerie.becaPorcentaje   ← congelado al emitir
         │
         ▼
 ChequeraCuotaFactory   ← nuevo, compartido con SpoterService
-        │   importeN = importeNLista × (1 - becaPorcentaje/100), scale 0 HALF_UP
+        │   importeN = importeNLista × (1 - becaPorcentaje), scale 0 HALF_UP
         │   importeNOriginal = importeNLista
         ▼
 createTotals(chequeraSerie, cuotas)   ← total = Σ importe1, orden invertido
@@ -117,7 +117,7 @@ createTotals(chequeraSerie, cuotas)   ← total = Σ importe1, orden invertido
 
 ```
 beneficioAplicado = MAX(porcentajeBeneficio de requisitos con requisitoIngreso='S' y activo='S')
-importeN          = importeNLista × (1 - beneficioAplicado/100)  .setScale(0, HALF_UP)
+importeN          = importeNLista × (1 - beneficioAplicado)  .setScale(0, HALF_UP)
 importeNOriginal  = importeNLista
 total             = Σ importe1 de cuotas activas, por productoId
 ```
@@ -126,10 +126,10 @@ Los tres tramos reciben el mismo factor. Sin requisitos elegibles → 0 % → co
 
 ## Criterios de aceptación
 
-1. `POST` y `PUT /guaraniBeneficio` aceptan `porcentajeBeneficio` en `[0, 100]` inclusive y devuelven **400** fuera de rango, con `requisito` nulo, o con porcentaje nulo.
+1. `POST` y `PUT /guaraniBeneficio` aceptan `porcentajeBeneficio` en `[0, 1]` inclusive, con hasta dos decimales, y devuelven **400** fuera de rango, con `requisito` nulo, o con porcentaje nulo.
 2. `POST /guaraniBeneficio/` sobre un requisito ya cargado devuelve **409**, no 500.
 3. Alumno sin requisitos elegibles → `importe1/2/3`, `importe1/2/3Original`, `vencimiento1/2/3`, `codigoBarras` y `chequera_total.total` **idénticos** a los valores que fijan los tests de caracterización de F1 (`PreuniversitarioChequeraDetailsCreatorTest`, casos 1-8 y T1-T5), sobre las mismas fixtures. Ningún test de F1 puede modificarse para que este criterio pase.
-4. Alumno con requisitos de 10 %, 30 % y 20 % elegibles → `becaPorcentaje = 30` en `ChequeraSerie`.
+4. Alumno con requisitos de `0.10`, `0.30` y `0.20` elegibles → `becaPorcentaje = 0.30` en `ChequeraSerie`.
 5. Requisito con `requisitoIngreso = 'N'` o `activo = 'N'` → excluido, aunque tenga el porcentaje más alto.
 6. `requisitoRel` nulo → excluido, con `log.warn` que incluya `persona` y `requisito`.
 7. Los tres tramos de cada cuota reflejan el mismo factor, redondeados a entero HALF_UP.
@@ -184,7 +184,7 @@ El cambio de `createTotals()` es el único que altera semántica de datos; es ad
 
 | Archivo | Cambio |
 |---|---|
-| `src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/dto/GuaraniBeneficioRequest.java` | `@NotNull`, `@DecimalMin("0")`, `@DecimalMax("100")` |
+| `src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/dto/GuaraniBeneficioRequest.java` | `@NotNull`, `@DecimalMin("0")`, `@DecimalMax("1")`, `@Digits(integer=1, fraction=2)` |
 | `src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/controller/GuaraniBeneficioController.java:53,60` | `@Valid` en POST y PUT |
 | `src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/application/usecases/CreateGuaraniBeneficioUseCaseImpl.java` | Duplicado → 409 |
 | `src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicy.java` | **Nuevo** |
@@ -261,7 +261,8 @@ private Integer requisito;
 
 @NotNull
 @DecimalMin(value = "0",   inclusive = true)
-@DecimalMax(value = "100", inclusive = true)
+@DecimalMax(value = "1", inclusive = true)
+@Digits(integer = 1, fraction = 2)
 private BigDecimal porcentajeBeneficio;
 ```
 
@@ -269,16 +270,32 @@ private BigDecimal porcentajeBeneficio;
 
 **c) Manejo de duplicado** — `create()` hace `save()` directo; si el requisito ya tiene beneficio, la unique constraint de `guarani_beneficio` tira excepción de base sin manejar → **500 crudo**. Traducir a `409 Conflict` con `GuaraniBeneficioException`.
 
-**d) Tests** — `GuaraniBeneficioControllerTest` (`@WebMvcTest`): `porcentajeBeneficio` en 0 → aceptado; en 50 → aceptado; en **100 → aceptado**; en 100,01 → **400**; en 500 → **400**; negativo → **400**; nulo → **400**; `requisito` nulo → **400**; requisito duplicado → **409**. Mismos casos sobre el `PUT`.
+**d) Tests** — `GuaraniBeneficioControllerTest` (`@WebMvcTest`): `porcentajeBeneficio` en `0` → aceptado; en `0.50` → aceptado; en **`1.00` → aceptado**; en `1.01`, `50` o con más de dos decimales → **400**; negativo → **400**; nulo → **400**; `requisito` nulo → **400**; requisito duplicado → **409**. Mismos casos sobre el `PUT`.
 
-### Nota sobre el rango (corregido 2026-08-19)
+### Nota sobre la escala (confirmada contra la base real el 2026-08-20)
 
-El rango es `[0, 100]` **inclusive**. La cota de 99 de una versión anterior de este documento venía de la propuesta de **cascada multiplicativa**, donde el 100 % era inalcanzable por construcción y por eso se excluía.
+El rango persistido es `[0, 1]` **inclusive**, con dos decimales: `0.50` representa 50 % y `1.00`, 100 %. Tanto `guarani_beneficio.porcentaje_beneficio` como `chequera_serie.beca_porcentaje` son `DECIMAL(5,2)` y los datos reales usan esa escala fraccional.
 
-Con `MAX` esa lógica no aplica: el máximo de un conjunto de porcentajes válidos nunca supera el mayor de ellos, así que **no hace falta ningún tope adicional**. Y permitir 100 no es solo admisible: es **necesario**, porque la chequera debe confirmar que no queda deuda.
+Con `MAX` el resultado nunca supera el mayor de sus entradas, así que no hace falta ningún tope adicional. Y permitir `1.00` es necesario, porque la chequera debe confirmar que no queda deuda.
 
 ### Listo cuando
-Los nueve casos pasan, `100` se acepta, y `POST` / `PUT` con porcentaje fuera de `[0, 100]` devuelven 400 con mensaje legible.
+Los casos pasan, `1.00` se acepta, y `POST` / `PUT` con porcentaje fuera de `[0, 1]` o con más de dos decimales devuelven 400 con mensaje legible.
+
+### Gate de escala antes de desplegar
+
+La escala es parte del contrato de datos: `0.50` significa 50 %, no 0,50 %. Antes de promover el cambio, verificar en la base objetivo:
+
+```sql
+SELECT MIN(porcentaje_beneficio), MAX(porcentaje_beneficio),
+       SUM(porcentaje_beneficio < 0 OR porcentaje_beneficio > 1) AS fuera_de_rango
+FROM guarani_beneficio;
+
+SELECT MIN(beca_porcentaje), MAX(beca_porcentaje),
+       SUM(beca_porcentaje < 0 OR beca_porcentaje > 1) AS fuera_de_rango
+FROM chequera_serie;
+```
+
+Ambas consultas deben informar `fuera_de_rango = 0`. Confirmar además que las dos columnas siguen como `DECIMAL(5,2)`, que Sender muestra el porcentaje multiplicando el valor por 100 y que una emisión de prueba con `0.50` cobra exactamente la mitad de cada tramo.
 
 ---
 
@@ -369,7 +386,7 @@ F3 ya **no está bloqueada**.
 |---|---|---|
 | 1 | **Acumulación entre requisitos** | Gana el **más alto**. No se acumulan, no hay cascada |
 | 2 | **Vigencia** | **No hay**. La chequera del preuniversitario es un trámite puntual, no se reevalúa en el tiempo |
-| 3 | **Tope** | Ninguno adicional. Cada porcentaje acotado a `[0, 100]` inclusive por F0; `MAX` no puede superar el mayor de sus entradas |
+| 3 | **Tope** | Ninguno adicional. Cada porcentaje fraccional acotado a `[0, 1]` inclusive por F0; `MAX` no puede superar el mayor de sus entradas |
 | 4 | **Tramos** | Los **tres** (`importe1/2/3`) reciben el mismo factor |
 | 5 | **`importeNOriginal`** | Precio de **lista**, sin ningún descuento |
 | 6 | **Redondeo** | Pesos enteros, `setScale(0, RoundingMode.HALF_UP)` |
@@ -380,7 +397,7 @@ F3 ya **no está bloqueada**.
 beneficioAplicado = MAX(porcentajeBeneficio de los requisitos del alumno
                           con requisitoIngreso = 'S' y activo = 'S')
 
-importeN         = importeNLista × (1 - beneficioAplicado/100)
+importeN         = importeNLista × (1 - beneficioAplicado)
                        .setScale(0, RoundingMode.HALF_UP)
 importeNOriginal = importeNLista          // sin ningún descuento
 ```
@@ -389,7 +406,7 @@ Sin requisitos elegibles → `beneficioAplicado = 0` → importes idénticos a h
 
 ### El caso 100 % — **resuelto** (2026-08-19)
 
-El rango es `[0, 100]` inclusive y el 100 % es un caso **de primera clase**, no un borde a evitar: la chequera debe informar que no queda deuda.
+El rango fraccional es `[0, 1]` inclusive y `1.00` (100 %) es un caso **de primera clase**, no un borde a evitar: la chequera debe informar que no queda deuda.
 
 La cota de 99 que figuraba antes venía de la propuesta de cascada multiplicativa y quedó obsoleta al adoptar `MAX`. Con máximo no hay riesgo de combinación: el resultado nunca supera el mayor de los porcentajes de entrada, así que la validación por campo de F0 es el único control necesario.
 
@@ -490,7 +507,7 @@ El caso 10 es el que verifica que el orden de los dos pasos es el correcto. Inve
 
 ```java
 importeN = importeNLista.multiply(BigDecimal.ONE.subtract(
-               beneficio.divide(BigDecimal.valueOf(100))))
+               beneficio))
            .setScale(0, RoundingMode.HALF_UP);
 ```
 
@@ -630,7 +647,7 @@ El JSON que recibe sender-service incluye precio de lista y precio bonificado, v
 ## F6 — Calidad dividida entre Issue 1 e Issue 2 `[ ]`
 
 El Issue 1 cubre controllers, cálculo, inconsistencias y JaCoCo. El Issue 2 agrega los
-tests de contrato Core → sender y las fixtures documentales 0/30/100.
+tests de contrato Core → sender y las fixtures documentales 0 %/30 %/100 %.
 
 ### Alcance
 
@@ -674,7 +691,7 @@ F3 requiere además validar el payload en staging
 F5 comienza sólo después del despliegue del Issue 1
 ```
 
-Las seis decisiones de negocio y el rango `[0, 100]` están cerrados. Ver `decisiones.md`.
+Las seis decisiones de negocio y el rango fraccional `[0, 1]` están cerrados. Ver `decisiones.md`.
 
 ## Riesgos
 

--- a/specs/features/beneficio-requisitos-ingreso/spec.md
+++ b/specs/features/beneficio-requisitos-ingreso/spec.md
@@ -1,0 +1,698 @@
+# Spec — Beneficio por requisitos de ingreso en cuotas preuniversitarias
+
+> Especificación ejecutable de **una** feature. El orden de trabajo del repositorio
+> completo vive en `../../roadmap.md`.
+>
+> Versión del servicio al redactar: **4.1.1** · Fecha: **2026-08-19** · Estado: **implementación local en validación; no lista para rollout**
+
+## Estado de implementación — Issue #338 (2026-08-20)
+
+Esta sección registra evidencia del estado real del workspace. No sustituye los
+criterios de aceptación ni habilita el rollout: una fase sólo se marca completa
+cuando se cumple íntegramente su apartado **Listo cuando**.
+
+| Fase | Estado | Evidencia local | Pendiente para cerrar |
+|---|---|---|---|
+| F0 — validación y conflicto | Parcial | Validaciones `@Valid`/rango y 409 implementadas; los tests de controller cubren 0/50/100, fuera de rango, negativo y nulos **sobre POST y PUT**, más el duplicado a 409 en el alta. | Verificar los mensajes HTTP legibles del 400 contra el formato que espera el cliente. |
+| F1 — caracterización | Parcial | `PreuniversitarioChequeraDetailsCreatorTest` cubre precio de lista/originales/barcode, alternativas, total, vencimientos vencidos, offset y lista vacía. | No puede demostrarse retrospectivamente la condición «antes de tocar producción»; faltan T1–T5 y los siete casos equivalentes de Spoter como contrato histórico. El test existente fija el orden **nuevo** (alternativas → cuotas → totales), no el que T4 debía congelar. |
+| F2 — factory | Implementada, pendiente de contrato F1 | `ChequeraCuotaFactory` es usada por preuniversitario y Spoter; pruebas de 0/20/33,33/100 %, HALF_UP, originales, vencimientos y datos incompletos pasan. El predicado de vencimiento (`vencio`) vive en la factory, así que los dos consumidores comparten la misma regla. | Validarla contra la suite histórica completa e inmutable de F1. |
+| F3 — cálculo y persistencia | Implementada localmente, bloqueada para rollout | Política MAX filtrada por ingreso/activo, `becaPorcentaje`, factor en tres tramos, total de cuotas activas y fallbacks con `warn`. Los productos de `chequera_total` salen de `lectivo_total` unidos a los que generaron cuotas, así una alternativa sin cuotas para un producto conserva su fila en cero. | Confirmar en staging que `requisitoRel` llega poblado y ejecutar la matriz 0 %/parcial/100 % con payload real. |
+| F4 — inconsistencias | Completada localmente, bloqueada para rollout | Detector null-safe; pruebas para parcial, un tramo inválido, 0 %, 100 %, máximo y originales nulos, más endpoint local sin falsos positivos. | Ejecutar el endpoint sobre chequeras bonificadas en staging y confirmar que no aparezcan inconsistencias nuevas. **Los campos nulos ahora se reportan como inconsistentes** (antes lanzaban `NullPointerException`): medir el volumen sobre datos históricos antes de exponer el endpoint. |
+| F6-Core — calidad | Parcial | Tests de política, factory, servicio, cinco endpoints de beneficios, `ChequeraCuotaController` (JSON bonificado/original e ISO), inconsistencias, alta 100 % con `send-chequera`, Spoter sin beneficio, productos sin cuotas por alternativa e importes nulos. JaCoCo con `check` efectivo. | Falta la integración `AlumnoGuaraniController` y la regresión end-to-end de alta → cuotas → inconsistencias → evento, que requiere el payload/infraestructura de staging. |
+| Documentación | Completada | `docs/hexagonal-beneficioCuota.mmd`, registrado en `docs/script.js`, `docs/index.html` y `docs/README.md`. | — |
+
+**Resultado de la validación local:** `mvn -B verify` pasó el 2026-08-20 con
+108 tests, 0 fallos y el check JaCoCo activo.
+
+**Corrección del gate de cobertura (2026-08-20).** La primera versión de la
+`<execution>` usaba `<element>BUNDLE</element>` con `<includes>` en formato de
+ruta (`um/tesoreria/...`). En JaCoCo los `<includes>` de una `<rule>` matchean el
+**nombre del elemento**, y para `BUNDLE` ese nombre es el del bundle
+(`um.tesoreria.core-service`): los cinco patrones no matcheaban nada, la regla se
+evaluaba sobre cero elementos y el check pasaba siempre. Verificado subiendo el
+mínimo a 0,99 sin que el build fallara, con la cobertura del bundle completo en
+7,71 %. Corregido a `<element>CLASS</element>` con nombres separados por
+**puntos**; comprobado que a 0,99 la regla dispara sobre
+`PreuniversitarioChequeraService` (0,82) y que a 0,80 pasa.
+
+**Gates externos pendientes:** payload de staging con `requisitoRel`, endpoint de
+inconsistencias en staging y conciliación de 0 %/parcial/100 %. No se modificaron
+sender-service, PDF ni correo, que continúan fuera del alcance de #338.
+> Decisiones de negocio: `decisiones.md` (D1–D8)
+
+---
+
+## Objetivo
+
+**Aplicar el beneficio por requisitos de ingreso cargados en Guaraní al cálculo de importes de cuota para alumnos preuniversitarios, en `core-service`.**
+
+Todo lo que no sirva a ese objetivo queda fuera. La deuda técnica general del repositorio está documentada en `../../tech-stack.md` (§6, huecos H1–H8) pero **no priorizada**: son huecos reconocidos, no fases activas.
+
+## Contexto
+
+Guaraní registra los requisitos de ingreso que presenta cada aspirante. Tesorería definió que ciertos requisitos otorgan un porcentaje de bonificación sobre el arancel. Ese porcentaje **hoy no llega a ningún importe**: se puede cargar por REST en `guarani_beneficio`, pero ningún componente del servicio lo lee.
+
+El resultado es que un ingresante con derecho a beneficio recibe una chequera al precio de lista. La corrección es manual, o no ocurre.
+
+El módulo `GuaraniBeneficio` se construyó en la 3.45.0 y se le agregó la consulta por múltiples requisitos en la 4.1.0. La infraestructura está; falta el cableado.
+
+## Estado actual (verificado sobre 4.1.1)
+
+### El módulo existe y está aislado
+
+`GuaraniBeneficio` tiene dominio, 5 casos de uso, adaptador JPA sobre `guarani_beneficio` y controller con 5 endpoints. **Ninguna clase fuera de su propio paquete lo referencia.**
+
+### Landscape de los mecanismos de descuento
+
+| Mecanismo | Modelado | Persistido | Aplicado a importes |
+|---|---|---|---|
+| `GuaraniBeneficio` (requisito → %) | ✅ | ✅ | ❌ |
+| `ArancelPorcentaje` (arancelTipo+producto → %) | ✅ | ✅ | ❌ |
+| `ChequeraSerie.becaPorcentaje` | ✅ | ✅ | ❌ hardcodeado en `ZERO` |
+
+Tres mecanismos, cero aplicados. Esta feature cablea el primero usando el tercero como almacenamiento.
+
+### El hook ya está reservado
+
+`PreuniversitarioChequeraService.java:49-50` tiene el lugar exacto, con comentario y todo. Fluye a `policy.createSerie(data, control, becaPorcentaje)` (línea 58) → `ChequeraSerie.becaPorcentaje` → `ChequeraService.track():190` → `ChequeraImpresionCabecera`. La cadena hasta impresión está completa.
+
+### Los importes se copian sin descuento, en dos lugares casi idénticos
+
+| Ubicación | Qué hace |
+|---|---|
+| `PreuniversitarioChequeraDetailsCreator.createCuotas()` | Copia `importe1/2/3` de `LectivoCuota`; fija `importeN` e `importeNOriginal` **iguales** |
+| `SpoterService.java:180-206` | El mismo bloque duplicado |
+
+### El total ya es inconsistente, antes de esta feature
+
+`createTotals()` copia `LectivoTotal.getTotal()`. Pero `PagoService.calcularPagado():214` lo reasigna a `Σ importe1` de las cuotas activas al primer pago. Si difieren, el total cambia en silencio.
+
+### Cobertura del camino
+
+19 archivos de test en todo el repo. Sobre este camino: **cero**.
+
+## Cambio propuesto
+
+```
+AlumnoGuaraniRequest.personaRel.requisitosPresentados
+        │
+        ▼
+BeneficioPolicy.porcentajeEfectivo(requisitos, beneficios)   ← nuevo, dominio puro
+        │   filtra requisitoIngreso='S' AND activo='S', toma MAX
+        ▼
+PreuniversitarioChequeraService:49-50   ← hook existente
+        │
+        ▼
+ChequeraSerie.becaPorcentaje   ← congelado al emitir
+        │
+        ▼
+ChequeraCuotaFactory   ← nuevo, compartido con SpoterService
+        │   importeN = importeNLista × (1 - becaPorcentaje/100), scale 0 HALF_UP
+        │   importeNOriginal = importeNLista
+        ▼
+createTotals(chequeraSerie, cuotas)   ← total = Σ importe1, orden invertido
+```
+
+### Fórmula
+
+```
+beneficioAplicado = MAX(porcentajeBeneficio de requisitos con requisitoIngreso='S' y activo='S')
+importeN          = importeNLista × (1 - beneficioAplicado/100)  .setScale(0, HALF_UP)
+importeNOriginal  = importeNLista
+total             = Σ importe1 de cuotas activas, por productoId
+```
+
+Los tres tramos reciben el mismo factor. Sin requisitos elegibles → 0 % → comportamiento idéntico al actual. Justificación de cada decisión en `decisiones.md`.
+
+## Criterios de aceptación
+
+1. `POST` y `PUT /guaraniBeneficio` aceptan `porcentajeBeneficio` en `[0, 100]` inclusive y devuelven **400** fuera de rango, con `requisito` nulo, o con porcentaje nulo.
+2. `POST /guaraniBeneficio/` sobre un requisito ya cargado devuelve **409**, no 500.
+3. Alumno sin requisitos elegibles → `importe1/2/3`, `importe1/2/3Original`, `vencimiento1/2/3`, `codigoBarras` y `chequera_total.total` **idénticos** a los valores que fijan los tests de caracterización de F1 (`PreuniversitarioChequeraDetailsCreatorTest`, casos 1-8 y T1-T5), sobre las mismas fixtures. Ningún test de F1 puede modificarse para que este criterio pase.
+4. Alumno con requisitos de 10 %, 30 % y 20 % elegibles → `becaPorcentaje = 30` en `ChequeraSerie`.
+5. Requisito con `requisitoIngreso = 'N'` o `activo = 'N'` → excluido, aunque tenga el porcentaje más alto.
+6. `requisitoRel` nulo → excluido, con `log.warn` que incluya `persona` y `requisito`.
+7. Los tres tramos de cada cuota reflejan el mismo factor, redondeados a entero HALF_UP.
+8. `importeNOriginal` conserva el precio de lista en las tres posiciones.
+9. `chequera_total.total` es **exactamente** `Σ importe1` de las cuotas activas de ese `productoId`.
+10. Tras `PagoService.calcularPagado()`, `chequera_total.total` **no cambia**.
+11. Beneficio 100 % → cuotas y total en cero; `FindAllInconsistenciasUseCaseImpl` no reporta la chequera.
+12. `GET /chequeraCuota/inconsistencias/{desde}/{hasta}` no reporta falsos positivos sobre chequeras bonificadas.
+13. Una chequera creada por `SpoterService` no recibe beneficio.
+14. Ante cualquiera de estas fallas, la chequera se emite con `becaPorcentaje = 0` y se registra `log.warn` con `persona`, `documentoId` y la causa; **nunca** se aborta la emisión ni se propaga la excepción:
+    - `personaRel` nulo en el `PersonalesResponse` recibido
+    - `requisitosPresentados` nulo o lista vacía
+    - `requisitoRel` nulo en uno o más elementos (se excluye ese requisito, no la chequera)
+    - `GuaraniBeneficioRepository.findByRequisitos(...)` lanza excepción de persistencia
+    - `porcentajeBeneficio` nulo en un registro de `guarani_beneficio` (se trata como cero)
+15. Tests escritos y pasando; sin degradación de funcionalidad existente.
+
+## Plan de tests
+
+| Capa | Qué | Count |
+|---|---|---|
+| Unit | `BeneficioPolicy` (12 casos, 100 % de ramas) | +12 |
+| Unit | `ChequeraCuotaFactory`: vencimientos, offset, factor, redondeo, originales | +11 |
+| Unit | `createTotals`: suma, multi-producto, baja, 100 %, resto de redondeo | +7 |
+| Unit | `GuaraniBeneficio` use cases + mappers | +5 |
+| Unit | `FindAllInconsistenciasUseCaseImpl` con cuotas bonificadas | +6 |
+| Integration | `PreuniversitarioChequeraService` end-to-end con y sin beneficio | +4 |
+| Integration | `SpoterService` sin beneficio (no regresión) | +2 |
+| Controller | `GuaraniBeneficioController` validación + `ChequeraCuotaController` | +12 |
+
+Total: **+59 tests**.
+
+**Umbral de cobertura:** `jacoco-maven-plugin` 0.8.13 ya está en `pom.xml` con `prepare-agent` y `report`, pero **sin** goal `check` ni `<rules>`, así que hoy nada rompe el build por cobertura. Se agrega una `<execution>` con goal `check` y una `<rule>` de `BUNDLE` con `LINE` al 80 %, limitada vía `<includes>` a `um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/**`, `um/tesoreria/core/hexagonal/chequera/chequeraCuota/**` y `um/tesoreria/core/hexagonal/chequera/chequeraSerie/**`. El resto del proyecto queda sin umbral para no frenar PRs ajenos. `mvn -B verify` en `maven.yml` debe fallar si esos tres paquetes bajan del 80 %.
+
+## Plan de rollback
+
+El beneficio se aplica solo en **creación**; las chequeras existentes no se tocan. Revertir el PR restituye el comportamiento anterior para chequeras nuevas. Las emitidas con beneficio quedan con `becaPorcentaje` grabado y sus importes persistidos: revertirlas requiere baja y reemisión, que es el flujo manual que tesorería ya usa.
+
+El cambio de `createTotals()` es el único que altera semántica de datos; es aditivo sobre chequeras nuevas y no reescribe históricos.
+
+## Hitos
+
+| Hito | Resultado | Dependencia |
+|---|---|---|
+| 1. Configuración y contrato actual | Validación, conflicto 409 y tests de caracterización | — |
+| 2. Cálculo persistido | Factory, política MAX, cuotas, totales e inconsistencias | Hito 1 y payload validado en staging |
+| 3. Cierre de cálculo | Controllers, JaCoCo, diagrama y regresión de `send-chequera` | Hito 2 |
+| 4. Documento con beneficios | Contrato Core → sender, PDF 0/30/100 y barcode acordado | Hito 3 desplegado |
+| 5. Aviso complementario | Mail específico de beca completa, si el equipo lo aprueba | Hito 4 y contenido definido |
+
+## Archivos afectados
+
+| Archivo | Cambio |
+|---|---|
+| `src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/dto/GuaraniBeneficioRequest.java` | `@NotNull`, `@DecimalMin("0")`, `@DecimalMax("100")` |
+| `src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/controller/GuaraniBeneficioController.java:53,60` | `@Valid` en POST y PUT |
+| `src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/application/usecases/CreateGuaraniBeneficioUseCaseImpl.java` | Duplicado → 409 |
+| `src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicy.java` | **Nuevo** |
+| `src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/factory/ChequeraCuotaFactory.java` | **Nuevo** |
+| `src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraService.java:49-50` | Llamada a `BeneficioPolicy` en el hook |
+| `src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraDetailsCreator.java` | Usa la factory; invierte orden; `createTotals` suma cuotas |
+| `src/main/java/um/tesoreria/core/service/transactional/spoter/SpoterService.java:180-206` | Usa la factory |
+| `docs/hexagonal-beneficioCuota.mmd` | **Nuevo** diagrama, registrado en `docs/script.js` |
+
+## Cómo leer el plan de implementación
+
+- Ocho fases, en orden estricto. Cada una es **un PR**.
+- Cada fase deja el repositorio en verde y desplegable.
+- `[ ]` pendiente · `[~]` en curso · `[x]` hecho.
+
+## Fuera de alcance — deuda conocida, no fases activas
+
+| Tema | Por qué queda afuera |
+|---|---|
+| `SpoterService` más allá de extraer la factory | Se toca en F2 solo para que consuma la factory; su migración a hexagonal no entra |
+| `RecalculateCuotaByUniqueIndexUseCaseImpl` | El recálculo por política arancelaria es otro camino de cálculo; no se cablea beneficio acá |
+| Todo lo de VB6 | Sistema externo, fuera de este servicio |
+| `ArancelPorcentaje` sin consumidores | Segunda isla de descuentos; se anota, no se resuelve |
+| Cobertura general, Flyway, cierre del legacy | H1, H2, H3 en `../../tech-stack.md` |
+| Corrupción silenciosa del código de barras | H7 en `../../tech-stack.md`. La feature lo evita por construcción, pero no lo corrige |
+
+---
+
+## Corrección de referencias
+
+Las líneas que se citaron al definir esta tarea apuntan a un estado anterior del código. Mapeo verificado al 4.1.1:
+
+| Referencia original | Ubicación real hoy |
+|---|---|
+| `PreuniversitarioChequeraService` líneas 218-242 | `PreuniversitarioChequeraDetailsCreator.createCuotas()` — el archivo original quedó en 76 líneas tras el refactor de la 4.1.0 que separó el flujo preuniversitario en componentes |
+| `SpoterService` líneas 179-203 | `SpoterService` líneas **180-206**, bloque `// Generar Cuotas` |
+
+**Hallazgo que justifica la fase 2:** los dos bloques son casi idénticos — mismo cálculo de vencimientos con offset de 30 días cuando la cuota ya venció, misma construcción de `ChequeraCuota` con constructor posicional de más de 30 argumentos, misma llamada a `calculateCodigoBarras`. La duplicación es literal, no conceptual.
+
+---
+
+## F0 — Validación de entrada en el alta de `guarani_beneficio` `[ ]`
+
+**Integridad de datos, no seguridad.** Un typo no puede poder cargar 500%.
+
+Sin dependencias: se puede hacer y desplegar hoy, en paralelo con F1.
+
+### Contexto
+
+Hoy no hay ninguna validación en el camino de alta, verificado en tres capas:
+
+```java
+// GuaraniBeneficioRequest — dos campos, cero anotaciones
+private Integer requisito;
+private BigDecimal porcentajeBeneficio;
+
+// GuaraniBeneficioController:53 — sin @Valid
+public ResponseEntity<GuaraniBeneficioResponse> add(@RequestBody GuaraniBeneficioRequest request)
+
+// CreateGuaraniBeneficioUseCaseImpl — sin validación
+public GuaraniBeneficio create(GuaraniBeneficio g) { return repository.save(g); }
+```
+
+`AuthController` **sí** usa `@Valid` en su `LoginRequest`, así que la omisión no es convención del proyecto.
+
+Esta validación es la barrera efectiva contra un error de carga. Eso la vuelve más importante, no menos.
+
+### Alcance
+
+**a) DTO** — `GuaraniBeneficioRequest`:
+```java
+@NotNull
+private Integer requisito;
+
+@NotNull
+@DecimalMin(value = "0",   inclusive = true)
+@DecimalMax(value = "100", inclusive = true)
+private BigDecimal porcentajeBeneficio;
+```
+
+**b) Controller** — `@Valid` en `POST /` (línea 53) **y** en `PUT /requisito/{requisito}` (línea 60). El `PUT` importa igual que el alta: hoy permite llevar a 500% un beneficio ya cargado.
+
+**c) Manejo de duplicado** — `create()` hace `save()` directo; si el requisito ya tiene beneficio, la unique constraint de `guarani_beneficio` tira excepción de base sin manejar → **500 crudo**. Traducir a `409 Conflict` con `GuaraniBeneficioException`.
+
+**d) Tests** — `GuaraniBeneficioControllerTest` (`@WebMvcTest`): `porcentajeBeneficio` en 0 → aceptado; en 50 → aceptado; en **100 → aceptado**; en 100,01 → **400**; en 500 → **400**; negativo → **400**; nulo → **400**; `requisito` nulo → **400**; requisito duplicado → **409**. Mismos casos sobre el `PUT`.
+
+### Nota sobre el rango (corregido 2026-08-19)
+
+El rango es `[0, 100]` **inclusive**. La cota de 99 de una versión anterior de este documento venía de la propuesta de **cascada multiplicativa**, donde el 100 % era inalcanzable por construcción y por eso se excluía.
+
+Con `MAX` esa lógica no aplica: el máximo de un conjunto de porcentajes válidos nunca supera el mayor de ellos, así que **no hace falta ningún tope adicional**. Y permitir 100 no es solo admisible: es **necesario**, porque la chequera debe confirmar que no queda deuda.
+
+### Listo cuando
+Los nueve casos pasan, `100` se acepta, y `POST` / `PUT` con porcentaje fuera de `[0, 100]` devuelven 400 con mensaje legible.
+
+---
+
+## F1 — Tests de caracterización `[ ]`
+
+Documentar el comportamiento actual **antes de tocar nada**. Estos tests son el contrato contra el que se verifica F2.
+
+### Alcance
+
+**`PreuniversitarioChequeraDetailsCreatorTest`**
+
+| # | Escenario | Esperado |
+|---|---|---|
+| 1 | `LectivoCuota` con `vencimiento1` futuro | Vencimientos copiados tal cual desde `LectivoCuota` |
+| 2 | `vencimiento1` ya vencido | Vencimientos reemplazados por `dateAbsoluteArgentina() + 7/20/40` días |
+| 3 | Varias cuotas vencidas | El `offset` incrementa 30 días por cuota — **solo** para las vencidas |
+| 4 | Mezcla de vencidas y no vencidas | El `offset` no se incrementa en las no vencidas |
+| 5 | Cualquier caso | `importe1/2/3` **y** `importe1/2/3Original` reciben el mismo valor de `LectivoCuota` |
+| 6 | Cualquier caso | `arancelTipoId` viene de `chequeraSerie`, no de `LectivoCuota` |
+| 7 | Cualquier caso | `codigoBarras` se calcula después de fijar importes; flags `pagado`/`baja`/`manual`/`compensada` en 0 |
+| 8 | Sin `LectivoCuota` | `saveAll` con lista vacía, sin excepción |
+
+**`createTotals()` necesita cobertura real, no un caso de cortesía.** F3(f) le cambia tanto la fuente del dato como su posición en `create()`, así que hay que congelar antes:
+
+| # | Escenario | Esperado hoy |
+|---|---|---|
+| T1 | Un producto | `total` = `LectivoTotal.getTotal()` copiado tal cual |
+| T2 | Varios productos | Un `ChequeraTotal` por `productoId` |
+| T3 | Cualquier caso | `pagado` inicializa en `BigDecimal.ZERO` |
+| T4 | Cualquier caso | Se ejecuta **antes** que `createCuotas()` |
+| T5 | Sin `LectivoTotal` | `saveAll` con lista vacía, sin excepción |
+
+T4 documenta el orden actual justamente porque F3(f) lo invierte.
+
+Añadir además un caso de caracterización sobre `createAlternatives()`, que no cambia pero comparte el mismo `create()`.
+
+**`SpoterServiceTest`** — acotado al bloque `// Generar Cuotas` (líneas 180-206): repetir los casos 1 a 7. Es deliberadamente redundante: si F2 hace divergir los dos caminos, estos tests lo detectan.
+
+**Punto crítico del caso 5:** hoy `importeN` e `importeNOriginal` nacen **idénticos**. Ese es exactamente el invariante que F3 va a romper a propósito, y el que F4 verifica. Dejarlo escrito y explícito acá.
+
+### Listo cuando
+Los tests pasan sin modificar una línea de producción. Si hubo que tocar producción para poder testear, es refactor y pertenece a F2.
+
+---
+
+## F2 — Extraer `ChequeraCuotaFactory` `[ ]`
+
+Refactor puro. **Cero cambio de comportamiento**, verificado contra F1.
+
+### Alcance
+
+Nueva clase en `.../chequera/chequeraCuota/application/factory/ChequeraCuotaFactory.java`:
+
+```java
+ChequeraCuota crear(ChequeraSerie chequeraSerie, LectivoCuota lectivoCuota, int offset, OffsetDateTime ahora);
+```
+
+Absorbe, tal cual está hoy:
+- el cálculo de `vencimiento1/2/3` con la regla de los 7/20/40 días más `30 * offset`
+- la construcción de `ChequeraCuota` — **reemplazando el constructor posicional de 30+ argumentos por `builder()`**, que es donde vive el riesgo real de este refactor
+- la llamada a `calculateCodigoBarras`
+
+Dos consumidores pasan a usarla: `PreuniversitarioChequeraDetailsCreator.createCuotas()` y `SpoterService` (bloque 180-206).
+
+**`ahora` entra por parámetro**, no se resuelve adentro con `OffsetDateTime.now()`. Es lo que hace la factory testeable de forma determinística, y sigue el criterio que ya se aplicó en la 3.42.0 al pasar la fecha de referencia por parámetro en `FindAllDebidasUseCase`.
+
+La gestión del `offset` queda en cada llamador (es estado del bucle, no de la factory).
+
+### Riesgo y mitigación
+Traducir 30 argumentos posicionales a builder es donde se cuela un campo cambiado de lugar. Mitigación: los tests de F1 ya fijan valor por valor; **ningún test de F1 puede modificarse en esta fase**.
+
+### Listo cuando
+Todos los tests de F1 pasan **sin una sola modificación**, y `git diff` muestra que el bloque de cuotas desapareció de los dos consumidores.
+
+> **Invariante del roadmap:** si un test de F1 tuvo que cambiar, el refactor cambió comportamiento. Frenar y revisar.
+
+---
+
+## F3 — Conectar `GuaraniBeneficioService` dentro de la factory `[ ]`
+
+El corazón de la feature. Todo el cableado ocurre en **un solo lugar** gracias a F2.
+
+### Decisiones de negocio — **CERRADAS** (2026-08-19)
+
+F3 ya **no está bloqueada**.
+
+| # | Decisión | Resuelto |
+|---|---|---|
+| 1 | **Acumulación entre requisitos** | Gana el **más alto**. No se acumulan, no hay cascada |
+| 2 | **Vigencia** | **No hay**. La chequera del preuniversitario es un trámite puntual, no se reevalúa en el tiempo |
+| 3 | **Tope** | Ninguno adicional. Cada porcentaje acotado a `[0, 100]` inclusive por F0; `MAX` no puede superar el mayor de sus entradas |
+| 4 | **Tramos** | Los **tres** (`importe1/2/3`) reciben el mismo factor |
+| 5 | **`importeNOriginal`** | Precio de **lista**, sin ningún descuento |
+| 6 | **Redondeo** | Pesos enteros, `setScale(0, RoundingMode.HALF_UP)` |
+
+### Fórmula acordada
+
+```
+beneficioAplicado = MAX(porcentajeBeneficio de los requisitos del alumno
+                          con requisitoIngreso = 'S' y activo = 'S')
+
+importeN         = importeNLista × (1 - beneficioAplicado/100)
+                       .setScale(0, RoundingMode.HALF_UP)
+importeNOriginal = importeNLista          // sin ningún descuento
+```
+
+Sin requisitos elegibles → `beneficioAplicado = 0` → importes idénticos a hoy.
+
+### El caso 100 % — **resuelto** (2026-08-19)
+
+El rango es `[0, 100]` inclusive y el 100 % es un caso **de primera clase**, no un borde a evitar: la chequera debe informar que no queda deuda.
+
+La cota de 99 que figuraba antes venía de la propuesta de cascada multiplicativa y quedó obsoleta al adoptar `MAX`. Con máximo no hay riesgo de combinación: el resultado nunca supera el mayor de los porcentajes de entrada, así que la validación por campo de F0 es el único control necesario.
+
+**Consecuencias verificadas del beneficio 100 %** (importes en cero):
+
+- `FindAllInconsistenciasUseCaseImpl` **no** se dispara. `importesInvalidos` compara `0 > 0` → falso en los tres tramos. `multiplicadoresInvalidos` evalúa `importeNOriginal × 49 < 0` → falso, porque `importeNOriginal` guarda el precio de lista (positivo). Ver F4 caso 4.
+- `calculateCodigoBarras` no se corrompe: `DecimalFormat("0000000").format(0)` da `"0000000"`, y las diferencias `0 - 0 = 0` dan `"00000"`. Largo correcto, sin signo negativo. Queda por confirmar con el banco si un código Gire con importe cero es **operativamente** válido, aunque sea sintácticamente correcto.
+- `importeNOriginal` conserva el precio de lista, así que la chequera puede mostrar cuánto se bonificó.
+
+### Alcance
+
+**a) Origen de los requisitos.** Hoy `PersonaGuarani.requisitosPresentados` solo entra por `AlumnoGuaraniRequest`; no existe caso de uso que consulte los requisitos vigentes de una persona. Definir al empezar la fase si vienen en el request del alta preuniversitaria o si hay que consultarlos, y construir el eslabón que falte.
+
+**a.bis) El hook ya existe — usarlo.** `PreuniversitarioChequeraService.java:49-50` tiene el lugar reservado:
+
+```java
+// Determina beneficio
+var becaPorcentaje = BigDecimal.ZERO;
+```
+
+Ahí va la llamada a `BeneficioPolicy`. El resultado se persiste en `ChequeraSerie.becaPorcentaje` a través de `policy.createSerie(data, control, becaPorcentaje)` (línea 58), que ya recibe el porcentaje como parámetro.
+
+Tres cosas que esto resuelve sin código extra:
+
+- **Congelamiento.** El porcentaje queda grabado en la serie al emitir. No se reevalúa nunca.
+- **Trazabilidad.** `ChequeraSerie` ya tiene `becaResolucion`, `becaFecha` y `becaUserId` para registrar de dónde salió el beneficio.
+- **Impresión.** `ChequeraService.track():190` ya copia `becaPorcentaje` a `ChequeraImpresionCabecera`, así que el dato llega solo a la capa de impresión.
+
+`detailsCreator.create(chequeraSerie)` se invoca en la línea 62, después de que la serie tiene el porcentaje. **La factory lo lee de `chequeraSerie.getBecaPorcentaje()`**, sin parámetro adicional. Eso también resuelve F3(e): `SpoterService` construye su propia `ChequeraSerie`, cuyo `becaPorcentaje` es null o cero, así que no recibe beneficio sin necesidad de una rama especial.
+
+**b) `BeneficioPolicy`** — dominio puro, sin Spring ni JPA:
+
+```java
+BigDecimal porcentajeEfectivo(List<RequisitoPresentadoGuarani> requisitos,
+                              List<GuaraniBeneficio> beneficios);
+```
+
+Sin parámetro de fecha: la decisión 2 eliminó la vigencia temporal, así que la política es **puramente funcional** sobre sus dos entradas. Eso la vuelve trivial de testear y elimina toda dependencia del reloj.
+
+La política resuelve en dos pasos, en este orden:
+
+**1. Elegibilidad del requisito** — solo cuentan los requisitos de ingreso activos:
+
+```java
+requisito.getRequisitoRel() != null
+  && "S".equalsIgnoreCase(requisito.getRequisitoRel().getRequisitoIngreso())
+  && "S".equalsIgnoreCase(requisito.getRequisitoRel().getActivo())
+```
+
+`requisitoIngreso` y `activo` son `String` en `RequisitoGuarani` (líneas 19-20), así que la comparación va **null-safe y case-insensitive**, con la constante a la izquierda.
+
+Este filtro importa porque `guarani_beneficio` no tiene FK hacia el catálogo de Guaraní: es un `Integer` con unique constraint. Nada impide que alguien cargue un beneficio para un requisito de **egreso** o para uno dado de baja. Este filtro y la validación de F0 son las dos barreras del dominio.
+
+**2. Máximo** — de los beneficios cuyos requisitos pasaron el filtro, se toma el `porcentajeBeneficio` más alto. Sin requisitos elegibles, `ZERO`.
+
+> **La deduplicación dejó de hacer falta.** Con suma o cascada, un requisito repetido en la lista contaba dos veces y había que deduplicar. Con `MAX`, repetir el mismo requisito no cambia el resultado: la operación es idempotente. Un test lo deja fijado igual, porque es una propiedad de la que ahora dependemos.
+>
+> Por la misma razón desaparecieron los casos de "requisito vencido" y "`fechaPresentacion` futura": la decisión 2 eliminó la vigencia, así que `fechaPresentacion`, `fechaVencimiento` y `fechaAlta` **no se leen**.
+
+**Decisión pendiente — `requisitoRel` nulo.** El filtro depende de que Guaraní popule `requisitoRel`; si llega nulo, no se puede saber si el requisito es de ingreso. Se **falla cerrado**: no se otorga el beneficio para ese requisito y se loguea en `warn` con `requisito` y `persona`. Un descuento otorgado de más produce cuotas más baratas ya enviadas por mail, difíciles de revertir; un descuento faltante lo corrige tesorería a mano, que es el camino que el principio 5 de `../../mission.md` ya privilegia.
+
+> ### 🔴 Verificación bloqueante antes de arrancar F3
+>
+> La plomería del core está verificada e intacta: `AlumnoGuaraniDtoMapper:40` y `:55` pasan `personaRel` **por referencia**, sin reconstruir. Lo que no se pudo verificar desde el repositorio es si Guaraní **envía** el objeto anidado — no hay fixtures JSON ni cliente hacia Guaraní, porque el core es receptor.
+>
+> **Cómo verificar (10 minutos, sin código nuevo):** `PersonaGuarani implements Jsonifyable`. Agregar un `log.debug("personaRel -> {}", personaRel.jsonify())` temporal en `CreatePreuniversitarioUseCaseImpl` y disparar un alta real en staging.
+>
+> | Resultado | Qué se hace |
+> |---|---|
+> | `requisitoRel` poblado | Se implementa F3 tal como está especificada. **Camino esperado** |
+> | `requisitoRel` nulo | El filtro `requisitoIngreso`/`activo` **no se puede aplicar sobre el payload**. Plan B: resolver la elegibilidad contra un catálogo local de requisitos de Guaraní, que hoy **no existe** en el core. Agrega un módulo de persistencia y sincronización: **hay que revisar el alcance del hito antes de arrancar** |
+> | Poblado de forma intermitente | Se trata como nulo por requisito (criterio 6): se excluye ese requisito, no la chequera |
+>
+> **Riesgo adicional, fuera de este repositorio:** el flujo son dos llamadas (`/create/personales` → `/create/preuniversitario`). El cliente recibe `PersonalesResponse` y debe reenviarlo. Si lo reconstruye en vez de reenviarlo, `personaRel` se pierde ahí y ningún test de core lo detecta.
+
+**Tests de `BeneficioPolicy`:**
+
+| # | Entrada | Esperado |
+|---|---|---|
+| 1 | Sin requisitos | `ZERO` |
+| 2 | Requisito sin beneficio configurado | `ZERO`, sin excepción |
+| 3 | Un requisito con 20 % | `20` |
+| 4 | Requisitos con 10 %, 30 % y 20 % | **`30`** — gana el máximo, no suma 60 |
+| 5 | El mismo requisito repetido | Igual que una sola vez (idempotencia de `MAX`) |
+| 6 | `requisitoIngreso = 'N'` | Excluido |
+| 7 | `activo = 'N'` | Excluido |
+| 8 | `requisitoRel` nulo | Excluido, con `log.warn` |
+| 9 | `'s'` minúscula en ambos flags | **Incluido** (case-insensitive) |
+| 10 | El de mayor porcentaje es de egreso; el menor es de ingreso | Gana el **menor** — el filtro corre **antes** que el máximo |
+| 11 | Listas nulas | `ZERO`, nunca `NullPointerException` |
+| 12 | Beneficio con `porcentajeBeneficio` nulo | `ZERO` para ese requisito (el `@Builder.Default` es `ZERO`, pero un registro viejo puede tener null) |
+
+El caso 10 es el que verifica que el orden de los dos pasos es el correcto. Invertirlo produce el resultado equivocado sin fallar ningún otro test.
+
+**100 % de ramas** — es una clase chica y pura.
+
+**c) Aplicación en la factory.** La factory recibe el porcentaje efectivo y lo aplica a **los tres tramos** con el mismo factor, redondeando a entero con `HALF_UP`:
+
+```java
+importeN = importeNLista.multiply(BigDecimal.ONE.subtract(
+               beneficio.divide(BigDecimal.valueOf(100))))
+           .setScale(0, RoundingMode.HALF_UP);
+```
+
+`importeNOriginal` recibe `importeNLista` **sin tocar**.
+
+Tests: 0 % → resultado **idéntico** a F1 (garantía de no regresión); 20 % sobre importes reales → valor exacto contra ejemplo firmado; porcentaje con decimales (ej. 33,33 %) → redondeo verificado; los tres tramos mantienen `importe1 ≤ importe2 ≤ importe3`; `importeNOriginal ≠ importeN` cuando hay beneficio; `importeNOriginal == importeN` cuando el beneficio es 0.
+
+**d) Degradación segura.** Si falla la resolución de beneficios, se crea la cuota **sin bonificación** y se loguea. Nunca se rompe la emisión de una chequera por un beneficio no resuelto. Test explícito.
+
+**e) Alcance del cableado.** Resuelto por (a.bis): la factory lee `chequeraSerie.getBecaPorcentaje()`. `SpoterService` construye series sin beca, así que queda excluido sin rama especial. Test que lo fija.
+
+**f) `ChequeraTotal` — el total debe coincidir con la suma de las cuotas.**
+
+Hoy `createTotals()` copia `LectivoTotal.getTotal()` sin descuento, mientras las cuotas sí lo tendrían. `ChequeraService.track():203-207` mete ambos en la misma fila de `ChequeraImpresionDetalle`, así que la chequera impresa mostraría total sin bonificar y cuotas bonificadas.
+
+**No aplicar el factor al total.** Bonificar `LectivoTotal.total` por separado no garantiza que coincida con la suma de las cuotas, porque cada cuota se redondea a entero de forma independiente:
+
+```
+Total lista $47.350, tres cuotas de $15.783,33, beneficio 30 %
+
+Factor al total:   47.350 × 0,70            = $33.145
+Suma de cuotas:    (15.783,33 × 0,70 → 11.048) × 3 = $33.144   ← no coinciden
+```
+
+**Calcular el total como la suma de las cuotas ya redondeadas.** Es lo que el sistema **ya hace** en otro momento del ciclo: `PagoService.calcularPagado():214` reasigna
+
+```java
+chequeraTotal.setTotal(chequeraCuotaService.calculateTotalCuotasActivas(...));
+```
+
+y `CalculateTotalCuotasActivasUseCaseImpl` suma `importe1` de las cuotas activas (`baja = 0`). O sea: el invariante `total = Σ importe1` ya existe en el sistema, pero se aplica recién con el primer pago, no al crear.
+
+**Esto además corrige un defecto latente previo a esta feature:** si `LectivoTotal.total` difiere de `Σ importe1` de las cuotas, el total cambia solo al registrarse el primer pago, sin que nadie lo note. Con beneficio aplicado a las cuotas y no al total, esa diferencia pasaría de sutil a enorme.
+
+**Cambio de orden en `PreuniversitarioChequeraDetailsCreator.create()`:**
+
+```java
+// antes
+createTotals(chequeraSerie);
+createAlternatives(chequeraSerie);
+createCuotas(chequeraSerie);
+
+// después
+createAlternatives(chequeraSerie);
+var cuotas = createCuotas(chequeraSerie);      // devuelve las cuotas guardadas
+createTotals(chequeraSerie, cuotas);           // agrupa por productoId y suma importe1
+```
+
+Agrupar en memoria por `productoId` evita una segunda consulta a la base. `createCuotas` pasa a devolver `List<ChequeraCuota>` en vez de `void`.
+
+**Semántica de "cuotas activas"** — idéntica a la que ya usa `CalculateTotalCuotasActivasUseCaseImpl`, para que el invariante sea el mismo en creación y en pago:
+
+- Se consulta `findAllByCuotasActivas(facultadId, tipoChequeraId, chequeraSerieId, productoId, alternativaId, (byte) 0)`, o sea **`baja = 0`**.
+- Se suma **`importe1`**, no `importe2` ni `importe3`.
+- Se crea **un `ChequeraTotal` por `productoId`**, sumando solo las cuotas de ese producto.
+- `pagado` inicializa en `BigDecimal.ZERO`, igual que hoy.
+
+**Tests:**
+- Beneficio 0 % → `total` igual a `Σ importe1`, y verificar si eso coincide o no con `LectivoTotal.total` (deja documentado el estado real del dato)
+- Beneficio 30 % con importes que produzcan resto de redondeo → `total == Σ importe1` **exacto**
+- Beneficio 100 % → `total = 0` y todas las cuotas en cero
+- Varios productos → un `ChequeraTotal` por `productoId`, cada uno sumando solo sus cuotas
+- Cuota con `baja = 1` → excluida del total, igual que en `calculateTotalCuotasActivas`
+- `pagado` sigue inicializando en `BigDecimal.ZERO`
+- Tras `PagoService.calcularPagado()`, el total **no cambia** (invariante ya consistente desde la creación)
+
+### Listo cuando
+Los tests de F1 siguen verdes con beneficio 0 %, los nuevos pasan, y `BeneficioPolicy` está al 100 % de ramas.
+
+---
+
+## F4 — Verificar el invariante de `FindAllInconsistenciasUseCaseImpl` `[ ]`
+
+La fase que evita que la feature dispare falsas alarmas en el detector de inconsistencias.
+
+### Por qué importa — verificado en código
+
+`FindAllInconsistenciasUseCaseImpl` marca una cuota como inconsistente si se cumple **cualquiera** de tres condiciones:
+
+| Chequeo | Condición que dispara la alarma |
+|---|---|
+| `vencimientosInvalidos` | `vencimiento1 > vencimiento2` o `vencimiento2 > vencimiento3` |
+| `importesInvalidos` | `importe1 > importe2` o `importe2 > importe3` |
+| `multiplicadoresInvalidos` | `importeNOriginal * 49 < importeN` para algún tramo |
+
+Consecuencias directas sobre F3:
+
+- **Si el beneficio se aplica a un solo tramo** (decisión 4), puede romperse la relación creciente `importe1 ≤ importe2 ≤ importe3` y disparar `importesInvalidos`. Bonificar solo `importe1` es seguro; bonificar solo `importe3` **no lo es**.
+- **`multiplicadoresInvalidos` es asimétrico**: solo detecta importes demasiado *grandes* respecto del original. Un beneficio que reduce `importeN` dejando `importeNOriginal` intacto **no lo dispara**. Esa asimetría es la razón por la que la decisión 3.5 es segura en ambas direcciones — pero hay que verificarlo, no asumirlo.
+- El chequeo desreferencia `importeNOriginal` sin control de nulo. Si F3 llegara a dejar algún original en nulo, esto es un `NullPointerException`.
+
+### Alcance
+
+`FindAllInconsistenciasUseCaseImplTest` con cuotas generadas por la factory de F3:
+
+1. Cuota con beneficio aplicado a todos los tramos → **no** es inconsistente
+2. Cuota con beneficio en un solo tramo → verificar contra la decisión 4 si corresponde alarma o no
+3. Cuota con beneficio 0 % → idéntica al comportamiento pre-feature
+4. Beneficio del 100 % (importes en cero) → verificar que `0 * 49 < 0` es falso y no dispara
+5. `importeNOriginal` nulo → hoy revienta; decidir si se blinda acá o se garantiza en F3 que nunca sea nulo
+6. Beneficio máximo posible → sigue dentro del margen del multiplicador 49
+
+Además, correr el endpoint `GET /chequeraCuota/inconsistencias/{desde}/{hasta}` sobre datos de staging con beneficios aplicados y confirmar que no aparecen falsos positivos.
+
+### Listo cuando
+Los seis casos pasan y la corrida sobre staging no reporta inconsistencias nuevas atribuibles al beneficio.
+
+---
+
+## F5 — Issue 2: proyección documental para `sender-service` `[ ]`
+
+**Depende del Issue 1 de cálculo desplegado.** Esta fase consume cuotas y porcentajes ya
+persistidos; no modifica elegibilidad, factor ni totales. Su objetivo es que la chequera
+impresa pueda mostrar precio de lista y precio con beneficio, incluso cuando el importe a
+cobrar sea cero.
+
+### Precondición — identificar el DTO exacto
+
+Verificado hoy: **`ChequeraCuotaResponse` y `ChequeraCuotaPagosDto` ya exponen `importe1/2/3Original`.** También los tienen las vistas `ChequeraCuotaDeuda.kt`, `CuotaDeuda.java`, `CuotaDeudaPayPerTic.java` y `ChequeraCuotaPersona.java`.
+
+Es decir: **el campo puede estar ya expuesto en el DTO correcto**, y la fase se reduciría a verificarlo y documentarlo. La relación con `sender-service` es por Feign (`ChequeraClient` → `tesoreria-sender-service` para `generatePdf`/`sendChequera`), así que sender consulta de vuelta a core por algún endpoint que hay que identificar.
+
+**Primer paso de la fase:** determinar qué endpoint de core consume `sender-service` para armar el PDF, y qué DTO devuelve. Recién ahí se sabe si hay que agregar el campo o solo verificarlo.
+
+### Alcance
+Según lo que arroje la verificación:
+- **Si el campo ya está**: test de contrato que lo fija, y nota en el roadmap. Fase de medio día.
+- **Si falta**: agregarlo al DTO y su mapper, con test de serialización JSON. Cambio **aditivo** → *minor* de SemVer, sin romper clientes.
+
+En ambos casos: confirmar con sender-service que el nombre del campo en el JSON coincide con lo que espera (`importe1Original` vs `importe_1_original` — hay precedente de `@JsonProperty` con snake_case en `DeudaExamenResponse`).
+
+### Listo cuando
+El JSON que recibe sender-service incluye precio de lista y precio bonificado, verificado con un test de contrato.
+
+---
+
+## F6 — Calidad dividida entre Issue 1 e Issue 2 `[ ]`
+
+El Issue 1 cubre controllers, cálculo, inconsistencias y JaCoCo. El Issue 2 agrega los
+tests de contrato Core → sender y las fixtures documentales 0/30/100.
+
+### Alcance
+
+**`GuaraniBeneficioControllerTest`** (`@WebMvcTest`) — **extiende** el archivo que ya creó F0 con sus casos de validación; no lo reemplaza. Cubrir los 5 endpoints bajo `/api/tesoreria/core/guaraniBeneficio`:
+- `GET /` lista completa
+- `GET /requisito/{requisito}` → 200, y **404** vía `ResponseStatusException` cuando no existe
+- `POST /requisitos` con lista de enteros → respuesta parcial cuando algunos requisitos no tienen beneficio
+- `POST /` alta
+- `PUT /requisito/{requisito}` actualización
+
+**`AlumnoGuaraniControllerTest`** — alta preuniversitaria con requisitos presentados; verificar que la respuesta refleja los importes bonificados.
+
+**`ChequeraCuotaControllerTest`** — acotado a lo que toca la feature:
+- `GET /chequera/{facultadId}/{tipoChequeraId}/{chequeraSerieId}/{alternativaId}` → importes bonificados y originales en el JSON
+- `GET /inconsistencias/{desde}/{hasta}` → sin falsos positivos (cierra el círculo con F4)
+- `GET /unique/...` → formato ISO 8601 de vencimientos
+
+**Regresión Issue 1**: alta de preuniversitario con beneficio → chequera creada → cuotas con
+importes correctos → sin inconsistencias → evento `send-chequera` publicado, también para
+100 %.
+
+**Regresión Issue 2**: el DTO/proyección que consulta sender-service contiene los precios de
+lista y bonificados, incluidas las filas en cero necesarias para el PDF.
+
+### Listo cuando
+Los cuatro grupos pasan y el JSON de cada endpoint queda documentado como ejemplo dentro del propio test.
+
+---
+
+## Dependencias entre fases
+
+```
+F0 ─────────────────────────────────> (independiente, desplegable solo)
+
+ISSUE 1: F1 ──> F2 ──> F3 ──> F4 ──> F6-Core
+
+ISSUE 2: (Issue 1 desplegado) ──> F5 ──> F6-integración
+
+F0 y F1 sin bloqueos — se pueden empezar hoy, en paralelo
+F3 requiere además validar el payload en staging
+F5 comienza sólo después del despliegue del Issue 1
+```
+
+Las seis decisiones de negocio y el rango `[0, 100]` están cerrados. Ver `decisiones.md`.
+
+## Riesgos
+
+| Riesgo | Mitigación |
+|---|---|
+| Las decisiones de negocio de F3 se demoran | F1 y F2 no dependen de ellas; se puede avanzar con esos hitos sin bloquear el cálculo |
+| El refactor de F2 cambia comportamiento en silencio | F1 es el contrato; ningún test de F1 puede tocarse en F2. El constructor posicional de 30+ argumentos es el punto exacto de riesgo |
+| El beneficio dispara falsas inconsistencias | F4 existe para eso, y ya está identificada la condición precisa (`importe1 ≤ importe2 ≤ importe3`) que puede romperse |
+| Aplicar beneficios altera chequeras ya emitidas | La factory solo interviene en la **creación**. Verificar en staging antes de main |
+| `SpoterService` hereda el beneficio sin quererlo | F3(e) lo define explícitamente: el porcentaje entra por parámetro y Spoter pasa `ZERO` si corresponde |
+| F5 resulta ser trabajo nulo | Es un desenlace posible y bueno: se convierte en verificación documentada |
+| **`requisitoRel` viene nulo desde Guaraní** y el filtro de ingreso anula todos los beneficios | Verificar contra datos reales **antes** de cerrar F3. Es el riesgo más concreto de la feature: falla cerrado y en silencio, sin errores, solo cuotas sin descuento |
+| Un beneficio cargado sobre un requisito de egreso o dado de baja | F0 valida el rango del porcentaje; F3(b) filtra `requisitoIngreso`/`activo`. Son las dos barreras del dominio |
+
+---
+
+## Documentos relacionados
+
+- `../../mission.md` — propósito, audiencia y principios
+- `../../tech-stack.md` — stack y huecos declarados (H1–H8, documentados y **no priorizados**)
+- `decisiones.md` — decisiones de negocio D1–D8 y verificaciones

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -36,9 +36,9 @@ Guaraní es la autoridad académica; el core traduce esa realidad a consecuencia
 - Habilitación para rendir examen en función de la deuda (`DeudaExamen`, `TesoreriaEstado`).
 - Flujo preuniversitario completo: de un alumno en Guaraní a una chequera emitida y enviada.
 
-> **Estado real al 2026-08-19:** el punto de *beneficios por requisitos* está **incompleto**. `GuaraniBeneficio` existe como módulo hexagonal con persistencia y API REST, pero **ningún otro componente del servicio lo consume**: `PreuniversitarioChequeraDetailsCreator.createCuotas()` y `SpoterService` (líneas 180-206) copian importes desde `LectivoCuota` sin aplicar bonificación alguna, con código casi idéntico entre sí.
+> **Estado local al 2026-08-20:** el camino preuniversitario resuelve el beneficio máximo elegible a partir de los requisitos de ingreso activos, persiste el porcentaje en la serie y lo aplica a los tres tramos de cada cuota, preservando los importes originales. `PreuniversitarioChequeraDetailsCreator` y `SpoterService` comparten la factory de cuotas; Spoter mantiene beneficio 0 %.
 >
-> **Cerrar esa brecha en el camino preuniversitario es el trabajo activo** (ver `features/beneficio-requisitos-ingreso/spec.md`). El camino de recálculo por política arancelaria (`RecalculateCuotaByUniqueIndexUseCaseImpl`) y el mecanismo paralelo de `ArancelPorcentaje` quedan como deuda conocida y explícitamente fuera de alcance por ahora.
+> La validación con datos reales de staging, la matriz de emisión 0 %/parcial/100 % y la comunicación del beneficio al alumno permanecen como trabajo pendiente. El camino de recálculo por política arancelaria (`RecalculateCuotaByUniqueIndexUseCaseImpl`) y el mecanismo paralelo de `ArancelPorcentaje` siguen como deuda conocida y explícitamente fuera de alcance.
 
 ---
 

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -1,0 +1,121 @@
+# Misión — UM.tesoreria.core-service
+
+> Documento de constitución. Define **qué es** este servicio y **para quién**.
+> No describe cómo está implementado (ver `tech-stack.md`) ni en qué orden avanzamos (ver `roadmap.md`).
+>
+> Versión del servicio al redactar: **4.1.1** · Fecha: **2026-08-19**
+
+---
+
+## 1. Propósito
+
+**El core de tesorería es la fuente única de verdad transaccional de la Universidad de Mendoza para todo lo que involucra dinero de alumnos, y el puente formal entre el sistema académico Guaraní y esa realidad económica.**
+
+Se desdobla en dos responsabilidades inseparables:
+
+### 1.1 Núcleo transaccional de tesorería
+
+El servicio es dueño del modelo de dominio del dinero académico y administrativo:
+
+- **Chequeras**: series, tipos, clases, alternativas, productos, totales, bajas y reemplazos.
+- **Cuotas**: importes en tres tramos con sus vencimientos (`importe1/2/3`, `vencimiento1/2/3`), importes originales, estado de pago, compensación y recálculo por política arancelaria.
+- **Pagos**: registración, imputación, tipos de pago, conciliación con facturación electrónica y con MercadoPago.
+- **Deuda**: cálculo de deuda por persona, por lectivo y por producto, incluyendo la deuda que habilita o bloquea actos académicos.
+- **Contabilidad y compras asociadas**: cuentas, asientos, movimientos, proveedores, comprobantes, órdenes de pago.
+
+Ninguna otra pieza del ecosistema tiene autoridad sobre estos datos. Si un importe, un vencimiento o un estado de pago difiere entre dos sistemas, **el core tiene razón**.
+
+### 1.2 Puente Guaraní ↔ Tesorería
+
+Guaraní es la autoridad académica; el core traduce esa realidad a consecuencias económicas:
+
+- Alta de alumnos y datos personales provenientes de Guaraní (`AlumnoGuarani`, `PersonalesResultado`).
+- Mapeo de propuestas académicas a tipos de chequera (`GuaraniPropuestaTipoChequera`).
+- Ubicaciones y responsables académicos (`GuaraniUbicacion`, `Facultad.guaraniResponsableAcademica`).
+- **Beneficios por requisitos de ingreso** (`GuaraniBeneficio`): los requisitos que un ingresante presenta en Guaraní deben traducirse en un porcentaje de bonificación sobre el arancel.
+- Habilitación para rendir examen en función de la deuda (`DeudaExamen`, `TesoreriaEstado`).
+- Flujo preuniversitario completo: de un alumno en Guaraní a una chequera emitida y enviada.
+
+> **Estado real al 2026-08-19:** el punto de *beneficios por requisitos* está **incompleto**. `GuaraniBeneficio` existe como módulo hexagonal con persistencia y API REST, pero **ningún otro componente del servicio lo consume**: `PreuniversitarioChequeraDetailsCreator.createCuotas()` y `SpoterService` (líneas 180-206) copian importes desde `LectivoCuota` sin aplicar bonificación alguna, con código casi idéntico entre sí.
+>
+> **Cerrar esa brecha en el camino preuniversitario es el trabajo activo** (ver `features/beneficio-requisitos-ingreso/spec.md`). El camino de recálculo por política arancelaria (`RecalculateCuotaByUniqueIndexUseCaseImpl`) y el mecanismo paralelo de `ArancelPorcentaje` quedan como deuda conocida y explícitamente fuera de alcance por ahora.
+
+---
+
+## 2. Lo que este servicio NO es
+
+Delimitar importa tanto como declarar. El core **no**:
+
+- Expone interfaz de usuario. No hay pantallas, no hay decisiones de UX acá.
+- Es dueño del dato académico. Guaraní lo es; el core lo consume y lo refleja.
+- Toma decisiones de negocio de política arancelaria por sí mismo. Ejecuta las políticas que tesorería define; no las inventa.
+- Es un gateway de pagos. Integra con MercadoPago, pero el procesamiento del pago ocurre afuera.
+- Reemplaza a `facultad-service` ni a `umhub`. Colabora con ellos vía REST.
+
+---
+
+## 3. Audiencia
+
+El servicio no tiene usuarios directos, pero sí destinatarios claros. Cada decisión de diseño debe poder justificarse ante al menos uno de estos tres.
+
+### 3.1 Otros microservicios del ecosistema UM — *audiencia primaria*
+
+Consumidores directos de la API REST bajo `/api/tesoreria/core/**`:
+
+- `facultad-service` (consumido en sentido inverso por 19 consumers `*FacultadConsumer` vía `FacultadUrlResolver`)
+- `umhub` (campañas, reserva de vacante)
+- Aplicaciones web y móviles de la universidad
+
+**Qué significa para nosotros:** el contrato REST es un compromiso público. Romperlo es un evento *major* de SemVer, no un detalle de implementación — como ocurrió en la 4.0.0 al cambiar la respuesta de `POST /guarani/alumno/create/personales` y eliminar un endpoint. Las rutas duplicadas que existen (`/documento` junto a `/api/tesoreria/core/documento`) son deuda intencional para no romper clientes, y se mantienen hasta que se verifique que nadie las usa.
+
+### 3.2 Personal de tesorería y administración de las facultades
+
+No tocan la API, pero son la razón por la que existe casi toda la lógica de negocio: recálculo de cuotas vencidas, política arancelaria, emisión e impresión de chequeras, altas y habilitaciones manuales, conciliación.
+
+**Qué significa para nosotros:** el sistema debe dejar lugar al criterio humano en vez de imponerse. Por eso existen el flag `manual` en `TesoreriaEstado` (habilitar a un alumno a rendir aunque tenga deuda) y `ChequeraCuota.manual`. Cuando una regla automática y una decisión manual chocan, **gana la decisión manual** — y esa regla vale como invariante de diseño.
+
+### 3.3 El equipo de desarrollo UM-services
+
+Quienes mantienen y extienden el core.
+
+**Qué significa para nosotros:** invertir en tests, en documentación (diagramas Mermaid por módulo, OpenAPI) y en cerrar la migración hexagonal es trabajo legítimo del roadmap, con dueño explícito, y no un lujo que se posterga cuando aprieta el calendario.
+
+---
+
+## 4. Principios que gobiernan las decisiones
+
+Cuando haya que elegir entre dos caminos, estos principios desempatan. Están ordenados: el de arriba gana.
+
+1. **La corrección del dinero está por encima de todo.** Un importe mal calculado le cuesta plata a un alumno o a la universidad. Ante la duda entre rendimiento y exactitud, gana exactitud. Todo cálculo monetario usa `BigDecimal` con escala y redondeo explícitos — nunca `double`, nunca redondeo implícito.
+
+2. **Ninguna regla de precios sin test.** Toda lógica que determine un importe, un descuento, un vencimiento o un estado de deuda entra acompañada de pruebas que cubran sus ramas. Es la regla que rescata al servicio de su hueco de cobertura actual, y no admite excepción "por ser un cambio chico".
+
+3. **El dominio no sabe de infraestructura.** Los modelos de `domain/model` no conocen JPA, HTTP ni Jackson. Los casos de uso dependen de puertos, no de adaptadores. La arquitectura hexagonal existente es el estándar; el código legacy es la excepción a extinguir, no un patrón alternativo válido.
+
+4. **El contrato REST es un compromiso.** Cambios compatibles → *minor*. Cambios que rompen un cliente → *major*, documentado en el README con la justificación verificada en código.
+
+5. **El criterio humano prevalece sobre la automatización.** Las habilitaciones y ajustes manuales de tesorería no se pisan con recálculos automáticos.
+
+6. **Verificar antes de afirmar.** La convención del README —cada nota de versión respaldada por `git diff`, código y `pom.xml`— se extiende a todo el proyecto. Nada se declara hecho sin evidencia.
+
+---
+
+## 5. Cómo medimos el éxito
+
+| Dimensión | Cómo se ve el éxito |
+|---|---|
+| Corrección | Cero incidentes de importe o deuda mal calculados que lleguen a un alumno |
+| Confianza | Cobertura real sobre los caminos de cálculo de dinero; hoy es el punto más débil |
+| Contratos | Los servicios consumidores no se rompen entre versiones *minor* |
+| Coherencia | Un solo modelo por entidad de negocio: hexagonal, sin gemelo legacy |
+| Trazabilidad | Un beneficio, un descuento o un recálculo se puede explicar y reproducir a partir de los datos |
+
+---
+
+## 6. Documentos relacionados
+
+- `tech-stack.md` — stack, restricciones y huecos declarados H1–H8
+- `roadmap.md` — en qué orden avanza el servicio completo
+- `features/beneficio-requisitos-ingreso/spec.md` — feature activa
+- `../docs/*.mmd` — diagramas Mermaid por módulo hexagonal
+- `../README.md` — historial de versiones verificado en código

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -1,0 +1,106 @@
+# Roadmap — UM.tesoreria.core-service
+
+> Documento de constitución. Define **en qué orden avanza el servicio completo**.
+> No es el plan de una feature: cada feature activa tiene su propia spec bajo `features/`.
+>
+> Versión del servicio al redactar: **4.1.1** · Fecha: **2026-08-19**
+
+---
+
+## Cómo se organiza el trabajo
+
+```
+specs/
+  mission.md                          qué es el servicio y para quién
+  tech-stack.md                       con qué está construido y qué huecos tiene (H1–H8)
+  roadmap.md                          ESTE archivo: en qué orden avanzamos
+  features/
+    <nombre-feature>/
+      spec.md                         la feature: contexto, criterios, fases, tests
+      decisiones.md                   decisiones de negocio con su justificación
+```
+
+**Una feature entra al roadmap como una línea**, no como un plan desarrollado. El detalle vive en `features/<nombre>/spec.md`. Así el roadmap se lee de una sentada y no envejece cada vez que cambia una fase.
+
+**Convención:** `[ ]` pendiente · `[~]` en curso · `[x]` hecho · `🔒` bloqueado.
+
+---
+
+## Ahora — trabajo activo
+
+### R1 `[~]` Beneficio por requisitos de ingreso en cuotas preuniversitarias
+
+**Spec:** `features/beneficio-requisitos-ingreso/spec.md` · **Decisiones:** `features/beneficio-requisitos-ingreso/decisiones.md`
+· **Issues:** [#338 cálculo y persistencia](https://github.com/UM-services/UM.tesoreria.core-service/issues/338) → correo/PDF con beneficios
+
+Los requisitos de ingreso que un aspirante presenta en Guaraní deben traducirse en un porcentaje de bonificación sobre el arancel. Hoy el porcentaje se puede cargar pero no llega a ningún importe.
+
+Cierra parcialmente el hueco **H4** de `tech-stack.md`. Se trabaja en dos issues secuenciales:
+primero F0–F4 y calidad de Core (cálculo); después F5/F7 y la integración documental con
+sender-service (correo/PDF). El segundo no puede comenzar hasta que el cálculo esté desplegado.
+
+**Bloqueo previo a F3:** verificar contra un alta real en staging si Guaraní popula `RequisitoPresentadoGuarani.requisitoRel`. Si viene nulo, el filtro de elegibilidad cambia de diseño.
+
+---
+
+## Después — sin fecha, ordenado por riesgo
+
+Lo que sigue sale de los huecos declarados en `tech-stack.md` §6. **No está comprometido**: es la cola de la que se elige cuando R1 termine.
+
+### R2 `[ ]` Extender la red de tests al resto del cálculo de dinero
+
+**Hueco:** H1 — 19 archivos de test contra ~1476 de producción, y cero cobertura sobre los caminos que deciden cuánta plata debe un alumno.
+
+R1 deja cubierto su propio camino y un umbral de JaCoCo acotado a tres paquetes. R2 extiende el mismo método a lo que quedó afuera: `ChequeraCuotaService`, `LectivoCuotaService`, `GetDeudaExamenUseCaseImpl`, `calculateDeuda` y su ejecución paralela con `CompletableFuture`, `calculateCodigoBarras`, `ChequeraTotal` y `ChequeraPago`.
+
+**Por qué va primero de los pendientes:** contradice de frente el principio 2 de `mission.md` ("ninguna regla de precios sin test"), y sin esta red cualquier trabajo de R3 o R4 es una apuesta.
+
+### R3 `[ ]` Esquema de base de datos versionado
+
+**Hueco:** H3 — no hay Flyway ni Liquibase; el esquema MySQL vive fuera del repositorio y cada módulo nuevo implicó un `CREATE TABLE` manual.
+
+Baseline del esquema actual, migración de los tests de H2 con `ddl-auto` a Flyway sobre un MySQL real, y regla de proceso: todo módulo nuevo trae su migración versionada.
+
+**Va después de R2** porque migrar esquema sin tests que cubran la persistencia es apostar dos veces.
+
+### R4 `[ ]` Cierre del legacy
+
+**Hueco:** H2 — ~391 archivos Java legacy más 60 Kotlin conviviendo con 1085 hexagonales.
+
+Un módulo por PR, de menor a mayor acoplamiento. El orden lo sugiere lo que hoy contamina código hexagonal: `ChequeraAlternativa` y `LectivoAlternativa` (Kotlin) y `LectivoTotal`, que `PreuniversitarioChequeraDetailsCreator` importa directamente. Después conciliación bancaria, impresión y reemplazos. Cierra con eliminar `core/kotlin/` y sacar Kotlin del `pom.xml`.
+
+**Regla:** ningún módulo migra sin tests. Migrar sin red es cambiar deuda de lugar.
+
+### R5 `[ ]` Coherencia de los mecanismos de descuento
+
+**Hueco:** H4, la parte que R1 **no** cierra.
+
+Quedan dos caminos de determinación de importes que no conocen beneficios: `RecalculateCuotaByUniqueIndexUseCaseImpl` (recálculo por política arancelaria) y `ArancelPorcentaje`, que sigue sin consumidores. Después de R1 el sistema tiene un descuento que se aplica al crear y se ignora al recalcular. Hay que unificarlo o declarar explícitamente que son mundos separados.
+
+### R6 `[ ]` Robustez del código de barras
+
+**Hueco:** H8 — `calculateCodigoBarras` genera códigos corruptos en silencio: diferencias negativas que solo se loguean en `debug`, sin control de desborde de los campos de 5 y 7 dígitos, y dos modos de redondeo distintos en la misma función.
+
+R1 lo evita por construcción pero no lo corrige. Cualquier camino que modifique importes de a un tramo lo sigue exponiendo, en particular `RecalculateCuotaByUniqueIndexUseCaseImpl`, que escribe solo `importe3`.
+
+### R7 `[ ]` Observabilidad de negocio
+
+**Hueco:** H5 — hay Actuator y `micrometer-registry-prometheus`, pero no hay métricas propias ni tracing. El síntoma está en el historial: se agregan `log.debug` ad hoc para diagnosticar producción.
+
+Métricas de negocio (recálculos ejecutados, beneficios aplicados, importe bonificado total), logging estructurado en reemplazo de los debug ad hoc, y alertas sobre fallos de la integración con Guaraní.
+
+---
+
+## Fuera del roadmap
+
+| Tema | Motivo |
+|---|---|
+| Sistemas heredados en VB6 | Externo al servicio. Ver H6 |
+
+---
+
+## Documentos relacionados
+
+- `mission.md` — propósito, audiencia y principios
+- `tech-stack.md` — stack, restricciones y huecos declarados H1–H8
+- `features/beneficio-requisitos-ingreso/spec.md` — feature activa

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -154,17 +154,17 @@ Deuda reconocida y aceptada, no descubrimientos.
 
 **El costo concreto:** cada módulo hexagonal nuevo implicó un `CREATE TABLE` manual y no versionado (`guarani_beneficio`, `guarani_ubicacion`, `guarani_propuesta_tipo_chequera`). No hay forma de reconstruir un ambiente desde cero ni de auditar cuándo cambió una columna. Los tests con H2 dependen de `ddl-auto` y de desactivar la integridad referencial, lo que los aleja del comportamiento real de MySQL.
 
-### H4 — Beneficios de Guaraní sin cablear  ▲ *en curso — es la feature activa*
+### H4 — Beneficios de Guaraní cableados, con validación externa pendiente
 
-**Evidencia verificada:** `GuaraniBeneficio` (`requisito` → `porcentajeBeneficio`) tiene módulo hexagonal completo —dominio, 5 casos de uso, adaptador JPA sobre `guarani_beneficio`, controller con 5 endpoints— pero **ninguna clase fuera de su propio paquete lo referencia**.
+**Evidencia local:** `GuaraniBeneficio` (`requisito` → `porcentajeBeneficio`) ya es consumido por el flujo preuniversitario. `CreatePreuniversitarioUseCaseImpl` transporta los requisitos presentados; `PreuniversitarioChequeraService` consulta los beneficios y `BeneficioPolicy` elige el porcentaje máximo de los requisitos de ingreso activos. La serie persiste `becaPorcentaje`.
 
-La cadena está cortada en tres puntos:
+La creación de cuotas quedó unificada en `ChequeraCuotaFactory`:
 
-1. `PersonaGuarani.requisitosPresentados` (`List<RequisitoPresentadoGuarani>`) solo entra por `AlumnoGuaraniRequest`; no existe caso de uso que consulte los requisitos vigentes de una persona.
-2. `PreuniversitarioChequeraDetailsCreator.createCuotas()` copia `importe1/2/3` desde `LectivoCuota` tal cual, sin aplicar bonificación. Además fija `importeN` e `importeNOriginal` con el **mismo** valor.
-3. `SpoterService` (líneas 180-206) duplica ese bloque casi literalmente, con el mismo problema.
+1. Conserva `importe1/2/3Original` como importe de lista y aplica el porcentaje a los tres tramos con redondeo `HALF_UP`.
+2. `PreuniversitarioChequeraDetailsCreator` recalcula los totales desde las cuotas activas; conserva la fila en cero cuando `lectivo_total` define un producto sin cuotas para la alternativa elegida.
+3. `SpoterService` consume la misma factory con beneficio 0 %, por lo que conserva sus importes de lista y elimina la duplicación anterior.
 
-**En alcance de `features/beneficio-requisitos-ingreso/spec.md`:** los puntos 1 y 2, más la extracción de una `ChequeraCuotaFactory` compartida que elimina la duplicación del punto 3.
+**Pendiente de validación en `features/beneficio-requisitos-ingreso/spec.md`:** payload real de staging con `requisitoRel`, matriz de emisión 0 %/parcial/100 %, endpoint de inconsistencias sobre chequeras bonificadas y conciliación de datos históricos.
 
 **Fuera de alcance, se mantiene como deuda:**
 
@@ -172,7 +172,7 @@ La cadena está cortada en tres puntos:
 - **`ArancelPorcentaje`** (`aranceltipoId` + `productoId` → `porcentaje`) sufre exactamente lo mismo: `ChequeraCuota.arancelTipoId` se persiste, pero `ArancelPorcentajeService` no tiene consumidores fuera de su paquete. Quedan **dos mecanismos de descuento**, y su relación entre sí sigue sin definir.
 - **`SpoterService` más allá de consumir la factory**: su migración a hexagonal no entra.
 
-**Interacción crítica con `FindAllInconsistenciasUseCaseImpl`:** ese caso de uso marca una cuota como inconsistente si `importe1 > importe2` o `importe2 > importe3`, y si `importeNOriginal * 49 < importeN`. Aplicar el beneficio a un solo tramo puede romper la relación creciente y disparar falsas alarmas. El segundo chequeo es asimétrico —solo detecta importes demasiado grandes—, así que reducir `importeN` dejando el original intacto no lo dispara. Está cubierto por la fase F4 del roadmap.
+**Interacción con `FindAllInconsistenciasUseCaseImpl`:** el caso de uso reconoce las cuotas bonificadas y trata los importes o vencimientos nulos como inconsistencias en vez de abortar. La validación con chequeras reales bonificadas permanece pendiente en la fase F4 del roadmap.
 
 ### H5 — Observabilidad instrumentada pero no explotada
 

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -1,0 +1,223 @@
+# Stack Técnico — UM.tesoreria.core-service
+
+> Documento de constitución. Define **con qué construimos**, **qué reglas rigen** ese stack y **qué huecos reconocemos**.
+>
+> Versión del servicio al redactar: **4.1.1** · Fecha: **2026-08-19**
+> Todo lo listado está verificado en `pom.xml`, `Dockerfile`, `.github/workflows/` y el árbol de fuentes.
+
+---
+
+## 1. Plataforma
+
+| Pieza | Versión | Nota |
+|---|---|---|
+| Java | 25 | `<java.version>` en `pom.xml` |
+| Kotlin | 2.4.10 | Solo legacy en extinción — **no se escribe Kotlin nuevo** |
+| Spring Boot | 4.1.0 | Parent POM |
+| Spring Cloud | 2025.1.2 | BOM |
+| Maven | 3.8.8+ | |
+| MySQL Connector/J | 26.7.0 | Runtime |
+| Docker | — | Imagen JVM publicada en Docker Hub |
+
+## 2. Dependencias principales
+
+**Web y API**
+`spring-boot-starter-web` · `spring-boot-starter-webflux` · `spring-boot-starter-validation` · `springdoc-openapi-starter-webmvc-ui` 3.1.0
+
+**Persistencia**
+`spring-boot-starter-data-jpa` · `spring-boot-starter-jdbc` · `mysql-connector-j` 26.7.0
+
+**Ecosistema distribuido**
+`spring-cloud-starter-consul-discovery` (service discovery) · `spring-cloud-starter-openfeign` + `feign-hc5` · `spring-cloud-starter-bootstrap` · `spring-kafka` · `RestClient` compartido vía `RestClientConfig` (read timeout 15 s)
+
+**Observabilidad**
+`spring-boot-starter-actuator` · `micrometer-registry-prometheus` · logging con `@Slf4j`
+
+**Cache**
+`spring-boot-starter-cache` + `caffeine`
+
+**Utilidades**
+`lombok` 1.18.38 · `modelmapper` 3.2.6 · `guava` 33.6.0-jre · `jackson-datatype-jsr310` · `json-path` 3.0.0 · `commons-fileupload` 1.6.0
+
+**Reportes y archivos**
+`poi` / `poi-ooxml` 5.5.1 (Excel) · `openpdf` 3.0.5 (PDF)
+
+**Mail**
+`spring-boot-starter-mail`
+
+**Testing**
+`spring-boot-starter-test` (JUnit 5 + Mockito + AssertJ) · `spring-boot-starter-data-jpa-test` · `spring-boot-starter-webmvc-test` · `h2` (con `INIT=SET REFERENTIAL_INTEGRITY FALSE` en `src/test/resources/application.yml`)
+
+**Calidad**
+`jacoco-maven-plugin` 0.8.13 · SonarCloud (`UM-services_UM.tesoreria.core-service`)
+
+## 3. CI/CD
+
+Cuatro workflows en `.github/workflows/`:
+
+| Workflow | Disparador | Qué hace |
+|---|---|---|
+| `maven.yml` | push/PR a `main` | `mvn -B verify` + análisis SonarCloud; en push a `main` construye y publica la imagen JVM |
+| `deploy-develop.yml` | push a `develop` | Verifica, construye, publica y despliega en develop |
+| `deploy-staging.yml` | staging | Verifica, construye, publica y despliega en staging |
+| `generate-docs.yml` | — | Valida los diagramas Mermaid y publica en GitHub Pages |
+
+Ramas: `develop` → `staging` → `main`. Versionado SemVer en `pom.xml`, con nota de versión verificada en `../README.md`.
+
+---
+
+## 4. Arquitectura
+
+**Hexagonal (puertos y adaptadores)** es el estándar. Cada módulo bajo `src/main/java/um/tesoreria/core/hexagonal/<contexto>/<modulo>/` sigue esta estructura, sin excepciones:
+
+```
+domain/
+  model/                    # POJOs puros: sin JPA, sin Jackson, sin Spring
+  ports/in/                 # Un caso de uso por interfaz
+  ports/out/                # Contratos de repositorio
+application/
+  usecases/                 # *UseCaseImpl — la lógica de negocio vive acá
+  service/                  # Fachada que delega a los casos de uso
+  exception/                # <Modulo>Exception
+infrastructure/
+  persistence/
+    entity/                 # *Entity JPA
+    repository/             # Jpa*Repository (Spring Data)
+    adapter/                # Jpa*RepositoryAdapter implementa el puerto out
+    mapper/                 # entidad ↔ dominio
+  web/
+    controller/             # REST
+    dto/                    # *Request / *Response
+    mapper/                 # *DtoMapper: DTO ↔ dominio
+```
+
+Contextos existentes: `auth`, `chequera`, `compras`, `comprobante`, `contable`, `contratos`, `dependencias`, `extern`, `guarani`, `lectivo`, `matriculacionContext`, `mercadoPagoContext`, `personas`, `setup`, `track`, `ubicacionArticulo`, `umhub`, `usuario`.
+
+### Reglas de arquitectura — no negociables
+
+1. `domain/model` no importa `jakarta.persistence`, `org.springframework` ni tipos HTTP. La única anotación tolerada es `@JsonFormat` en campos de fecha (deuda conocida, ver §6).
+2. Los casos de uso dependen de puertos, nunca de adaptadores ni de `Jpa*Repository`.
+3. Inyección **por constructor** con `@RequiredArgsConstructor`. `@Autowired` en campos está prohibido en código nuevo (migración ya hecha en ~80 controllers y ~70 services en la 3.46.0).
+4. Un caso de uso, una interfaz, un método. Nada de interfaces "de conveniencia" con cinco operaciones.
+5. Los controllers devuelven `ResponseEntity` y traducen las excepciones de dominio a `ResponseStatusException`.
+6. Todo módulo nuevo trae su diagrama `docs/hexagonal-<modulo>.mmd`, registrado en `docs/script.js` y validado por `generate-docs.yml`.
+7. Dinero siempre en `BigDecimal`, con escala y redondeo explícitos.
+
+---
+
+## 5. Convenciones
+
+- Rutas REST bajo `/api/tesoreria/core/**`. Las rutas cortas heredadas (ej. `/documento`) se conservan solo por compatibilidad de clientes.
+- Nomenclatura: `*UseCase` / `*UseCaseImpl` / `*Service` / `*Repository` / `*Entity` / `*Mapper` / `*DtoMapper` / `*Request` / `*Response` / `*Exception`. Las interfaces **no** llevan prefijo `I`.
+- Modelos de dominio: `@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor`; DTOs con `@Getter`/`@Setter` (no `@Data`).
+- Serialización de logs vía la interfaz `Jsonifyable` (`jsonify()`), no concatenación manual.
+- Fechas en la API: ISO 8601 con offset (`yyyy-MM-dd'T'HH:mm:ssXX`). Fechas de negocio con `OffsetDateTime`; utilidades horarias de Argentina en `Tool` (`dateAbsoluteArgentina()`, `firstTime()`).
+
+---
+
+## 6. Huecos declarados
+
+Deuda reconocida y aceptada, no descubrimientos.
+
+> **Estos huecos están declarados acá; el orden en que se atacan vive en `roadmap.md`.** La feature activa (`features/beneficio-requisitos-ingreso/spec.md`) solo cierra parcialmente H4. El resto figura en el roadmap como cola priorizada por riesgo (R2–R7), **no como trabajo comprometido**.
+>
+> Una excepción al criterio de "deuda pendiente":
+> - **H4** es el hueco que la feature en curso cierra parcialmente.
+
+### H1 — Cobertura de tests crítica
+
+**Evidencia:** 19 archivos de test contra ~1476 archivos de producción en `src/main/java`. La cobertura existente está concentrada casi por completo en un solo módulo (`lectivoTotalImputacion`, 10 de los 19), más `auth`, `tesoreriaEstado`, `persona` y `preuniversitario`.
+
+**Agravante:** `jacoco-maven-plugin` está configurado con `prepare-agent` y `report`, pero **sin goal `check` ni `<rules>`**. Nada rompe el build por cobertura insuficiente; SonarCloud reporta pero no bloquea.
+
+**Dónde duele más:** ningún test cubre hoy `RecalculateCuotaByUniqueIndexUseCaseImpl`, `ChequeraCuotaService`, `LectivoCuotaService`, `GetDeudaExamenUseCaseImpl` ni `calculateDeuda`. Es decir: **la lógica que decide cuánta plata debe un alumno no tiene red de seguridad**. Contradice de frente el principio 2 de `mission.md`.
+
+### H2 — Coexistencia legacy / doble modelo
+
+**Evidencia:** conviviendo con 1085 archivos hexagonales quedan
+
+| Paquete legacy | Archivos |
+|---|---|
+| `core/service/` | 105 |
+| `core/repository/` | 84 |
+| `core/model/` | 74 |
+| `core/controller/` | 68 |
+| `core/exception/` | 62 |
+| `core/kotlin/` (model + repository, Kotlin) | 60 |
+| `core/extern/` | 36 |
+
+**El costo concreto:** la misma entidad puede existir dos veces con reglas distintas, y hay que saber cuál manda. Ya se filtra hacia adentro del código nuevo — `PreuniversitarioChequeraDetailsCreator` (hexagonal) importa `um.tesoreria.core.kotlin.model.ChequeraAlternativa`, `LectivoAlternativa`, `um.tesoreria.core.model.LectivoTotal` y tres services legacy.
+
+### H3 — Sin gestión de esquema de base de datos
+
+**Evidencia:** no hay Flyway ni Liquibase en `pom.xml`. El esquema MySQL vive fuera del repositorio.
+
+**El costo concreto:** cada módulo hexagonal nuevo implicó un `CREATE TABLE` manual y no versionado (`guarani_beneficio`, `guarani_ubicacion`, `guarani_propuesta_tipo_chequera`). No hay forma de reconstruir un ambiente desde cero ni de auditar cuándo cambió una columna. Los tests con H2 dependen de `ddl-auto` y de desactivar la integridad referencial, lo que los aleja del comportamiento real de MySQL.
+
+### H4 — Beneficios de Guaraní sin cablear  ▲ *en curso — es la feature activa*
+
+**Evidencia verificada:** `GuaraniBeneficio` (`requisito` → `porcentajeBeneficio`) tiene módulo hexagonal completo —dominio, 5 casos de uso, adaptador JPA sobre `guarani_beneficio`, controller con 5 endpoints— pero **ninguna clase fuera de su propio paquete lo referencia**.
+
+La cadena está cortada en tres puntos:
+
+1. `PersonaGuarani.requisitosPresentados` (`List<RequisitoPresentadoGuarani>`) solo entra por `AlumnoGuaraniRequest`; no existe caso de uso que consulte los requisitos vigentes de una persona.
+2. `PreuniversitarioChequeraDetailsCreator.createCuotas()` copia `importe1/2/3` desde `LectivoCuota` tal cual, sin aplicar bonificación. Además fija `importeN` e `importeNOriginal` con el **mismo** valor.
+3. `SpoterService` (líneas 180-206) duplica ese bloque casi literalmente, con el mismo problema.
+
+**En alcance de `features/beneficio-requisitos-ingreso/spec.md`:** los puntos 1 y 2, más la extracción de una `ChequeraCuotaFactory` compartida que elimina la duplicación del punto 3.
+
+**Fuera de alcance, se mantiene como deuda:**
+
+- **`RecalculateCuotaByUniqueIndexUseCaseImpl`** recalcula `importe3` y `vencimiento3` **sin conocer beneficios**: compara la cuota en revisión contra una de referencia y toma el mayor. Es un segundo camino de determinación de importes que quedará inconsistente con el de creación hasta que se cablee.
+- **`ArancelPorcentaje`** (`aranceltipoId` + `productoId` → `porcentaje`) sufre exactamente lo mismo: `ChequeraCuota.arancelTipoId` se persiste, pero `ArancelPorcentajeService` no tiene consumidores fuera de su paquete. Quedan **dos mecanismos de descuento**, y su relación entre sí sigue sin definir.
+- **`SpoterService` más allá de consumir la factory**: su migración a hexagonal no entra.
+
+**Interacción crítica con `FindAllInconsistenciasUseCaseImpl`:** ese caso de uso marca una cuota como inconsistente si `importe1 > importe2` o `importe2 > importe3`, y si `importeNOriginal * 49 < importeN`. Aplicar el beneficio a un solo tramo puede romper la relación creciente y disparar falsas alarmas. El segundo chequeo es asimétrico —solo detecta importes demasiado grandes—, así que reducir `importeN` dejando el original intacto no lo dispara. Está cubierto por la fase F4 del roadmap.
+
+### H5 — Observabilidad instrumentada pero no explotada
+
+`micrometer-registry-prometheus` y Actuator están presentes, pero no hay métricas de negocio propias ni tracing distribuido. El síntoma es visible en el historial: se agregan `log.debug` ad hoc para diagnosticar (3.42.1, 3.49.0), lo que sugiere que las métricas existentes no alcanzan para entender qué pasó en producción.
+
+### H6 — Sistemas externos heredados (VB6)
+
+Existe un sistema heredado en VB6 que convive con este servicio. Queda **fuera del alcance** de cualquier trabajo en este repositorio: no se migra, no se integra y no se toca desde acá. Se anota únicamente para que cualquier decisión de contrato o de modelo de datos tenga presente que hay otro consumidor de la misma base fuera del ecosistema de microservicios.
+
+### H7 — `calculateCodigoBarras` genera códigos corruptos en silencio
+
+**Evidencia:** `UpdateBarrasUseCaseImpl.calculateCodigoBarras()` (línea 44 en adelante) arma el código Gire codificando `importe1` y las **diferencias** entre tramos:
+
+```java
+// 1er Importe     → new DecimalFormat("0000000").format(importe1)     7 dígitos, sin decimales
+// Dif 2do Importe → (importe2 - importe1).setScale(0, HALF_UP)        5 dígitos
+// Dif 3er Importe → (importe3 - importe2).setScale(0, HALF_UP)        5 dígitos
+```
+
+Tres defectos, todos verificados en código:
+
+1. **Diferencias negativas no se frenan.** Si `importe3 < importe2`, `diferenciaImporte2` es negativa; el código escribe `log.debug(...)` y **continúa**. `DecimalFormat("00000")` sobre un negativo produce una cadena con signo, y el código de barras resultante tiene largo y contenido inválidos. Llega impreso al alumno y el banco lo rechaza.
+2. **Sin control de desborde.** Las diferencias tienen 5 dígitos (máximo 99.999). `DecimalFormat("00000")` sobre un valor mayor imprime 6 dígitos en vez de truncar o fallar, corrompiendo el largo total. Lo mismo con `importe1` sobre 9.999.999.
+3. **Dos modos de redondeo en la misma función.** `importe1` usa el default de `DecimalFormat` (**HALF_EVEN**); las diferencias usan `setScale(0, HALF_UP)`. Inconsistencia latente.
+
+**Por qué importa:** el barcode no tiene decimales, así que **la moneda efectiva del sistema es el peso entero**. Cualquier importe con centavos genera divergencia entre lo que dice la base y lo que cobra el banco.
+
+**Estado:** fuera del alcance del roadmap actual. La feature en curso lo evita por construcción —aplicar el mismo factor a los tres tramos escala las diferencias sin volverlas negativas ni desbordarlas— pero el defecto sigue latente para cualquier otro camino que modifique importes de a un tramo, en particular `RecalculateCuotaByUniqueIndexUseCaseImpl`, que escribe solo `importe3`.
+
+---
+
+## 7. Restricciones aceptadas
+
+Cosas que **no** vamos a cambiar aunque incomoden:
+
+- **Rutas REST duplicadas** se mantienen hasta verificar que ningún cliente las usa.
+- **`@JsonFormat` en modelos de dominio**: filtración de infraestructura conocida y tolerada; corregirla rompería contratos de fecha.
+- **ModelMapper** convive con mappers manuales. Los mappers nuevos se escriben a mano (más explícitos y testeables); ModelMapper no se erradica por ahora.
+- **Kotlin** permanece hasta que el último archivo legacy migre. No se agrega Kotlin nuevo.
+
+---
+
+## 8. Documentos relacionados
+
+- `mission.md` — propósito, audiencia y principios
+- `roadmap.md` — en qué orden avanza el servicio completo
+- `features/beneficio-requisitos-ingreso/spec.md` — feature activa
+- `../docs/hexagonal-architecture.mmd` — diagrama general

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/factory/ChequeraCuotaFactory.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/factory/ChequeraCuotaFactory.java
@@ -1,0 +1,124 @@
+package um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.factory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.model.LectivoCuota;
+import um.tesoreria.core.util.Tool;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChequeraCuotaFactory {
+
+    private static final BigDecimal CIEN = BigDecimal.valueOf(100);
+
+    private final ChequeraCuotaService chequeraCuotaService;
+
+    /**
+     * Una cuota está vencida cuando su primer vencimiento quedó en el pasado. Con
+     * {@code vencimiento1} nulo no hay forma de saberlo, así que se trata como no vencida: los
+     * vencimientos se copian tal cual y el llamador no incrementa el offset.
+     */
+    public static boolean vencio(LectivoCuota lectivoCuota, OffsetDateTime ahora) {
+        return lectivoCuota.getVencimiento1() != null && ahora.isAfter(lectivoCuota.getVencimiento1());
+    }
+
+    public ChequeraCuota crear(ChequeraSerie chequeraSerie, LectivoCuota lectivoCuota, int offset,
+                               OffsetDateTime ahora) {
+        OffsetDateTime vencimiento1 = lectivoCuota.getVencimiento1();
+        OffsetDateTime vencimiento2 = lectivoCuota.getVencimiento2();
+        OffsetDateTime vencimiento3 = lectivoCuota.getVencimiento3();
+        if (vencio(lectivoCuota, ahora)) {
+            OffsetDateTime fechaBase = Tool.firstTime(ahora);
+            vencimiento1 = fechaBase.plusDays(7 + 30L * offset);
+            vencimiento2 = fechaBase.plusDays(20 + 30L * offset);
+            vencimiento3 = fechaBase.plusDays(40 + 30L * offset);
+        }
+
+        BigDecimal beneficio = chequeraSerie.getBecaPorcentaje() == null
+                ? BigDecimal.ZERO : chequeraSerie.getBecaPorcentaje();
+        ChequeraCuota cuota = ChequeraCuota.builder()
+                .chequeraId(chequeraSerie.getChequeraId())
+                .facultadId(chequeraSerie.getFacultadId())
+                .tipoChequeraId(chequeraSerie.getTipoChequeraId())
+                .chequeraSerieId(chequeraSerie.getChequeraSerieId())
+                .productoId(lectivoCuota.getProductoId())
+                .alternativaId(lectivoCuota.getAlternativaId())
+                .cuotaId(lectivoCuota.getCuotaId())
+                .mes(lectivoCuota.getMes())
+                .anho(lectivoCuota.getAnho())
+                .arancelTipoId(chequeraSerie.getArancelTipoId())
+                .vencimiento1(vencimiento1)
+                .importe1(aplicarBeneficio(lectivoCuota.getImporte1(), beneficio, chequeraSerie, lectivoCuota, 1))
+                .importe1Original(lectivoCuota.getImporte1())
+                .vencimiento2(vencimiento2)
+                .importe2(aplicarBeneficio(lectivoCuota.getImporte2(), beneficio, chequeraSerie, lectivoCuota, 2))
+                .importe2Original(lectivoCuota.getImporte2())
+                .vencimiento3(vencimiento3)
+                .importe3(aplicarBeneficio(lectivoCuota.getImporte3(), beneficio, chequeraSerie, lectivoCuota, 3))
+                .importe3Original(lectivoCuota.getImporte3())
+                .codigoBarras("")
+                .i2Of5("")
+                .pagado((byte) 0)
+                .baja((byte) 0)
+                .manual((byte) 0)
+                .compensada((byte) 0)
+                .tramoId(0)
+                .build();
+        cuota.setCodigoBarras(calcularCodigoBarras(cuota, chequeraSerie, lectivoCuota));
+        return cuota;
+    }
+
+    /**
+     * El importe de lista nulo se conserva nulo: no se lo reemplaza por cero, porque cero es un
+     * importe válido y encubriría el dato faltante. Sin importe no hay factor que aplicar, así que
+     * el tramo queda igual que en {@code lectivo_cuota} y la emisión sigue adelante.
+     */
+    private BigDecimal aplicarBeneficio(BigDecimal importeLista, BigDecimal beneficio,
+                                        ChequeraSerie chequeraSerie, LectivoCuota lectivoCuota, int tramo) {
+        if (importeLista == null) {
+            log.warn("Importe de lista nulo; se conserva nulo y no se aplica beneficio. {} tramo={} beneficio={}",
+                    contexto(chequeraSerie, lectivoCuota), tramo, beneficio);
+            return null;
+        }
+        if (beneficio.compareTo(BigDecimal.ZERO) == 0) {
+            return importeLista;
+        }
+        return importeLista.multiply(BigDecimal.ONE.subtract(beneficio.divide(CIEN)))
+                .setScale(0, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * {@code calculateCodigoBarras} formatea importes y desreferencia vencimientos sin control de
+     * nulo. Con datos incompletos la cuota queda sin código de barras en vez de abortar la emisión
+     * de toda la chequera; tesorería lo corrige a mano, que es el camino que ya usa.
+     */
+    private String calcularCodigoBarras(ChequeraCuota cuota, ChequeraSerie chequeraSerie,
+                                        LectivoCuota lectivoCuota) {
+        if (cuota.getImporte1() == null || cuota.getImporte2() == null || cuota.getImporte3() == null
+                || cuota.getVencimiento1() == null || cuota.getVencimiento2() == null
+                || cuota.getVencimiento3() == null) {
+            log.warn("Código de barras no calculado por importes o vencimientos nulos; la chequera se emite igual. {}",
+                    contexto(chequeraSerie, lectivoCuota));
+            return "";
+        }
+        return chequeraCuotaService.calculateCodigoBarras(cuota);
+    }
+
+    private String contexto(ChequeraSerie chequeraSerie, LectivoCuota lectivoCuota) {
+        return "facultadId=" + chequeraSerie.getFacultadId()
+                + " tipoChequeraId=" + chequeraSerie.getTipoChequeraId()
+                + " chequeraSerieId=" + chequeraSerie.getChequeraSerieId()
+                + " productoId=" + lectivoCuota.getProductoId()
+                + " alternativaId=" + lectivoCuota.getAlternativaId()
+                + " cuotaId=" + lectivoCuota.getCuotaId();
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/factory/ChequeraCuotaFactory.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/factory/ChequeraCuotaFactory.java
@@ -18,8 +18,6 @@ import java.time.OffsetDateTime;
 @RequiredArgsConstructor
 public class ChequeraCuotaFactory {
 
-    private static final BigDecimal CIEN = BigDecimal.valueOf(100);
-
     private final ChequeraCuotaService chequeraCuotaService;
 
     /**
@@ -43,8 +41,7 @@ public class ChequeraCuotaFactory {
             vencimiento3 = fechaBase.plusDays(40 + 30L * offset);
         }
 
-        BigDecimal beneficio = chequeraSerie.getBecaPorcentaje() == null
-                ? BigDecimal.ZERO : chequeraSerie.getBecaPorcentaje();
+        BigDecimal beneficio = normalizarBeneficio(chequeraSerie);
         ChequeraCuota cuota = ChequeraCuota.builder()
                 .chequeraId(chequeraSerie.getChequeraId())
                 .facultadId(chequeraSerie.getFacultadId())
@@ -92,8 +89,26 @@ public class ChequeraCuotaFactory {
         if (beneficio.compareTo(BigDecimal.ZERO) == 0) {
             return importeLista;
         }
-        return importeLista.multiply(BigDecimal.ONE.subtract(beneficio.divide(CIEN)))
+        return importeLista.multiply(BigDecimal.ONE.subtract(beneficio))
                 .setScale(0, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * {@code becaPorcentaje} se persiste como fracción: {@code 0.50} representa 50 % y
+     * {@code 1.00}, 100 %. La defensa evita que un dato histórico fuera de esa escala genere
+     * importes negativos o una bonificación distinta de la configurada.
+     */
+    private BigDecimal normalizarBeneficio(ChequeraSerie chequeraSerie) {
+        BigDecimal beneficio = chequeraSerie.getBecaPorcentaje();
+        if (beneficio == null) {
+            return BigDecimal.ZERO;
+        }
+        if (beneficio.compareTo(BigDecimal.ZERO) < 0 || beneficio.compareTo(BigDecimal.ONE) > 0) {
+            log.warn("Beneficio fuera de la escala fraccional [0,1]; se emite con 0%. chequeraSerieId={} beneficio={}",
+                    chequeraSerie.getChequeraSerieId(), beneficio);
+            return BigDecimal.ZERO;
+        }
+        return beneficio;
     }
 
     /**

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/usecases/FindAllInconsistenciasUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/usecases/FindAllInconsistenciasUseCaseImpl.java
@@ -7,11 +7,8 @@ import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.ports.out.Chequ
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
-import java.util.AbstractMap;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Component
 public class FindAllInconsistenciasUseCaseImpl implements FindAllInconsistenciasUseCase {
@@ -28,21 +25,26 @@ public class FindAllInconsistenciasUseCaseImpl implements FindAllInconsistencias
 
         return repository.findAllByVencimiento1Between(desde, hasta).stream()
                 .filter(cuota -> {
-                    boolean vencimientosInvalidos = Objects.requireNonNull(cuota.getVencimiento1())
-                            .isAfter(cuota.getVencimiento2()) ||
-                            Objects.requireNonNull(cuota.getVencimiento2()).isAfter(cuota.getVencimiento3());
+                    boolean vencimientosInvalidos = cuota.getVencimiento1() == null
+                            || cuota.getVencimiento2() == null || cuota.getVencimiento3() == null
+                            || cuota.getVencimiento1().isAfter(cuota.getVencimiento2())
+                            || cuota.getVencimiento2().isAfter(cuota.getVencimiento3());
 
-                    boolean importesInvalidos = cuota.getImporte1().compareTo(cuota.getImporte2()) > 0 ||
-                            cuota.getImporte2().compareTo(cuota.getImporte3()) > 0;
+                    boolean importesInvalidos = cuota.getImporte1() == null || cuota.getImporte2() == null
+                            || cuota.getImporte3() == null
+                            || cuota.getImporte1().compareTo(cuota.getImporte2()) > 0
+                            || cuota.getImporte2().compareTo(cuota.getImporte3()) > 0;
 
-                    boolean multiplicadoresInvalidos = Stream.of(
-                            new AbstractMap.SimpleEntry<>(cuota.getImporte1Original(), cuota.getImporte1()),
-                            new AbstractMap.SimpleEntry<>(cuota.getImporte2Original(), cuota.getImporte2()),
-                            new AbstractMap.SimpleEntry<>(cuota.getImporte3Original(), cuota.getImporte3()))
-                            .anyMatch(entry -> entry.getKey().multiply(MULTIPLICADOR).compareTo(entry.getValue()) < 0);
+                    boolean multiplicadoresInvalidos = multiplicadorInvalido(cuota.getImporte1Original(), cuota.getImporte1(), MULTIPLICADOR)
+                            || multiplicadorInvalido(cuota.getImporte2Original(), cuota.getImporte2(), MULTIPLICADOR)
+                            || multiplicadorInvalido(cuota.getImporte3Original(), cuota.getImporte3(), MULTIPLICADOR);
 
                     return vencimientosInvalidos || importesInvalidos || multiplicadoresInvalidos;
                 })
                 .collect(Collectors.toList());
+    }
+
+    private boolean multiplicadorInvalido(BigDecimal original, BigDecimal importe, BigDecimal multiplicador) {
+        return original == null || importe == null || original.multiply(multiplicador).compareTo(importe) < 0;
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraDetailsCreator.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraDetailsCreator.java
@@ -3,6 +3,7 @@ package um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.factory.ChequeraCuotaFactory;
 import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
 import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
 import um.tesoreria.core.hexagonal.chequera.chequeraTotal.application.service.ChequeraTotalService;
@@ -22,8 +23,13 @@ import um.tesoreria.core.util.Tool;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -35,28 +41,72 @@ class PreuniversitarioChequeraDetailsCreator {
     private final LectivoAlternativaService lectivoAlternativaService;
     private final ChequeraAlternativaService chequeraAlternativaService;
     private final LectivoCuotaService lectivoCuotaService;
+    private final ChequeraCuotaFactory chequeraCuotaFactory;
     private final ChequeraCuotaService chequeraCuotaService;
 
     void create(ChequeraSerie chequeraSerie) {
-        createTotals(chequeraSerie);
         createAlternatives(chequeraSerie);
-        createCuotas(chequeraSerie);
+        var cuotas = createCuotas(chequeraSerie);
+        createTotals(chequeraSerie, cuotas);
     }
 
-    private void createTotals(ChequeraSerie chequeraSerie) {
+    private void createTotals(ChequeraSerie chequeraSerie, List<ChequeraCuota> cuotas) {
+        Map<Integer, List<ChequeraCuota>> activasPorProducto = cuotas.stream()
+                .filter(Objects::nonNull)
+                .filter(cuota -> cuota.getProductoId() != null)
+                .filter(cuota -> Byte.valueOf((byte) 0).equals(cuota.getBaja()))
+                .collect(Collectors.groupingBy(ChequeraCuota::getProductoId));
         List<ChequeraTotal> totals = new ArrayList<>();
-        for (LectivoTotal source : lectivoTotalService.findAllByTipo(
-                chequeraSerie.getFacultadId(), chequeraSerie.getLectivoId(), chequeraSerie.getTipoChequeraId())) {
+        for (Integer productoId : productos(chequeraSerie, activasPorProducto.keySet())) {
             totals.add(ChequeraTotal.builder()
                     .facultadId(chequeraSerie.getFacultadId())
                     .tipoChequeraId(chequeraSerie.getTipoChequeraId())
                     .chequeraSerieId(chequeraSerie.getChequeraSerieId())
-                    .productoId(source.getProductoId())
-                    .total(source.getTotal())
+                    .productoId(productoId)
+                    .total(sumarActivas(chequeraSerie, productoId,
+                            activasPorProducto.getOrDefault(productoId, List.of())))
                     .pagado(BigDecimal.ZERO)
                     .build());
         }
         log.debug("ChequeraTotals -> {}", Jsonifier.builder(chequeraTotalService.saveAll(totals)).build());
+    }
+
+    /**
+     * Los productos salen de {@code lectivo_total}, que no filtra por alternativa, unidos a los que
+     * efectivamente generaron cuotas. Derivarlos solo de las cuotas dejaría sin fila de
+     * {@code chequera_total} a un producto con total configurado pero sin cuotas en la alternativa
+     * elegida; esa fila se persiste igual, en cero.
+     */
+    private Collection<Integer> productos(ChequeraSerie chequeraSerie, Set<Integer> conCuotas) {
+        Set<Integer> productos = new LinkedHashSet<>();
+        for (LectivoTotal source : lectivoTotalService.findAllByTipo(
+                chequeraSerie.getFacultadId(), chequeraSerie.getLectivoId(), chequeraSerie.getTipoChequeraId())) {
+            if (source.getProductoId() != null) {
+                productos.add(source.getProductoId());
+            }
+        }
+        productos.addAll(conCuotas);
+        return productos;
+    }
+
+    /**
+     * Mismo invariante que {@code CalculateTotalCuotasActivasUseCaseImpl}: suma de {@code importe1}
+     * de las cuotas con {@code baja = 0}. Un importe nulo se excluye de la suma y se loguea, pero no
+     * aborta la emisión ni se confunde con un cero legítimo del beneficio del 100 %.
+     */
+    private BigDecimal sumarActivas(ChequeraSerie chequeraSerie, Integer productoId, List<ChequeraCuota> cuotas) {
+        BigDecimal total = BigDecimal.ZERO;
+        for (ChequeraCuota cuota : cuotas) {
+            if (cuota.getImporte1() == null) {
+                log.warn("Importe1 nulo excluido del total; la chequera se emite igual. facultadId={} "
+                                + "tipoChequeraId={} chequeraSerieId={} productoId={} cuotaId={}",
+                        chequeraSerie.getFacultadId(), chequeraSerie.getTipoChequeraId(),
+                        chequeraSerie.getChequeraSerieId(), productoId, cuota.getCuotaId());
+                continue;
+            }
+            total = total.add(cuota.getImporte1());
+        }
+        return total;
     }
 
     private void createAlternatives(ChequeraSerie chequeraSerie) {
@@ -72,32 +122,22 @@ class PreuniversitarioChequeraDetailsCreator {
         log.debug("ChequeraAlternativas -> {}", Jsonifier.builder(chequeraAlternativaService.saveAll(alternatives)).build());
     }
 
-    private void createCuotas(ChequeraSerie chequeraSerie) {
+    private List<ChequeraCuota> createCuotas(ChequeraSerie chequeraSerie) {
         List<ChequeraCuota> cuotas = new ArrayList<>();
         int offset = 0;
+        OffsetDateTime ahora = Tool.hourAbsoluteArgentina();
         for (LectivoCuota source : lectivoCuotaService.findAllByTipo(
                 chequeraSerie.getFacultadId(), chequeraSerie.getLectivoId(), chequeraSerie.getTipoChequeraId(),
                 chequeraSerie.getAlternativaId())) {
-            OffsetDateTime vencimiento1 = source.getVencimiento1();
-            OffsetDateTime vencimiento2 = source.getVencimiento2();
-            OffsetDateTime vencimiento3 = source.getVencimiento3();
-            if (OffsetDateTime.now().isAfter(vencimiento1)) {
-                vencimiento1 = Tool.dateAbsoluteArgentina().plusDays(7 + 30L * offset);
-                vencimiento2 = Tool.dateAbsoluteArgentina().plusDays(20 + 30L * offset);
-                vencimiento3 = Tool.dateAbsoluteArgentina().plusDays(40 + 30L * offset);
+            ChequeraCuota cuota = chequeraCuotaFactory.crear(chequeraSerie, source, offset, ahora);
+            if (ChequeraCuotaFactory.vencio(source, ahora)) {
                 offset++;
             }
-            ChequeraCuota cuota = new ChequeraCuota(null, chequeraSerie.getChequeraId(),
-                    chequeraSerie.getFacultadId(), chequeraSerie.getTipoChequeraId(),
-                    chequeraSerie.getChequeraSerieId(), source.getProductoId(), source.getAlternativaId(),
-                    source.getCuotaId(), source.getMes(), source.getAnho(), chequeraSerie.getArancelTipoId(),
-                    vencimiento1, source.getImporte1(), source.getImporte1(), vencimiento2, source.getImporte2(),
-                    source.getImporte2(), vencimiento3, source.getImporte3(), source.getImporte3(), "", "",
-                    (byte) 0, (byte) 0, (byte) 0, (byte) 0, 0, null, null, null, null);
             log.debug("chequera_cuota -> {}", cuota.jsonify());
-            cuota.setCodigoBarras(chequeraCuotaService.calculateCodigoBarras(cuota));
             cuotas.add(cuota);
         }
-        log.debug("ChequeraCuotas -> {}", Jsonifier.builder(chequeraCuotaService.saveAll(cuotas)).build());
+        List<ChequeraCuota> cuotasGuardadas = chequeraCuotaService.saveAll(cuotas);
+        log.debug("ChequeraCuotas -> {}", Jsonifier.builder(cuotasGuardadas).build());
+        return cuotasGuardadas;
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraService.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraService.java
@@ -9,10 +9,16 @@ import um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.exception.
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.PreuniversitarioChequeraData;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.ports.in.CreatePreuniversitarioChequeraUseCase;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.application.service.GuaraniBeneficioService;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.model.GuaraniBeneficio;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.RequisitoPresentadoGuarani;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.policy.BeneficioPolicy;
 import um.tesoreria.core.model.ChequeraSerieControl;
 import um.tesoreria.core.service.ChequeraSerieControlService;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
 
 @Service
 @Slf4j
@@ -25,6 +31,8 @@ public class PreuniversitarioChequeraService implements CreatePreuniversitarioCh
     private final ChequeraSerieControlService chequeraSerieControlService;
     private final PreuniversitarioChequeraDetailsCreator detailsCreator;
     private final PreuniversitarioChequeraPolicy policy;
+    private final GuaraniBeneficioService guaraniBeneficioService;
+    private final BeneficioPolicy beneficioPolicy;
 
     @Transactional
     @Override
@@ -47,7 +55,7 @@ public class PreuniversitarioChequeraService implements CreatePreuniversitarioCh
         }
 
         // Determina beneficio
-        var becaPorcentaje = BigDecimal.ZERO;
+        var becaPorcentaje = resolverBeneficio(alumnoGuaraniFull);
 
         long chequeraSerieId = nextChequeraSerieId(data);
         var control = chequeraSerieControlService.add(new ChequeraSerieControl(
@@ -71,6 +79,43 @@ public class PreuniversitarioChequeraService implements CreatePreuniversitarioCh
         } catch (ChequeraSerieControlException exception) {
             log.error("Error al obtener el último chequeraSerieControl -> {}", exception.getMessage());
             return 1L;
+        }
+    }
+
+    private BigDecimal resolverBeneficio(PreuniversitarioChequeraData data) {
+        if (data.requisitosPresentados() == null || data.requisitosPresentados().isEmpty()) {
+            log.warn("Beneficio no resuelto; se emite con 0%. persona={} documentoId={} causa=requisitos ausentes",
+                    data.personaId(), data.documentoId());
+            return BigDecimal.ZERO;
+        }
+        List<Integer> requisitos = data.requisitosPresentados().stream()
+                .filter(Objects::nonNull)
+                .map(RequisitoPresentadoGuarani::getRequisito)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (requisitos.isEmpty()) {
+            log.warn("Beneficio no resuelto; se emite con 0%. persona={} documentoId={} causa=requisitos sin identificador",
+                    data.personaId(), data.documentoId());
+            return BigDecimal.ZERO;
+        }
+        try {
+            List<GuaraniBeneficio> beneficios = guaraniBeneficioService.findByRequisitos(requisitos);
+            if (beneficios == null) {
+                log.warn("Beneficio no resuelto; se emite con 0%. persona={} documentoId={} causa=beneficios ausentes",
+                        data.personaId(), data.documentoId());
+                return BigDecimal.ZERO;
+            }
+            if (beneficios.stream().filter(Objects::nonNull)
+                    .anyMatch(beneficio -> beneficio.getPorcentajeBeneficio() == null)) {
+                log.warn("Beneficio incompleto; porcentaje nulo tratado como 0%. persona={} documentoId={}",
+                        data.personaId(), data.documentoId());
+            }
+            return beneficioPolicy.porcentajeEfectivo(data.requisitosPresentados(), beneficios);
+        } catch (RuntimeException exception) {
+            log.warn("Beneficio no resuelto; se emite con 0%. persona={} documentoId={} causa={}",
+                    data.personaId(), data.documentoId(), exception.getMessage());
+            return BigDecimal.ZERO;
         }
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/domain/model/PreuniversitarioChequeraData.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/domain/model/PreuniversitarioChequeraData.java
@@ -1,11 +1,19 @@
 package um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model;
 
 import java.math.BigDecimal;
+import java.util.List;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.RequisitoPresentadoGuarani;
 
 public record PreuniversitarioChequeraData(
         Integer propuesta,
         Integer responsableAcademica,
         Integer ubicacion,
         BigDecimal personaId,
-        Integer documentoId) {
+        Integer documentoId,
+        List<RequisitoPresentadoGuarani> requisitosPresentados) {
+
+    public PreuniversitarioChequeraData(Integer propuesta, Integer responsableAcademica, Integer ubicacion,
+                                        BigDecimal personaId, Integer documentoId) {
+        this(propuesta, responsableAcademica, ubicacion, personaId, documentoId, List.of());
+    }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/persistence/entity/ChequeraSerieEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/persistence/entity/ChequeraSerieEntity.java
@@ -97,6 +97,7 @@ public class ChequeraSerieEntity extends Auditable {
     private Byte hpum = 0;
 
     @Builder.Default
+    @Column(precision = 5, scale = 2, nullable = false)
     private BigDecimal becaPorcentaje = BigDecimal.ZERO;
 
     private String becaResolucion;

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/web/controller/ChequeraSerieController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/web/controller/ChequeraSerieController.java
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -207,7 +208,7 @@ public class ChequeraSerieController {
     }
 
     @PutMapping("/{chequeraId}")
-    public ResponseEntity<ChequeraSerieResponse> update(@RequestBody ChequeraSerieRequest chequeraserieRequest,
+    public ResponseEntity<ChequeraSerieResponse> update(@Valid @RequestBody ChequeraSerieRequest chequeraserieRequest,
                                                       @PathVariable Long chequeraId) {
         ChequeraSerie domain = chequeraSerieDtoMapper.toDomain(chequeraserieRequest);
         ChequeraSerie updatedDomain = service.update(domain, chequeraId);

--- a/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/web/dto/ChequeraSerieRequest.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/web/dto/ChequeraSerieRequest.java
@@ -1,5 +1,8 @@
 package um.tesoreria.core.hexagonal.chequera.chequeraSerie.infrastructure.web.dto;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -31,6 +34,10 @@ public class ChequeraSerieRequest {
     private Byte retenida;
     private Long version;
     private Byte hpum;
+
+    @DecimalMin(value = "0", inclusive = true)
+    @DecimalMax(value = "1", inclusive = true)
+    @Digits(integer = 1, fraction = 2)
     private BigDecimal becaPorcentaje;
     private String becaResolucion;
     private OffsetDateTime becaFecha;

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/alumnoGuarani/application/usecases/CreatePreuniversitarioUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/alumnoGuarani/application/usecases/CreatePreuniversitarioUseCaseImpl.java
@@ -6,9 +6,12 @@ import org.springframework.stereotype.Component;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.PreuniversitarioChequeraData;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.ports.in.CreatePreuniversitarioChequeraUseCase;
 import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.AlumnoGuarani;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.RequisitoPresentadoGuarani;
 import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.ports.in.CreatePreuniversitarioUseCase;
 import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.infrastructure.web.dto.PersonalesResponse;
 import um.tesoreria.core.service.facade.MailChequeraService;
+
+import java.util.List;
 
 @Component
 @Slf4j
@@ -28,7 +31,8 @@ public class CreatePreuniversitarioUseCaseImpl implements CreatePreuniversitario
                         .getResponsableAcademica(),
                 alumnoGuaraniFull.getAlumnoGuarani().getUbicacion(),
                 alumnoGuaraniFull.getPersona().getPersonaId(),
-                alumnoGuaraniFull.getPersona().getDocumentoId()));
+                alumnoGuaraniFull.getPersona().getDocumentoId(),
+                requisitosPresentados(alumnoGuaraniFull)));
         if (chequeraSerie == null) {
             log.info("\n\nChequera serie nula\n\n");
             return alumnoGuaraniFull.getAlumnoGuarani();
@@ -49,6 +53,15 @@ public class CreatePreuniversitarioUseCaseImpl implements CreatePreuniversitario
         );
         log.info("\n\nResult -> {}", result);
         return alumnoGuaraniFull.getAlumnoGuarani();
+    }
+
+    private List<RequisitoPresentadoGuarani> requisitosPresentados(PersonalesResponse alumnoGuaraniFull) {
+        if (alumnoGuaraniFull.getAlumnoGuarani() == null
+                || alumnoGuaraniFull.getAlumnoGuarani().getPersonaRel() == null
+                || alumnoGuaraniFull.getAlumnoGuarani().getPersonaRel().getRequisitosPresentados() == null) {
+            return List.of();
+        }
+        return alumnoGuaraniFull.getAlumnoGuarani().getPersonaRel().getRequisitosPresentados();
     }
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/application/usecases/CreateGuaraniBeneficioUseCaseImpl.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/application/usecases/CreateGuaraniBeneficioUseCaseImpl.java
@@ -1,8 +1,10 @@
 package um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.application.usecases;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.model.GuaraniBeneficio;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.application.exception.GuaraniBeneficioException;
 import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.ports.in.CreateGuaraniBeneficioUseCase;
 import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.ports.out.GuaraniBeneficioRepository;
 
@@ -13,6 +15,15 @@ public class CreateGuaraniBeneficioUseCaseImpl implements CreateGuaraniBeneficio
 
     @Override
     public GuaraniBeneficio create(GuaraniBeneficio guaraniBeneficio) {
-        return repository.save(guaraniBeneficio);
+        if (repository.findByRequisito(guaraniBeneficio.getRequisito()).isPresent()) {
+            throw new GuaraniBeneficioException("Ya existe un beneficio para el requisito: "
+                    + guaraniBeneficio.getRequisito());
+        }
+        try {
+            return repository.save(guaraniBeneficio);
+        } catch (DataIntegrityViolationException exception) {
+            throw new GuaraniBeneficioException("Ya existe un beneficio para el requisito: "
+                    + guaraniBeneficio.getRequisito());
+        }
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicy.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicy.java
@@ -34,8 +34,8 @@ public class BeneficioPolicy {
                 .map(beneficiosPorRequisito::get)
                 .filter(Objects::nonNull)
                 .flatMap(List::stream)
+                .filter(this::tienePorcentajeFraccionalValido)
                 .map(GuaraniBeneficio::getPorcentajeBeneficio)
-                .filter(Objects::nonNull)
                 .max(BigDecimal::compareTo)
                 .orElse(BigDecimal.ZERO);
     }
@@ -49,5 +49,16 @@ public class BeneficioPolicy {
 
         return "S".equalsIgnoreCase(requisito.getRequisitoRel().getRequisitoIngreso())
                 && "S".equalsIgnoreCase(requisito.getRequisitoRel().getActivo());
+    }
+
+    private boolean tienePorcentajeFraccionalValido(GuaraniBeneficio beneficio) {
+        BigDecimal porcentaje = beneficio.getPorcentajeBeneficio();
+        if (porcentaje == null || porcentaje.compareTo(BigDecimal.ZERO) < 0
+                || porcentaje.compareTo(BigDecimal.ONE) > 0) {
+            log.warn("Beneficio omitido: porcentaje fuera de la escala fraccional [0,1] para requisito={} porcentaje={}",
+                    beneficio.getRequisito(), porcentaje);
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicy.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicy.java
@@ -1,0 +1,53 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.policy;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.RequisitoPresentadoGuarani;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.model.GuaraniBeneficio;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class BeneficioPolicy {
+
+    public BigDecimal porcentajeEfectivo(List<RequisitoPresentadoGuarani> requisitos,
+                                         List<GuaraniBeneficio> beneficios) {
+        if (requisitos == null || beneficios == null) {
+            return BigDecimal.ZERO;
+        }
+
+        Map<Integer, List<GuaraniBeneficio>> beneficiosPorRequisito = beneficios.stream()
+                .filter(Objects::nonNull)
+                .filter(beneficio -> beneficio.getRequisito() != null)
+                .collect(Collectors.groupingBy(GuaraniBeneficio::getRequisito));
+
+        return requisitos.stream()
+                .filter(Objects::nonNull)
+                .filter(this::esRequisitoElegible)
+                .map(RequisitoPresentadoGuarani::getRequisito)
+                .filter(Objects::nonNull)
+                .map(beneficiosPorRequisito::get)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .map(GuaraniBeneficio::getPorcentajeBeneficio)
+                .filter(Objects::nonNull)
+                .max(BigDecimal::compareTo)
+                .orElse(BigDecimal.ZERO);
+    }
+
+    private boolean esRequisitoElegible(RequisitoPresentadoGuarani requisito) {
+        if (requisito.getRequisitoRel() == null) {
+            log.warn("Beneficio omitido: requisitoRel nulo para persona={} requisito={}",
+                    requisito.getPersona(), requisito.getRequisito());
+            return false;
+        }
+
+        return "S".equalsIgnoreCase(requisito.getRequisitoRel().getRequisitoIngreso())
+                && "S".equalsIgnoreCase(requisito.getRequisitoRel().getActivo());
+    }
+}

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/persistence/entity/GuaraniBeneficioEntity.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/persistence/entity/GuaraniBeneficioEntity.java
@@ -22,6 +22,7 @@ public class GuaraniBeneficioEntity extends Auditable {
     private Integer requisito;
 
     @Builder.Default
+    @Column(precision = 5, scale = 2, nullable = false)
     private BigDecimal porcentajeBeneficio = BigDecimal.ZERO;
 
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/controller/GuaraniBeneficioController.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/controller/GuaraniBeneficioController.java
@@ -1,6 +1,7 @@
 package um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.infrastructure.web.controller;
 
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -51,16 +52,20 @@ public class GuaraniBeneficioController {
     }
 
     @PostMapping("/")
-    public ResponseEntity<GuaraniBeneficioResponse> add(@RequestBody GuaraniBeneficioRequest request) {
-        GuaraniBeneficio domain = guaraniBeneficioDtoMapper.toDomain(request);
-        GuaraniBeneficio created = guaraniBeneficioService.create(domain);
-        return ResponseEntity.ok(guaraniBeneficioDtoMapper.toResponse(created));
+    public ResponseEntity<GuaraniBeneficioResponse> add(@Valid @RequestBody GuaraniBeneficioRequest request) {
+        try {
+            GuaraniBeneficio domain = guaraniBeneficioDtoMapper.toDomain(request);
+            GuaraniBeneficio created = guaraniBeneficioService.create(domain);
+            return ResponseEntity.ok(guaraniBeneficioDtoMapper.toResponse(created));
+        } catch (GuaraniBeneficioException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        }
     }
 
     @PutMapping("/requisito/{requisito}")
     public ResponseEntity<GuaraniBeneficioResponse> updateByRequisito(
             @PathVariable Integer requisito,
-            @RequestBody GuaraniBeneficioRequest request) {
+            @Valid @RequestBody GuaraniBeneficioRequest request) {
         GuaraniBeneficio domain = guaraniBeneficioDtoMapper.toDomain(request);
         GuaraniBeneficio updated = guaraniBeneficioService.updateByRequisito(requisito, domain);
         return ResponseEntity.ok(guaraniBeneficioDtoMapper.toResponse(updated));

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/dto/GuaraniBeneficioRequest.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/dto/GuaraniBeneficioRequest.java
@@ -3,6 +3,7 @@ package um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.infrastructure.web.
 import lombok.Data;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
@@ -13,6 +14,7 @@ public class GuaraniBeneficioRequest {
 
     @NotNull
     @DecimalMin(value = "0", inclusive = true)
-    @DecimalMax(value = "100", inclusive = true)
+    @DecimalMax(value = "1", inclusive = true)
+    @Digits(integer = 1, fraction = 2)
     private BigDecimal porcentajeBeneficio;
 }

--- a/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/dto/GuaraniBeneficioRequest.java
+++ b/src/main/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/dto/GuaraniBeneficioRequest.java
@@ -1,10 +1,18 @@
 package um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.infrastructure.web.dto;
 
 import lombok.Data;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 @Data
 public class GuaraniBeneficioRequest {
+    @NotNull
     private Integer requisito;
+
+    @NotNull
+    @DecimalMin(value = "0", inclusive = true)
+    @DecimalMax(value = "100", inclusive = true)
     private BigDecimal porcentajeBeneficio;
 }

--- a/src/main/java/um/tesoreria/core/service/transactional/spoter/SpoterService.java
+++ b/src/main/java/um/tesoreria/core/service/transactional/spoter/SpoterService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import um.tesoreria.core.exception.ChequeraSerieControlException;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.factory.ChequeraCuotaFactory;
 import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
 import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
@@ -31,7 +32,6 @@ import um.tesoreria.core.util.Jsonifier;
 import um.tesoreria.core.util.Tool;
 
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -52,6 +52,7 @@ public class SpoterService {
     private final LectivoAlternativaService lectivoAlternativaService;
     private final ChequeraAlternativaService chequeraAlternativaService;
     private final LectivoCuotaService lectivoCuotaService;
+    private final ChequeraCuotaFactory chequeraCuotaFactory;
     private final ChequeraCuotaService chequeraCuotaService;
 
     @Transactional
@@ -180,28 +181,14 @@ public class SpoterService {
         // Generar Cuotas
         List<ChequeraCuota> chequeraCuotas = new ArrayList<>();
         int offset = 0;
+        var ahora = Tool.hourAbsoluteArgentina();
         for (LectivoCuota lectivoCuota : lectivoCuotaService.findAllByTipo(chequeraSerie.getFacultadId(),
                 chequeraSerie.getLectivoId(), chequeraSerie.getTipoChequeraId(), chequeraSerie.getAlternativaId())) {
-            OffsetDateTime vencimiento1 = lectivoCuota.getVencimiento1();
-            OffsetDateTime vencimiento2 = lectivoCuota.getVencimiento2();
-            OffsetDateTime vencimiento3 = lectivoCuota.getVencimiento3();
-            if (OffsetDateTime.now().isAfter(vencimiento1)) {
-                vencimiento1 = Tool.dateAbsoluteArgentina().plusDays(7 + 30L * offset);
-                vencimiento2 = Tool.dateAbsoluteArgentina().plusDays(20 + 30L * offset);
-                vencimiento3 = Tool.dateAbsoluteArgentina().plusDays(40 + 30L * offset);
+            ChequeraCuota chequeraCuota = chequeraCuotaFactory.crear(chequeraSerie, lectivoCuota, offset, ahora);
+            if (ChequeraCuotaFactory.vencio(lectivoCuota, ahora)) {
                 offset++;
             }
-            ChequeraCuota chequeraCuota = new ChequeraCuota(null, chequeraSerie.getChequeraId(), chequeraSerie.getFacultadId(),
-                    chequeraSerie.getTipoChequeraId(), chequeraSerie.getChequeraSerieId(), lectivoCuota.getProductoId(),
-                    lectivoCuota.getAlternativaId(), lectivoCuota.getCuotaId(), lectivoCuota.getMes(),
-                    lectivoCuota.getAnho(), chequeraSerie.getArancelTipoId(), vencimiento1, lectivoCuota.getImporte1(),
-                    lectivoCuota.getImporte1(), vencimiento2, lectivoCuota.getImporte2(), lectivoCuota.getImporte2(),
-                    vencimiento3, lectivoCuota.getImporte3(), lectivoCuota.getImporte3(), "", "", (byte) 0, (byte) 0,
-                    (byte) 0, (byte) 0, 0, null, null, null, null);
             log.debug("mail_chequera_service.make_chequera_spoter.chequera_cuota -> -> {}", chequeraCuota.jsonify());
-            log.debug("mail_chequera_service.make_chequera_spoter - calling calculate_codigo_barras");
-            chequeraCuota.setCodigoBarras(chequeraCuotaService.calculateCodigoBarras(chequeraCuota));
-            log.debug("mail_chequera_service.make_chequera_spoter - after calculate_codigo_barras");
             chequeraCuotas.add(chequeraCuota);
         }
         chequeraCuotas = chequeraCuotaService.saveAll(chequeraCuotas);

--- a/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/factory/ChequeraCuotaFactoryTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/factory/ChequeraCuotaFactoryTest.java
@@ -1,0 +1,154 @@
+package um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.factory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.model.LectivoCuota;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChequeraCuotaFactoryTest {
+
+    @Mock
+    private ChequeraCuotaService chequeraCuotaService;
+
+    @Test
+    void crear_appliesSameHalfUpFactorAndPreservesListPrices() {
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("33.33"), lectivo(), 0, referencia());
+
+        assertThat(cuota.getImporte1()).isEqualByComparingTo("67");
+        assertThat(cuota.getImporte2()).isEqualByComparingTo("134");
+        assertThat(cuota.getImporte3()).isEqualByComparingTo("200");
+        assertThat(cuota.getImporte1Original()).isEqualByComparingTo("100.50");
+        assertThat(cuota.getImporte2Original()).isEqualByComparingTo("200.50");
+        assertThat(cuota.getImporte3Original()).isEqualByComparingTo("300.50");
+        assertThat(cuota.getTramoId()).isZero();
+        assertThat(cuota.getCodigoBarras()).isEqualTo("barcode");
+    }
+
+    @Test
+    void crear_normalizesNullBenefitToZeroAndOffsetsExpiredDueDates() {
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+        var expired = lectivo();
+        expired.setVencimiento1(referencia().minusDays(1));
+
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie(null), expired, 1, referencia());
+
+        assertThat(cuota.getImporte1()).isEqualByComparingTo("100.50");
+        assertThat(cuota.getImporte2()).isEqualByComparingTo("200.50");
+        assertThat(cuota.getImporte3()).isEqualByComparingTo("300.50");
+        assertThat(cuota.getVencimiento1()).isEqualTo(referencia().toLocalDate().atStartOfDay().atOffset(ZoneOffset.UTC).plusDays(37));
+        assertThat(cuota.getVencimiento2()).isEqualTo(referencia().toLocalDate().atStartOfDay().atOffset(ZoneOffset.UTC).plusDays(50));
+        assertThat(cuota.getVencimiento3()).isEqualTo(referencia().toLocalDate().atStartOfDay().atOffset(ZoneOffset.UTC).plusDays(70));
+    }
+
+    @Test
+    void crear_preservesZeroBenefitAndZerosEveryTramoAtHundredPercent() {
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+        var factory = new ChequeraCuotaFactory(chequeraCuotaService);
+
+        var sinBeneficio = factory.crear(serie("0"), lectivo(), 0, referencia());
+        var becaCompleta = factory.crear(serie("100"), lectivo(), 0, referencia());
+
+        assertThat(sinBeneficio.getImporte1()).isEqualByComparingTo(sinBeneficio.getImporte1Original());
+        assertThat(sinBeneficio.getImporte2()).isEqualByComparingTo(sinBeneficio.getImporte2Original());
+        assertThat(sinBeneficio.getImporte3()).isEqualByComparingTo(sinBeneficio.getImporte3Original());
+        assertThat(becaCompleta.getImporte1()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(becaCompleta.getImporte2()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(becaCompleta.getImporte3()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(becaCompleta.getImporte1Original()).isEqualByComparingTo("100.50");
+    }
+
+    @Test
+    void crear_appliesTwentyPercentWithoutBreakingTramoOrder() {
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("20"), lectivo(), 0, referencia());
+
+        assertThat(cuota.getImporte1()).isEqualByComparingTo("80");
+        assertThat(cuota.getImporte2()).isEqualByComparingTo("160");
+        assertThat(cuota.getImporte3()).isEqualByComparingTo("240");
+        assertThat(cuota.getImporte1()).isLessThanOrEqualTo(cuota.getImporte2());
+        assertThat(cuota.getImporte2()).isLessThanOrEqualTo(cuota.getImporte3());
+    }
+
+    @Test
+    void crear_keepsNullListPriceAsNullAndSkipsBarcodeInsteadOfFailing() {
+        var incompleta = lectivo();
+        incompleta.setImporte2(null);
+
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("20"), incompleta, 0, referencia());
+
+        assertThat(cuota.getImporte2()).isNull();
+        assertThat(cuota.getImporte2Original()).isNull();
+        assertThat(cuota.getImporte1()).isEqualByComparingTo("80");
+        assertThat(cuota.getImporte1Original()).isEqualByComparingTo("100.50");
+        assertThat(cuota.getCodigoBarras()).isEmpty();
+        org.mockito.Mockito.verify(chequeraCuotaService, org.mockito.Mockito.never())
+                .calculateCodigoBarras(any(ChequeraCuota.class));
+    }
+
+    @Test
+    void crear_keepsNullListPriceAsNullWithoutBenefit() {
+        var incompleta = lectivo();
+        incompleta.setImporte1(null);
+
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("0"), incompleta, 0, referencia());
+
+        assertThat(cuota.getImporte1()).isNull();
+        assertThat(cuota.getImporte1Original()).isNull();
+        assertThat(cuota.getCodigoBarras()).isEmpty();
+    }
+
+    @Test
+    void crear_treatsNullFirstDueDateAsNotExpiredAndCopiesDatesUntouched() {
+        var sinVencimiento = lectivo();
+        sinVencimiento.setVencimiento1(null);
+
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("20"), sinVencimiento, 3, referencia());
+
+        assertThat(ChequeraCuotaFactory.vencio(sinVencimiento, referencia())).isFalse();
+        assertThat(cuota.getVencimiento1()).isNull();
+        assertThat(cuota.getVencimiento2()).isEqualTo(sinVencimiento.getVencimiento2());
+        assertThat(cuota.getVencimiento3()).isEqualTo(sinVencimiento.getVencimiento3());
+        assertThat(cuota.getImporte1()).isEqualByComparingTo("80");
+        assertThat(cuota.getCodigoBarras()).isEmpty();
+    }
+
+    @Test
+    void vencio_detectsExpiredFirstDueDate() {
+        var vencida = lectivo();
+        vencida.setVencimiento1(referencia().minusDays(1));
+
+        assertThat(ChequeraCuotaFactory.vencio(vencida, referencia())).isTrue();
+        assertThat(ChequeraCuotaFactory.vencio(lectivo(), referencia())).isFalse();
+    }
+
+    private static ChequeraSerie serie(String beneficio) {
+        return ChequeraSerie.builder().chequeraId(1L).facultadId(2).tipoChequeraId(3).chequeraSerieId(4L)
+                .arancelTipoId(5).becaPorcentaje(beneficio == null ? null : new BigDecimal(beneficio)).build();
+    }
+
+    private static LectivoCuota lectivo() {
+        return LectivoCuota.builder().productoId(6).alternativaId(7).cuotaId(8).mes(9).anho(2026).tramoId(10)
+                .vencimiento1(referencia().plusDays(1)).vencimiento2(referencia().plusDays(10)).vencimiento3(referencia().plusDays(20))
+                .importe1(new BigDecimal("100.50")).importe2(new BigDecimal("200.50")).importe3(new BigDecimal("300.50")).build();
+    }
+
+    private static OffsetDateTime referencia() {
+        return OffsetDateTime.of(2026, 8, 20, 13, 0, 0, 0, ZoneOffset.UTC);
+    }
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/factory/ChequeraCuotaFactoryTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/factory/ChequeraCuotaFactoryTest.java
@@ -24,14 +24,14 @@ class ChequeraCuotaFactoryTest {
     private ChequeraCuotaService chequeraCuotaService;
 
     @Test
-    void crear_appliesSameHalfUpFactorAndPreservesListPrices() {
+    void crear_appliesFractionalHalfUpFactorAndPreservesListPrices() {
         when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
 
-        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("33.33"), lectivo(), 0, referencia());
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("0.33"), lectivo(), 0, referencia());
 
         assertThat(cuota.getImporte1()).isEqualByComparingTo("67");
         assertThat(cuota.getImporte2()).isEqualByComparingTo("134");
-        assertThat(cuota.getImporte3()).isEqualByComparingTo("200");
+        assertThat(cuota.getImporte3()).isEqualByComparingTo("201");
         assertThat(cuota.getImporte1Original()).isEqualByComparingTo("100.50");
         assertThat(cuota.getImporte2Original()).isEqualByComparingTo("200.50");
         assertThat(cuota.getImporte3Original()).isEqualByComparingTo("300.50");
@@ -61,7 +61,7 @@ class ChequeraCuotaFactoryTest {
         var factory = new ChequeraCuotaFactory(chequeraCuotaService);
 
         var sinBeneficio = factory.crear(serie("0"), lectivo(), 0, referencia());
-        var becaCompleta = factory.crear(serie("100"), lectivo(), 0, referencia());
+        var becaCompleta = factory.crear(serie("1"), lectivo(), 0, referencia());
 
         assertThat(sinBeneficio.getImporte1()).isEqualByComparingTo(sinBeneficio.getImporte1Original());
         assertThat(sinBeneficio.getImporte2()).isEqualByComparingTo(sinBeneficio.getImporte2Original());
@@ -76,7 +76,7 @@ class ChequeraCuotaFactoryTest {
     void crear_appliesTwentyPercentWithoutBreakingTramoOrder() {
         when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
 
-        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("20"), lectivo(), 0, referencia());
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("0.20"), lectivo(), 0, referencia());
 
         assertThat(cuota.getImporte1()).isEqualByComparingTo("80");
         assertThat(cuota.getImporte2()).isEqualByComparingTo("160");
@@ -90,7 +90,7 @@ class ChequeraCuotaFactoryTest {
         var incompleta = lectivo();
         incompleta.setImporte2(null);
 
-        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("20"), incompleta, 0, referencia());
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("0.20"), incompleta, 0, referencia());
 
         assertThat(cuota.getImporte2()).isNull();
         assertThat(cuota.getImporte2Original()).isNull();
@@ -118,7 +118,7 @@ class ChequeraCuotaFactoryTest {
         var sinVencimiento = lectivo();
         sinVencimiento.setVencimiento1(null);
 
-        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("20"), sinVencimiento, 3, referencia());
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("0.20"), sinVencimiento, 3, referencia());
 
         assertThat(ChequeraCuotaFactory.vencio(sinVencimiento, referencia())).isFalse();
         assertThat(cuota.getVencimiento1()).isNull();
@@ -135,6 +135,17 @@ class ChequeraCuotaFactoryTest {
 
         assertThat(ChequeraCuotaFactory.vencio(vencida, referencia())).isTrue();
         assertThat(ChequeraCuotaFactory.vencio(lectivo(), referencia())).isFalse();
+    }
+
+    @Test
+    void crear_treatsAnOutOfScaleBenefitAsZeroInsteadOfApplyingAWrongDiscount() {
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+
+        var cuota = new ChequeraCuotaFactory(chequeraCuotaService).crear(serie("50"), lectivo(), 0, referencia());
+
+        assertThat(cuota.getImporte1()).isEqualByComparingTo("100.50");
+        assertThat(cuota.getImporte2()).isEqualByComparingTo("200.50");
+        assertThat(cuota.getImporte3()).isEqualByComparingTo("300.50");
     }
 
     private static ChequeraSerie serie(String beneficio) {

--- a/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/usecases/FindAllInconsistenciasUseCaseImplTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/application/usecases/FindAllInconsistenciasUseCaseImplTest.java
@@ -1,0 +1,77 @@
+package um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.usecases;
+
+import org.junit.jupiter.api.Test;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.ports.out.ChequeraCuotaRepository;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FindAllInconsistenciasUseCaseImplTest {
+
+    @Test
+    void findAllInconsistencias_acceptsBonifiedAndHundredPercentCuotas() {
+        var repository = mock(ChequeraCuotaRepository.class);
+        var parcial = cuota(new BigDecimal("70"), new BigDecimal("140"), new BigDecimal("210"),
+                new BigDecimal("100"), new BigDecimal("200"), new BigDecimal("300"));
+        var completa = cuota(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO,
+                new BigDecimal("100"), new BigDecimal("200"), new BigDecimal("300"));
+        when(repository.findAllByVencimiento1Between(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(List.of(parcial, completa));
+
+        assertThat(new FindAllInconsistenciasUseCaseImpl(repository)
+                .findAllInconsistencias(OffsetDateTime.now().minusDays(1), OffsetDateTime.now().plusDays(1), false)).isEmpty();
+    }
+
+    @Test
+    void findAllInconsistencias_reportsHistoricalNullFieldsInsteadOfThrowing() {
+        var repository = mock(ChequeraCuotaRepository.class);
+        var cuota = cuota(new BigDecimal("70"), new BigDecimal("140"), new BigDecimal("210"),
+                null, new BigDecimal("200"), new BigDecimal("300"));
+        when(repository.findAllByVencimiento1Between(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(List.of(cuota));
+
+        assertThat(new FindAllInconsistenciasUseCaseImpl(repository)
+                .findAllInconsistencias(OffsetDateTime.now().minusDays(1), OffsetDateTime.now().plusDays(1), false)).containsExactly(cuota);
+    }
+
+    @Test
+    void findAllInconsistencias_reportsAQuotaWhenOnlyOneTramoBreaksTheOrder() {
+        var repository = mock(ChequeraCuotaRepository.class);
+        var cuota = cuota(new BigDecimal("100"), new BigDecimal("200"), new BigDecimal("50"),
+                new BigDecimal("100"), new BigDecimal("200"), new BigDecimal("300"));
+        when(repository.findAllByVencimiento1Between(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(List.of(cuota));
+
+        assertThat(new FindAllInconsistenciasUseCaseImpl(repository)
+                .findAllInconsistencias(OffsetDateTime.now().minusDays(1), OffsetDateTime.now().plusDays(1), false))
+                .containsExactly(cuota);
+    }
+
+    @Test
+    void findAllInconsistencias_acceptsZeroBenefitAndMaximumBenefitWithinMultiplierMargin() {
+        var repository = mock(ChequeraCuotaRepository.class);
+        var sinBeneficio = cuota(new BigDecimal("100"), new BigDecimal("200"), new BigDecimal("300"),
+                new BigDecimal("100"), new BigDecimal("200"), new BigDecimal("300"));
+        var maximo = cuota(new BigDecimal("3"), new BigDecimal("6"), new BigDecimal("9"),
+                new BigDecimal("100"), new BigDecimal("200"), new BigDecimal("300"));
+        when(repository.findAllByVencimiento1Between(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(List.of(sinBeneficio, maximo));
+
+        assertThat(new FindAllInconsistenciasUseCaseImpl(repository)
+                .findAllInconsistencias(OffsetDateTime.now().minusDays(1), OffsetDateTime.now().plusDays(1), false)).isEmpty();
+    }
+
+    private static ChequeraCuota cuota(BigDecimal importe1, BigDecimal importe2, BigDecimal importe3,
+                                       BigDecimal original1, BigDecimal original2, BigDecimal original3) {
+        var now = OffsetDateTime.now();
+        return ChequeraCuota.builder().vencimiento1(now).vencimiento2(now.plusDays(1)).vencimiento3(now.plusDays(2))
+                .importe1(importe1).importe2(importe2).importe3(importe3)
+                .importe1Original(original1).importe2Original(original2).importe3Original(original3).build();
+    }
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/web/controller/ChequeraCuotaControllerTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraCuota/infrastructure/web/controller/ChequeraCuotaControllerTest.java
@@ -1,0 +1,91 @@
+package um.tesoreria.core.hexagonal.chequera.chequeraCuota.infrastructure.web.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaDeudaService;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.ports.in.CalculateDeudaUseCase;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.infrastructure.web.dto.ChequeraCuotaResponse;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.infrastructure.web.mapper.ChequeraCuotaDtoMapper;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.service.ChequeraSerieService;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(ChequeraCuotaController.class)
+class ChequeraCuotaControllerTest {
+
+    @Autowired
+    private MockMvcTester mockMvc;
+    @MockitoBean
+    private ChequeraCuotaService service;
+    @MockitoBean
+    private ChequeraCuotaDeudaService deudaService;
+    @MockitoBean
+    private ChequeraSerieService serieService;
+    @MockitoBean
+    private CalculateDeudaUseCase calculateDeudaUseCase;
+    @MockitoBean
+    private ChequeraCuotaDtoMapper mapper;
+
+    @Test
+    void findAllByChequera_returnsBonifiedAndOriginalAmounts() throws Exception {
+        var cuota = ChequeraCuota.builder().importe1(new BigDecimal("70")).importe1Original(new BigDecimal("100"))
+                .importe2(new BigDecimal("140")).importe2Original(new BigDecimal("200"))
+                .importe3(new BigDecimal("210")).importe3Original(new BigDecimal("300")).build();
+        var response = ChequeraCuotaResponse.builder().importe1(cuota.getImporte1()).importe1Original(cuota.getImporte1Original())
+                .importe2(cuota.getImporte2()).importe2Original(cuota.getImporte2Original())
+                .importe3(cuota.getImporte3()).importe3Original(cuota.getImporte3Original()).build();
+        when(service.findAllByFacultadIdAndTipoChequeraIdAndChequeraSerieIdAndAlternativaId(1, 2, 3L, 4))
+                .thenReturn(List.of(cuota));
+        when(mapper.toResponse(cuota)).thenReturn(response);
+
+        var uri = "/api/tesoreria/core/chequeraCuota/chequera/1/2/3/4";
+        assertJsonPath(uri, "$[0].importe1", 70);
+        assertJsonPath(uri, "$[0].importe1Original", 100);
+        assertJsonPath(uri, "$[0].importe2", 140);
+        assertJsonPath(uri, "$[0].importe2Original", 200);
+        assertJsonPath(uri, "$[0].importe3", 210);
+        assertJsonPath(uri, "$[0].importe3Original", 300);
+    }
+
+    @Test
+    void findAllInconsistencias_acceptsIsoDatesAndReturnsNoFalsePositives() throws Exception {
+        var desde = OffsetDateTime.parse("2026-08-01T00:00:00Z");
+        var hasta = OffsetDateTime.parse("2026-08-31T23:59:59Z");
+        when(service.findAllInconsistencias(desde, hasta, false)).thenReturn(List.of());
+
+        mockMvc.get().uri("/api/tesoreria/core/chequeraCuota/inconsistencias/2026-08-01T00:00:00Z/2026-08-31T23:59:59Z")
+                .assertThat().hasStatusOk();
+    }
+
+    @Test
+    void findByUnique_serializesBonifiedAmountsAndIsoDueDates() throws Exception {
+        var cuota = ChequeraCuota.builder().build();
+        var response = ChequeraCuotaResponse.builder()
+                .importe1(new BigDecimal("70")).importe1Original(new BigDecimal("100"))
+                .vencimiento1(OffsetDateTime.parse("2026-08-30T00:00:00Z"))
+                .build();
+        when(service.findByUnique(1, 2, 3L, 4, 5, 6)).thenReturn(cuota);
+        when(mapper.toResponse(cuota)).thenReturn(response);
+
+        var uri = "/api/tesoreria/core/chequeraCuota/unique/1/2/3/4/5/6";
+        assertJsonPath(uri, "$.importe1", 70);
+        assertJsonPath(uri, "$.importe1Original", 100);
+        assertJsonPath(uri, "$.vencimiento1", "2026-08-30T00:00:00Z");
+    }
+
+    private void assertJsonPath(String uri, String path, Object expected) {
+        mockMvc.get().uri(uri)
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson().extractingPath(path).isEqualTo(expected);
+    }
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraDetailsCreatorTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraDetailsCreatorTest.java
@@ -1,0 +1,331 @@
+package um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.factory.ChequeraCuotaFactory;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
+import um.tesoreria.core.hexagonal.chequera.chequeraTotal.application.service.ChequeraTotalService;
+import um.tesoreria.core.hexagonal.chequera.chequeraTotal.domain.model.ChequeraTotal;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.application.service.LectivoCuotaService;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.model.LectivoCuota;
+import um.tesoreria.core.kotlin.model.ChequeraAlternativa;
+import um.tesoreria.core.kotlin.model.LectivoAlternativa;
+import um.tesoreria.core.model.LectivoTotal;
+import um.tesoreria.core.service.ChequeraAlternativaService;
+import um.tesoreria.core.service.LectivoAlternativaService;
+import um.tesoreria.core.service.LectivoTotalService;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PreuniversitarioChequeraDetailsCreatorTest {
+
+    @Mock
+    private LectivoTotalService lectivoTotalService;
+    @Mock
+    private ChequeraTotalService chequeraTotalService;
+    @Mock
+    private LectivoAlternativaService lectivoAlternativaService;
+    @Mock
+    private ChequeraAlternativaService chequeraAlternativaService;
+    @Mock
+    private LectivoCuotaService lectivoCuotaService;
+    @Mock
+    private ChequeraCuotaService chequeraCuotaService;
+
+    @Test
+    void create_characterizesCurrentListPricesOriginalsBarcodeAndOrder() {
+        var series = serie();
+        var source = LectivoCuota.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3)
+                .productoId(4).alternativaId(5).cuotaId(6).mes(7).anho(2026).tramoId(99)
+                .vencimiento1(OffsetDateTime.now().plusDays(10)).importe1(new BigDecimal("100.50"))
+                .vencimiento2(OffsetDateTime.now().plusDays(20)).importe2(new BigDecimal("120.50"))
+                .vencimiento3(OffsetDateTime.now().plusDays(30)).importe3(new BigDecimal("140.50"))
+                .build();
+
+        when(lectivoAlternativaService.findAllByTipo(1, 2, 3, 5)).thenReturn(List.of());
+        when(lectivoCuotaService.findAllByTipo(1, 2, 3, 5)).thenReturn(List.of(source));
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+        when(chequeraCuotaService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(chequeraTotalService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(chequeraAlternativaService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        creator().create(series);
+
+        var cuotas = captor(ChequeraCuota.class);
+        org.mockito.Mockito.verify(chequeraCuotaService).saveAll(cuotas.capture());
+        var cuota = cuotas.getValue().getFirst();
+        assertThat(cuota.getVencimiento1()).isEqualTo(source.getVencimiento1());
+        assertThat(cuota.getVencimiento2()).isEqualTo(source.getVencimiento2());
+        assertThat(cuota.getVencimiento3()).isEqualTo(source.getVencimiento3());
+        assertThat(cuota.getImporte1()).isEqualByComparingTo(source.getImporte1());
+        assertThat(cuota.getImporte2()).isEqualByComparingTo(source.getImporte2());
+        assertThat(cuota.getImporte3()).isEqualByComparingTo(source.getImporte3());
+        assertThat(cuota.getImporte1Original()).isEqualByComparingTo(source.getImporte1());
+        assertThat(cuota.getImporte2Original()).isEqualByComparingTo(source.getImporte2());
+        assertThat(cuota.getImporte3Original()).isEqualByComparingTo(source.getImporte3());
+        assertThat(cuota.getArancelTipoId()).isEqualTo(series.getArancelTipoId());
+        assertThat(cuota.getTramoId()).isZero();
+        assertThat(cuota.getCodigoBarras()).isEqualTo("barcode");
+        assertThat(cuota.getPagado()).isZero();
+        assertThat(cuota.getBaja()).isZero();
+        assertThat(cuota.getManual()).isZero();
+        assertThat(cuota.getCompensada()).isZero();
+
+        InOrder order = inOrder(chequeraTotalService, chequeraAlternativaService, chequeraCuotaService);
+        order.verify(chequeraAlternativaService).saveAll(anyList());
+        order.verify(chequeraCuotaService).saveAll(anyList());
+        order.verify(chequeraTotalService).saveAll(anyList());
+    }
+
+    @Test
+    void create_calculatesTotalsFromSavedActiveCuotas() {
+        var series = serie();
+        var source = LectivoCuota.builder()
+                .facultadId(1).lectivoId(2).tipoChequeraId(3)
+                .productoId(4).alternativaId(5).cuotaId(6).mes(7).anho(2026)
+                .vencimiento1(OffsetDateTime.now().plusDays(10)).importe1(new BigDecimal("999.99"))
+                .vencimiento2(OffsetDateTime.now().plusDays(20)).importe2(new BigDecimal("1000"))
+                .vencimiento3(OffsetDateTime.now().plusDays(30)).importe3(new BigDecimal("1001"))
+                .build();
+
+        when(lectivoAlternativaService.findAllByTipo(1, 2, 3, 5)).thenReturn(List.of());
+        when(lectivoCuotaService.findAllByTipo(1, 2, 3, 5)).thenReturn(List.of(source));
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+        when(chequeraCuotaService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(chequeraTotalService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(chequeraAlternativaService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        creator().create(series);
+
+        var totals = captor(ChequeraTotal.class);
+        org.mockito.Mockito.verify(chequeraTotalService).saveAll(totals.capture());
+        assertThat(totals.getValue()).singleElement().satisfies(saved -> {
+            assertThat(saved.getProductoId()).isEqualTo(4);
+            assertThat(saved.getTotal()).isEqualByComparingTo("999.99");
+            assertThat(saved.getPagado()).isEqualByComparingTo(BigDecimal.ZERO);
+        });
+    }
+
+    @Test
+    void create_replacesExpiredDueDatesAndIncrementsOnlyExpiredQuotaOffsets() {
+        var series = serie();
+        var future = cuota(4, OffsetDateTime.now().plusDays(10));
+        var expired1 = cuota(5, OffsetDateTime.now().minusDays(2));
+        var expired2 = cuota(6, OffsetDateTime.now().minusDays(1));
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+        stubCreateSources(List.of(future, expired1, expired2));
+
+        creator().create(series);
+
+        var cuotas = captor(ChequeraCuota.class);
+        org.mockito.Mockito.verify(chequeraCuotaService).saveAll(cuotas.capture());
+        var saved = cuotas.getValue();
+        assertThat(saved.get(0).getVencimiento1()).isEqualTo(future.getVencimiento1());
+        assertThat(saved.get(1).getVencimiento2()).isEqualTo(saved.get(1).getVencimiento1().plusDays(13));
+        assertThat(saved.get(1).getVencimiento3()).isEqualTo(saved.get(1).getVencimiento1().plusDays(33));
+        assertThat(saved.get(2).getVencimiento1()).isEqualTo(saved.get(1).getVencimiento1().plusDays(30));
+    }
+
+    @Test
+    void create_savesEmptyCuotasAndTotalsWhenNoLectivoCuotasExist() {
+        var series = serie();
+        stubCreateSources(List.of());
+
+        creator().create(series);
+
+        var cuotas = captor(ChequeraCuota.class);
+        var totals = captor(ChequeraTotal.class);
+        org.mockito.Mockito.verify(chequeraCuotaService).saveAll(cuotas.capture());
+        org.mockito.Mockito.verify(chequeraTotalService).saveAll(totals.capture());
+        assertThat(cuotas.getValue()).isEmpty();
+        assertThat(totals.getValue()).isEmpty();
+    }
+
+    @Test
+    void create_totalsOnlyActiveCuotasAndKeepsProductsSeparated() {
+        var series = serie();
+        var factory = org.mockito.Mockito.mock(ChequeraCuotaFactory.class);
+        var activaProducto1 = ChequeraCuota.builder().productoId(1).importe1(new BigDecimal("11")).baja((byte) 0).build();
+        var bajaProducto1 = ChequeraCuota.builder().productoId(1).importe1(new BigDecimal("99")).baja((byte) 1).build();
+        var activaProducto2 = ChequeraCuota.builder().productoId(2).importe1(new BigDecimal("22")).baja((byte) 0).build();
+        stubCreateSources(List.of(cuota(1, OffsetDateTime.now().plusDays(1)),
+                cuota(2, OffsetDateTime.now().plusDays(2)), cuota(3, OffsetDateTime.now().plusDays(3))));
+        when(factory.crear(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any()))
+                .thenReturn(activaProducto1, bajaProducto1, activaProducto2);
+
+        creator(factory).create(series);
+
+        var totals = captor(ChequeraTotal.class);
+        org.mockito.Mockito.verify(chequeraTotalService).saveAll(totals.capture());
+        assertThat(totals.getValue()).extracting(ChequeraTotal::getProductoId, ChequeraTotal::getTotal)
+                .containsExactlyInAnyOrder(org.assertj.core.groups.Tuple.tuple(1, new BigDecimal("11")),
+                        org.assertj.core.groups.Tuple.tuple(2, new BigDecimal("22")));
+    }
+
+    @Test
+    void create_keepsProductsWithoutCuotasInTheChosenAlternativeAsZeroTotals() {
+        var series = serie();
+        when(lectivoTotalService.findAllByTipo(1, 2, 3)).thenReturn(List.of(lectivoTotal(4), lectivoTotal(8)));
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+        stubCreateSources(List.of(cuota(1, OffsetDateTime.now().plusDays(1))));
+
+        creator().create(series);
+
+        var totals = captor(ChequeraTotal.class);
+        org.mockito.Mockito.verify(chequeraTotalService).saveAll(totals.capture());
+        assertThat(totals.getValue()).extracting(ChequeraTotal::getProductoId, ChequeraTotal::getTotal)
+                .containsExactlyInAnyOrder(org.assertj.core.groups.Tuple.tuple(4, BigDecimal.TEN),
+                        org.assertj.core.groups.Tuple.tuple(8, BigDecimal.ZERO));
+        assertThat(totals.getValue()).allSatisfy(saved ->
+                assertThat(saved.getPagado()).isEqualByComparingTo(BigDecimal.ZERO));
+    }
+
+    @Test
+    void create_persistsZeroTotalWhenTheProductHasNoCuotasAtAll() {
+        var series = serie();
+        when(lectivoTotalService.findAllByTipo(1, 2, 3)).thenReturn(List.of(lectivoTotal(8)));
+        stubCreateSources(List.of());
+
+        creator().create(series);
+
+        var totals = captor(ChequeraTotal.class);
+        org.mockito.Mockito.verify(chequeraTotalService).saveAll(totals.capture());
+        assertThat(totals.getValue()).singleElement().satisfies(saved -> {
+            assertThat(saved.getProductoId()).isEqualTo(8);
+            assertThat(saved.getTotal()).isEqualByComparingTo(BigDecimal.ZERO);
+        });
+    }
+
+    @Test
+    void create_excludesNullImportesFromTotalsWithoutAbortingEmission() {
+        var series = serie();
+        var factory = org.mockito.Mockito.mock(ChequeraCuotaFactory.class);
+        var conImporte = ChequeraCuota.builder().productoId(4).cuotaId(1)
+                .importe1(new BigDecimal("70")).baja((byte) 0).build();
+        var sinImporte = ChequeraCuota.builder().productoId(4).cuotaId(2)
+                .importe1(null).baja((byte) 0).build();
+        stubCreateSources(List.of(cuota(1, OffsetDateTime.now().plusDays(1)),
+                cuota(2, OffsetDateTime.now().plusDays(2))));
+        when(factory.crear(any(), any(), org.mockito.ArgumentMatchers.anyInt(), any()))
+                .thenReturn(conImporte, sinImporte);
+
+        creator(factory).create(series);
+
+        var totals = captor(ChequeraTotal.class);
+        org.mockito.Mockito.verify(chequeraTotalService).saveAll(totals.capture());
+        assertThat(totals.getValue()).singleElement().satisfies(saved -> {
+            assertThat(saved.getProductoId()).isEqualTo(4);
+            assertThat(saved.getTotal()).isEqualByComparingTo("70");
+        });
+    }
+
+    @Test
+    void create_doesNotShiftOffsetWhenTheFirstDueDateIsNull() {
+        var series = serie();
+        var sinVencimiento = LectivoCuota.builder().facultadId(1).lectivoId(2).tipoChequeraId(3)
+                .productoId(4).alternativaId(5).cuotaId(1).mes(7).anho(2026)
+                .importe1(BigDecimal.TEN).importe2(BigDecimal.valueOf(20)).importe3(BigDecimal.valueOf(30))
+                .build();
+        var futura = cuota(2, OffsetDateTime.now().plusDays(10));
+        when(chequeraCuotaService.calculateCodigoBarras(any(ChequeraCuota.class))).thenReturn("barcode");
+        stubCreateSources(List.of(sinVencimiento, futura));
+
+        creator().create(series);
+
+        var cuotas = captor(ChequeraCuota.class);
+        org.mockito.Mockito.verify(chequeraCuotaService).saveAll(cuotas.capture());
+        var saved = cuotas.getValue();
+        assertThat(saved.get(0).getVencimiento1()).isNull();
+        assertThat(saved.get(0).getCodigoBarras()).isEmpty();
+        assertThat(saved.get(1).getVencimiento1()).isEqualTo(futura.getVencimiento1());
+    }
+
+    @Test
+    void create_copiesAlternativesBeforeCreatingCuotas() {
+        var source = org.mockito.Mockito.mock(LectivoAlternativa.class);
+        when(source.getProductoId()).thenReturn(7);
+        when(source.getAlternativaId()).thenReturn(5);
+        when(source.getTitulo()).thenReturn("Plan de pagos");
+        when(source.getCuotas()).thenReturn(3);
+        when(lectivoAlternativaService.findAllByTipo(1, 2, 3, 5)).thenReturn(List.of(source));
+        when(lectivoCuotaService.findAllByTipo(1, 2, 3, 5)).thenReturn(List.of());
+        when(chequeraAlternativaService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(chequeraCuotaService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(chequeraTotalService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        creator().create(serie());
+
+        var alternatives = captor(ChequeraAlternativa.class);
+        org.mockito.Mockito.verify(chequeraAlternativaService).saveAll(alternatives.capture());
+        assertThat(alternatives.getValue()).singleElement().satisfies(alternative -> {
+            assertThat(alternative.getProductoId()).isEqualTo(7);
+            assertThat(alternative.getTitulo()).isEqualTo("Plan de pagos");
+            assertThat(alternative.getCuotas()).isEqualTo(3);
+        });
+    }
+
+    private void stubCreateSources(List<LectivoCuota> cuotas) {
+        when(lectivoAlternativaService.findAllByTipo(1, 2, 3, 5)).thenReturn(List.of());
+        when(lectivoCuotaService.findAllByTipo(1, 2, 3, 5)).thenReturn(cuotas);
+        when(chequeraCuotaService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(chequeraTotalService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(chequeraAlternativaService.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private static LectivoCuota cuota(int cuotaId, OffsetDateTime vencimiento1) {
+        return LectivoCuota.builder().facultadId(1).lectivoId(2).tipoChequeraId(3)
+                .productoId(4).alternativaId(5).cuotaId(cuotaId).mes(7).anho(2026)
+                .vencimiento1(vencimiento1).importe1(BigDecimal.TEN)
+                .vencimiento2(vencimiento1.plusDays(10)).importe2(BigDecimal.valueOf(20))
+                .vencimiento3(vencimiento1.plusDays(20)).importe3(BigDecimal.valueOf(30)).build();
+    }
+
+    private PreuniversitarioChequeraDetailsCreator creator() {
+        return creator(new ChequeraCuotaFactory(chequeraCuotaService));
+    }
+
+    private PreuniversitarioChequeraDetailsCreator creator(ChequeraCuotaFactory factory) {
+        return new PreuniversitarioChequeraDetailsCreator(lectivoTotalService, chequeraTotalService,
+                lectivoAlternativaService, chequeraAlternativaService, lectivoCuotaService,
+                factory, chequeraCuotaService);
+    }
+
+    private static LectivoTotal lectivoTotal(int productoId) {
+        var total = new LectivoTotal();
+        total.setFacultadId(1);
+        total.setLectivoId(2);
+        total.setTipoChequeraId(3);
+        total.setProductoId(productoId);
+        total.setTotal(new BigDecimal("5000"));
+        return total;
+    }
+
+    private static ChequeraSerie serie() {
+        return ChequeraSerie.builder()
+                .chequeraId(10L).facultadId(1).lectivoId(2).tipoChequeraId(3)
+                .chequeraSerieId(4L).alternativaId(5).arancelTipoId(6)
+                .becaPorcentaje(BigDecimal.ZERO)
+                .build();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static <T> ArgumentCaptor<List<T>> captor(Class<T> ignored) {
+        return ArgumentCaptor.forClass((Class) List.class);
+    }
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraServiceTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraServiceTest.java
@@ -6,14 +6,26 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.PreuniversitarioChequeraData;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.exception.ChequeraSerieException;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.RequisitoGuarani;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.RequisitoPresentadoGuarani;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.application.service.GuaraniBeneficioService;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.model.GuaraniBeneficio;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.policy.BeneficioPolicy;
+import um.tesoreria.core.kotlin.model.Build;
+import um.tesoreria.core.hexagonal.personas.legajo.domain.model.Legajo;
 import um.tesoreria.core.service.ChequeraSerieControlService;
+import um.tesoreria.core.model.ChequeraSerieControl;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class PreuniversitarioChequeraServiceTest {
@@ -30,6 +42,10 @@ class PreuniversitarioChequeraServiceTest {
     private PreuniversitarioChequeraDetailsCreator detailsCreator;
     @Mock
     private PreuniversitarioChequeraPolicy policy;
+    @Mock
+    private GuaraniBeneficioService guaraniBeneficioService;
+    @Mock
+    private BeneficioPolicy beneficioPolicy;
 
     @InjectMocks
     private PreuniversitarioChequeraService service;
@@ -43,5 +59,110 @@ class PreuniversitarioChequeraServiceTest {
         assertThat(service.create(data)).isNull();
         verifyNoInteractions(legajoManager, chequeraSerieService,
                 chequeraSerieControlService, detailsCreator);
+    }
+
+    @Test
+    void create_persistsResolvedMaximumBenefitAndContinuesWithEmission() {
+        var requisito = RequisitoPresentadoGuarani.builder().requisito(99).persona(1)
+                .requisitoRel(RequisitoGuarani.builder().requisitoIngreso("S").activo("S").build()).build();
+        var data = new PreuniversitarioChequeraData(10, 20, 30, BigDecimal.ONE, 50, List.of(requisito));
+        var context = new PreuniversitarioChequeraContext(1, 2, 3, 4, BigDecimal.ONE, 50,
+                new Build(1L));
+        var control = new ChequeraSerieControl(null, 3, 2, 1L, (byte) 0, 0, 0, 0L, (byte) 0);
+        var serie = ChequeraSerie.builder().facultadId(3).tipoChequeraId(2).chequeraSerieId(1L)
+                .becaPorcentaje(new BigDecimal("30")).build();
+
+        when(dataResolver.resolve(data)).thenReturn(Optional.of(context));
+        when(legajoManager.findOrCreate(context)).thenReturn(mock(Legajo.class));
+        when(chequeraSerieService.findPreuniversitarioByPersonaIdAndDocumentoIdAndFacultadIdAndLectivoIdAndGeograficaId(
+                BigDecimal.ONE, 50, 3, 1, 4)).thenThrow(new ChequeraSerieException(1L));
+        when(guaraniBeneficioService.findByRequisitos(List.of(99)))
+                .thenReturn(List.of(GuaraniBeneficio.builder().requisito(99).porcentajeBeneficio(new BigDecimal("30")).build()));
+        when(beneficioPolicy.porcentajeEfectivo(eq(List.of(requisito)), any())).thenReturn(new BigDecimal("30"));
+        when(chequeraSerieControlService.findLastByTipoChequera(3, 2)).thenThrow(new um.tesoreria.core.exception.ChequeraSerieControlException(3, 2));
+        when(chequeraSerieControlService.add(any())).thenReturn(control);
+        when(policy.createSerie(context, control, new BigDecimal("30"))).thenReturn(serie);
+        when(chequeraSerieService.add(serie)).thenReturn(serie);
+
+        assertThat(service.create(data)).isSameAs(serie);
+        assertThat(serie.getBecaPorcentaje()).isEqualByComparingTo(new BigDecimal("30"));
+        verify(detailsCreator).create(serie);
+    }
+
+    @Test
+    void create_emitsWithZeroBenefitWhenRequirementsAreAbsent() {
+        var data = new PreuniversitarioChequeraData(10, 20, 30, BigDecimal.ONE, 50, List.of());
+        var context = context();
+        var control = control();
+        var serie = ChequeraSerie.builder().facultadId(3).tipoChequeraId(2).chequeraSerieId(1L)
+                .becaPorcentaje(BigDecimal.ZERO).build();
+        stubNewSeriesCreation(data, context, control, serie, BigDecimal.ZERO);
+
+        assertThat(service.create(data)).isSameAs(serie);
+
+        verifyNoInteractions(guaraniBeneficioService);
+        verify(beneficioPolicy, never()).porcentajeEfectivo(any(), any());
+        verify(policy).createSerie(context, control, BigDecimal.ZERO);
+        verify(detailsCreator).create(serie);
+    }
+
+    @Test
+    void create_emitsWithZeroBenefitWhenBenefitLookupFails() {
+        var requisito = RequisitoPresentadoGuarani.builder().requisito(99).persona(1)
+                .requisitoRel(RequisitoGuarani.builder().requisitoIngreso("S").activo("S").build()).build();
+        var data = new PreuniversitarioChequeraData(10, 20, 30, BigDecimal.ONE, 50, List.of(requisito));
+        var context = context();
+        var control = control();
+        var serie = ChequeraSerie.builder().facultadId(3).tipoChequeraId(2).chequeraSerieId(1L)
+                .becaPorcentaje(BigDecimal.ZERO).build();
+        stubNewSeriesCreation(data, context, control, serie, BigDecimal.ZERO);
+        when(guaraniBeneficioService.findByRequisitos(List.of(99))).thenThrow(new IllegalStateException("db down"));
+
+        assertThat(service.create(data)).isSameAs(serie);
+
+        verify(policy).createSerie(context, control, BigDecimal.ZERO);
+        verify(detailsCreator).create(serie);
+    }
+
+    @Test
+    void create_emitsWithZeroBenefitWhenALegacyBenefitHasNoPercentage() {
+        var requisito = RequisitoPresentadoGuarani.builder().requisito(99).persona(1)
+                .requisitoRel(RequisitoGuarani.builder().requisitoIngreso("S").activo("S").build()).build();
+        var data = new PreuniversitarioChequeraData(10, 20, 30, BigDecimal.ONE, 50, List.of(requisito));
+        var context = context();
+        var control = control();
+        var serie = ChequeraSerie.builder().facultadId(3).tipoChequeraId(2).chequeraSerieId(1L)
+                .becaPorcentaje(BigDecimal.ZERO).build();
+        stubNewSeriesCreation(data, context, control, serie, BigDecimal.ZERO);
+        var beneficioIncompleto = GuaraniBeneficio.builder().requisito(99).porcentajeBeneficio(null).build();
+        when(guaraniBeneficioService.findByRequisitos(List.of(99))).thenReturn(List.of(beneficioIncompleto));
+        when(beneficioPolicy.porcentajeEfectivo(List.of(requisito), List.of(beneficioIncompleto)))
+                .thenReturn(BigDecimal.ZERO);
+
+        assertThat(service.create(data)).isSameAs(serie);
+
+        verify(policy).createSerie(context, control, BigDecimal.ZERO);
+        verify(detailsCreator).create(serie);
+    }
+
+    private void stubNewSeriesCreation(PreuniversitarioChequeraData data, PreuniversitarioChequeraContext context,
+                                       ChequeraSerieControl control, ChequeraSerie serie, BigDecimal beneficio) {
+        when(dataResolver.resolve(data)).thenReturn(Optional.of(context));
+        when(legajoManager.findOrCreate(context)).thenReturn(mock(Legajo.class));
+        when(chequeraSerieService.findPreuniversitarioByPersonaIdAndDocumentoIdAndFacultadIdAndLectivoIdAndGeograficaId(
+                BigDecimal.ONE, 50, 3, 1, 4)).thenThrow(new ChequeraSerieException(1L));
+        when(chequeraSerieControlService.findLastByTipoChequera(3, 2))
+                .thenThrow(new um.tesoreria.core.exception.ChequeraSerieControlException(3, 2));
+        when(chequeraSerieControlService.add(any())).thenReturn(control);
+        when(policy.createSerie(context, control, beneficio)).thenReturn(serie);
+        when(chequeraSerieService.add(serie)).thenReturn(serie);
+    }
+
+    private static PreuniversitarioChequeraContext context() {
+        return new PreuniversitarioChequeraContext(1, 2, 3, 4, BigDecimal.ONE, 50, new Build(1L));
+    }
+
+    private static ChequeraSerieControl control() {
+        return new ChequeraSerieControl(null, 3, 2, 1L, (byte) 0, 0, 0, 0L, (byte) 0);
     }
 }

--- a/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraServiceTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/application/service/PreuniversitarioChequeraServiceTest.java
@@ -70,22 +70,22 @@ class PreuniversitarioChequeraServiceTest {
                 new Build(1L));
         var control = new ChequeraSerieControl(null, 3, 2, 1L, (byte) 0, 0, 0, 0L, (byte) 0);
         var serie = ChequeraSerie.builder().facultadId(3).tipoChequeraId(2).chequeraSerieId(1L)
-                .becaPorcentaje(new BigDecimal("30")).build();
+                .becaPorcentaje(new BigDecimal("0.30")).build();
 
         when(dataResolver.resolve(data)).thenReturn(Optional.of(context));
         when(legajoManager.findOrCreate(context)).thenReturn(mock(Legajo.class));
         when(chequeraSerieService.findPreuniversitarioByPersonaIdAndDocumentoIdAndFacultadIdAndLectivoIdAndGeograficaId(
                 BigDecimal.ONE, 50, 3, 1, 4)).thenThrow(new ChequeraSerieException(1L));
         when(guaraniBeneficioService.findByRequisitos(List.of(99)))
-                .thenReturn(List.of(GuaraniBeneficio.builder().requisito(99).porcentajeBeneficio(new BigDecimal("30")).build()));
-        when(beneficioPolicy.porcentajeEfectivo(eq(List.of(requisito)), any())).thenReturn(new BigDecimal("30"));
+                .thenReturn(List.of(GuaraniBeneficio.builder().requisito(99).porcentajeBeneficio(new BigDecimal("0.30")).build()));
+        when(beneficioPolicy.porcentajeEfectivo(eq(List.of(requisito)), any())).thenReturn(new BigDecimal("0.30"));
         when(chequeraSerieControlService.findLastByTipoChequera(3, 2)).thenThrow(new um.tesoreria.core.exception.ChequeraSerieControlException(3, 2));
         when(chequeraSerieControlService.add(any())).thenReturn(control);
-        when(policy.createSerie(context, control, new BigDecimal("30"))).thenReturn(serie);
+        when(policy.createSerie(context, control, new BigDecimal("0.30"))).thenReturn(serie);
         when(chequeraSerieService.add(serie)).thenReturn(serie);
 
         assertThat(service.create(data)).isSameAs(serie);
-        assertThat(serie.getBecaPorcentaje()).isEqualByComparingTo(new BigDecimal("30"));
+        assertThat(serie.getBecaPorcentaje()).isEqualByComparingTo(new BigDecimal("0.30"));
         verify(detailsCreator).create(serie);
     }
 

--- a/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/web/controller/ChequeraSerieControllerTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/chequera/chequeraSerie/infrastructure/web/controller/ChequeraSerieControllerTest.java
@@ -1,0 +1,32 @@
+package um.tesoreria.core.hexagonal.chequera.chequeraSerie.infrastructure.web.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.service.ChequeraSerieService;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.infrastructure.web.mapper.ChequeraSerieDtoMapper;
+
+@WebMvcTest(ChequeraSerieController.class)
+class ChequeraSerieControllerTest {
+
+    @Autowired
+    private MockMvcTester mockMvc;
+    @MockitoBean
+    private ChequeraSerieService service;
+    @MockitoBean
+    private ChequeraCuotaService chequeraCuotaService;
+    @MockitoBean
+    private ChequeraSerieDtoMapper mapper;
+
+    @Test
+    void update_rejectsBenefitOutsideTheFractionalScaleBeforeMapping() {
+        mockMvc.put().uri("/api/tesoreria/core/chequeraSerie/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"becaPorcentaje\":50}")
+                .assertThat().hasStatus(400);
+    }
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/guarani/alumnoGuarani/application/usecases/CreatePreuniversitarioUseCaseImplTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/guarani/alumnoGuarani/application/usecases/CreatePreuniversitarioUseCaseImplTest.java
@@ -1,0 +1,78 @@
+package um.tesoreria.core.hexagonal.guarani.alumnoGuarani.application.usecases;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.PreuniversitarioChequeraData;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.ports.in.CreatePreuniversitarioChequeraUseCase;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.AlumnoGuarani;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.PersonaGuarani;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.PropuestaGuarani;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.PropuestaResponsableAcademicaGuarani;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.RequisitoPresentadoGuarani;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.infrastructure.web.dto.PersonalesResponse;
+import um.tesoreria.core.hexagonal.personas.persona.infrastructure.web.dto.PersonaResponse;
+import um.tesoreria.core.service.facade.MailChequeraService;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CreatePreuniversitarioUseCaseImplTest {
+
+    @Test
+    void createPreuniversitario_keepsSendChequeraForHundredPercentBenefit() {
+        var createChequera = mock(CreatePreuniversitarioChequeraUseCase.class);
+        var mailChequera = mock(MailChequeraService.class);
+        var request = request();
+        var alumno = request.getAlumnoGuarani();
+        var serie = ChequeraSerie.builder()
+                .facultadId(1).tipoChequeraId(2).chequeraSerieId(3L).alternativaId(4)
+                .becaPorcentaje(new BigDecimal("100")).justCreated(true).build();
+        when(createChequera.create(any())).thenReturn(serie);
+
+        assertThat(new CreatePreuniversitarioUseCaseImpl(createChequera, mailChequera)
+                .createPreuniversitario(request)).isSameAs(alumno);
+
+        var data = ArgumentCaptor.forClass(PreuniversitarioChequeraData.class);
+        verify(createChequera).create(data.capture());
+        assertThat(data.getValue().requisitosPresentados()).isEmpty();
+        verify(mailChequera).sendChequera(1, 2, 3L, 4, false, false, false);
+    }
+
+    @Test
+    void createPreuniversitario_passesPresentedRequirementsUnchangedToChequeraCreation() {
+        var createChequera = mock(CreatePreuniversitarioChequeraUseCase.class);
+        var mailChequera = mock(MailChequeraService.class);
+        var request = request();
+        var requisitos = List.of(RequisitoPresentadoGuarani.builder().persona(1).requisito(10).build());
+        when(request.getAlumnoGuarani().getPersonaRel()).thenReturn(PersonaGuarani.builder()
+                .requisitosPresentados(requisitos).build());
+        when(createChequera.create(any())).thenReturn(null);
+
+        new CreatePreuniversitarioUseCaseImpl(createChequera, mailChequera).createPreuniversitario(request);
+
+        var data = ArgumentCaptor.forClass(PreuniversitarioChequeraData.class);
+        verify(createChequera).create(data.capture());
+        assertThat(data.getValue().requisitosPresentados()).isSameAs(requisitos);
+    }
+
+    private static PersonalesResponse request() {
+        var alumno = mock(AlumnoGuarani.class);
+        when(alumno.getPropuesta()).thenReturn(10);
+        when(alumno.getUbicacion()).thenReturn(20);
+        var responsable = mock(PropuestaResponsableAcademicaGuarani.class);
+        when(responsable.getResponsableAcademica()).thenReturn(30);
+        var propuesta = mock(PropuestaGuarani.class);
+        when(propuesta.getResponsablesAcademicas()).thenReturn(List.of(responsable));
+        var persona = mock(PersonaResponse.class);
+        when(persona.getPersonaId()).thenReturn(BigDecimal.ONE);
+        when(persona.getDocumentoId()).thenReturn(40);
+        return PersonalesResponse.builder().alumnoGuarani(alumno).propuestaGuarani(propuesta).persona(persona).build();
+    }
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/application/usecases/CreateGuaraniBeneficioUseCaseImplTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/application/usecases/CreateGuaraniBeneficioUseCaseImplTest.java
@@ -1,0 +1,31 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.application.usecases;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.application.exception.GuaraniBeneficioException;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.model.GuaraniBeneficio;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.ports.out.GuaraniBeneficioRepository;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CreateGuaraniBeneficioUseCaseImplTest {
+
+    @Test
+    void create_rejectsExistingAndConcurrentDuplicatesAsDomainConflict() {
+        var repository = mock(GuaraniBeneficioRepository.class);
+        var useCase = new CreateGuaraniBeneficioUseCaseImpl(repository);
+        var beneficio = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(BigDecimal.TEN).build();
+        when(repository.findByRequisito(10)).thenReturn(Optional.of(beneficio));
+
+        assertThatThrownBy(() -> useCase.create(beneficio)).isInstanceOf(GuaraniBeneficioException.class);
+
+        when(repository.findByRequisito(10)).thenReturn(Optional.empty());
+        when(repository.save(beneficio)).thenThrow(new DataIntegrityViolationException("duplicate"));
+        assertThatThrownBy(() -> useCase.create(beneficio)).isInstanceOf(GuaraniBeneficioException.class);
+    }
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicyTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicyTest.java
@@ -1,0 +1,69 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.policy;
+
+import org.junit.jupiter.api.Test;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.RequisitoGuarani;
+import um.tesoreria.core.hexagonal.guarani.alumnoGuarani.domain.model.RequisitoPresentadoGuarani;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.model.GuaraniBeneficio;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BeneficioPolicyTest {
+
+    private final BeneficioPolicy policy = new BeneficioPolicy();
+
+    @Test
+    void porcentajeEfectivo_usesMaximumOnlyAmongActiveIngresoRequirements() {
+        var requisitos = List.of(requisito(1, "S", "S"), requisito(2, "s", "S"),
+                requisito(3, "N", "S"), requisito(4, "S", "N"));
+        var beneficios = List.of(beneficio(1, "10"), beneficio(2, "30"), beneficio(3, "90"), beneficio(4, "80"));
+
+        assertThat(policy.porcentajeEfectivo(requisitos, beneficios)).isEqualByComparingTo("30");
+    }
+
+    @Test
+    void porcentajeEfectivo_isNullSafeAndIgnoresLegacyNullPercentages() {
+        assertThat(policy.porcentajeEfectivo(null, List.of(beneficio(1, "50"))))
+                .isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(policy.porcentajeEfectivo(List.of(requisito(1, "S", "S")), null))
+                .isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(policy.porcentajeEfectivo(List.of(requisito(1, "S", "S")),
+                List.of(beneficio(1, null)))).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void porcentajeEfectivo_ignoresNullRelationsAndDoesNotCountUnpresentedBenefits() {
+        var sinRelacion = RequisitoPresentadoGuarani.builder().persona(123).requisito(1).build();
+
+        assertThat(policy.porcentajeEfectivo(List.of(sinRelacion, requisito(2, "S", "S")),
+                List.of(beneficio(1, "100"), beneficio(2, "20"), beneficio(3, "99"))))
+                .isEqualByComparingTo("20");
+    }
+
+    @Test
+    void porcentajeEfectivo_isIdempotentForRepeatedEligibleRequirement() {
+        var requisito = requisito(1, "S", "S");
+
+        assertThat(policy.porcentajeEfectivo(List.of(requisito, requisito), List.of(beneficio(1, "20"))))
+                .isEqualByComparingTo("20");
+    }
+
+    @Test
+    void porcentajeEfectivo_returnsZeroForEmptyOrUnconfiguredRequirements() {
+        assertThat(policy.porcentajeEfectivo(List.of(), List.of())).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(policy.porcentajeEfectivo(List.of(requisito(1, "S", "S")), List.of(beneficio(2, "20"))))
+                .isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    private static RequisitoPresentadoGuarani requisito(Integer id, String ingreso, String activo) {
+        return RequisitoPresentadoGuarani.builder().persona(123).requisito(id)
+                .requisitoRel(RequisitoGuarani.builder().requisitoIngreso(ingreso).activo(activo).build()).build();
+    }
+
+    private static GuaraniBeneficio beneficio(Integer requisito, String porcentaje) {
+        return GuaraniBeneficio.builder().requisito(requisito)
+                .porcentajeBeneficio(porcentaje == null ? null : new BigDecimal(porcentaje)).build();
+    }
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicyTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/domain/policy/BeneficioPolicyTest.java
@@ -18,14 +18,14 @@ class BeneficioPolicyTest {
     void porcentajeEfectivo_usesMaximumOnlyAmongActiveIngresoRequirements() {
         var requisitos = List.of(requisito(1, "S", "S"), requisito(2, "s", "S"),
                 requisito(3, "N", "S"), requisito(4, "S", "N"));
-        var beneficios = List.of(beneficio(1, "10"), beneficio(2, "30"), beneficio(3, "90"), beneficio(4, "80"));
+        var beneficios = List.of(beneficio(1, "0.10"), beneficio(2, "0.30"), beneficio(3, "0.90"), beneficio(4, "0.80"));
 
-        assertThat(policy.porcentajeEfectivo(requisitos, beneficios)).isEqualByComparingTo("30");
+        assertThat(policy.porcentajeEfectivo(requisitos, beneficios)).isEqualByComparingTo("0.30");
     }
 
     @Test
     void porcentajeEfectivo_isNullSafeAndIgnoresLegacyNullPercentages() {
-        assertThat(policy.porcentajeEfectivo(null, List.of(beneficio(1, "50"))))
+        assertThat(policy.porcentajeEfectivo(null, List.of(beneficio(1, "0.50"))))
                 .isEqualByComparingTo(BigDecimal.ZERO);
         assertThat(policy.porcentajeEfectivo(List.of(requisito(1, "S", "S")), null))
                 .isEqualByComparingTo(BigDecimal.ZERO);
@@ -38,22 +38,29 @@ class BeneficioPolicyTest {
         var sinRelacion = RequisitoPresentadoGuarani.builder().persona(123).requisito(1).build();
 
         assertThat(policy.porcentajeEfectivo(List.of(sinRelacion, requisito(2, "S", "S")),
-                List.of(beneficio(1, "100"), beneficio(2, "20"), beneficio(3, "99"))))
-                .isEqualByComparingTo("20");
+                List.of(beneficio(1, "1"), beneficio(2, "0.20"), beneficio(3, "0.99"))))
+                .isEqualByComparingTo("0.20");
     }
 
     @Test
     void porcentajeEfectivo_isIdempotentForRepeatedEligibleRequirement() {
         var requisito = requisito(1, "S", "S");
 
-        assertThat(policy.porcentajeEfectivo(List.of(requisito, requisito), List.of(beneficio(1, "20"))))
-                .isEqualByComparingTo("20");
+        assertThat(policy.porcentajeEfectivo(List.of(requisito, requisito), List.of(beneficio(1, "0.20"))))
+                .isEqualByComparingTo("0.20");
     }
 
     @Test
     void porcentajeEfectivo_returnsZeroForEmptyOrUnconfiguredRequirements() {
         assertThat(policy.porcentajeEfectivo(List.of(), List.of())).isEqualByComparingTo(BigDecimal.ZERO);
-        assertThat(policy.porcentajeEfectivo(List.of(requisito(1, "S", "S")), List.of(beneficio(2, "20"))))
+        assertThat(policy.porcentajeEfectivo(List.of(requisito(1, "S", "S")), List.of(beneficio(2, "0.20"))))
+                .isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void porcentajeEfectivo_ignoresBenefitsOutsideTheFractionalScale() {
+        assertThat(policy.porcentajeEfectivo(List.of(requisito(1, "S", "S")),
+                List.of(beneficio(1, "50"), beneficio(1, "-0.10"))))
                 .isEqualByComparingTo(BigDecimal.ZERO);
     }
 

--- a/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/controller/GuaraniBeneficioControllerTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/controller/GuaraniBeneficioControllerTest.java
@@ -1,0 +1,154 @@
+package um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.infrastructure.web.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.application.exception.GuaraniBeneficioException;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.application.service.GuaraniBeneficioService;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.domain.model.GuaraniBeneficio;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.infrastructure.web.dto.GuaraniBeneficioResponse;
+import um.tesoreria.core.hexagonal.guarani.guaraniBeneficio.infrastructure.web.mapper.GuaraniBeneficioDtoMapper;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(GuaraniBeneficioController.class)
+class GuaraniBeneficioControllerTest {
+
+    @Autowired
+    private MockMvcTester mockMvc;
+
+    @MockitoBean
+    private GuaraniBeneficioService service;
+    @MockitoBean
+    private GuaraniBeneficioDtoMapper mapper;
+
+    @Test
+    void add_acceptsInclusiveBenefitLimits() throws Exception {
+        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(BigDecimal.ZERO).build();
+        when(mapper.toDomain(any())).thenReturn(domain);
+        when(service.create(domain)).thenReturn(domain);
+        when(mapper.toResponse(domain)).thenReturn(GuaraniBeneficioResponse.builder()
+                .requisito(10).porcentajeBeneficio(BigDecimal.ZERO).build());
+
+        mockMvc.post().uri("/api/tesoreria/core/guaraniBeneficio/")
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "0"))
+                .assertThat().hasStatusOk();
+        mockMvc.post().uri("/api/tesoreria/core/guaraniBeneficio/")
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "100"))
+                .assertThat().hasStatusOk();
+    }
+
+    @Test
+    void add_rejectsInvalidBenefitConfiguration() throws Exception {
+        assertBadRequest(json(10, "-0.01"));
+        assertBadRequest(json(10, "100.01"));
+        assertBadRequest(json(10, "500"));
+        assertBadRequest("{\"requisito\":10}");
+        assertBadRequest("{\"porcentajeBeneficio\":10}");
+    }
+
+    @Test
+    void add_translatesDuplicateToConflict() throws Exception {
+        when(mapper.toDomain(any())).thenReturn(GuaraniBeneficio.builder().requisito(10)
+                .porcentajeBeneficio(BigDecimal.TEN).build());
+        when(service.create(any())).thenThrow(new GuaraniBeneficioException("duplicado"));
+
+        mockMvc.post().uri("/api/tesoreria/core/guaraniBeneficio/")
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "10"))
+                .assertThat().hasStatus(409);
+    }
+
+    @Test
+    void update_appliesSameInputValidation() throws Exception {
+        mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "100.01"))
+                .assertThat().hasStatus(400);
+        mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "500"))
+                .assertThat().hasStatus(400);
+        mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "-0.01"))
+                .assertThat().hasStatus(400);
+        mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
+                .contentType(MediaType.APPLICATION_JSON).content("{\"requisito\":10}")
+                .assertThat().hasStatus(400);
+        mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
+                .contentType(MediaType.APPLICATION_JSON).content("{\"porcentajeBeneficio\":10}")
+                .assertThat().hasStatus(400);
+    }
+
+    @Test
+    void update_acceptsInclusiveBenefitLimits() throws Exception {
+        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(BigDecimal.ZERO).build();
+        when(mapper.toDomain(any())).thenReturn(domain);
+        when(service.updateByRequisito(org.mockito.ArgumentMatchers.eq(10), any())).thenReturn(domain);
+        when(mapper.toResponse(domain)).thenReturn(GuaraniBeneficioResponse.builder()
+                .requisito(10).porcentajeBeneficio(BigDecimal.ZERO).build());
+
+        for (String porcentaje : List.of("0", "50", "100")) {
+            mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
+                    .contentType(MediaType.APPLICATION_JSON).content(json(10, porcentaje))
+                    .assertThat().hasStatusOk();
+        }
+    }
+
+    @Test
+    void findEndpoints_returnMappedBenefitsAndNotFoundForMissingRequirement() throws Exception {
+        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(BigDecimal.TEN).build();
+        var response = GuaraniBeneficioResponse.builder().requisito(10).porcentajeBeneficio(BigDecimal.TEN).build();
+        when(service.findAll()).thenReturn(List.of(domain));
+        when(service.findByRequisito(10)).thenReturn(domain);
+        when(mapper.toResponse(domain)).thenReturn(response);
+
+        mockMvc.get().uri("/api/tesoreria/core/guaraniBeneficio/")
+                .assertThat().hasStatusOk();
+        mockMvc.get().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
+                .assertThat().hasStatusOk();
+
+        when(service.findByRequisito(99)).thenThrow(new GuaraniBeneficioException("no existe"));
+        mockMvc.get().uri("/api/tesoreria/core/guaraniBeneficio/requisito/99")
+                .assertThat().hasStatus(404);
+    }
+
+    @Test
+    void findByRequisitos_returnsOnlyConfiguredBenefits() throws Exception {
+        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(BigDecimal.TEN).build();
+        when(service.findByRequisitos(List.of(10, 99))).thenReturn(List.of(domain));
+        when(mapper.toResponse(domain)).thenReturn(GuaraniBeneficioResponse.builder()
+                .requisito(10).porcentajeBeneficio(BigDecimal.TEN).build());
+
+        mockMvc.post().uri("/api/tesoreria/core/guaraniBeneficio/requisitos")
+                .contentType(MediaType.APPLICATION_JSON).content("[10,99]")
+                .assertThat().hasStatusOk();
+    }
+
+    @Test
+    void update_mapsAndReturnsUpdatedBenefit() throws Exception {
+        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(BigDecimal.TEN).build();
+        when(mapper.toDomain(any())).thenReturn(domain);
+        when(service.updateByRequisito(10, domain)).thenReturn(domain);
+        when(mapper.toResponse(domain)).thenReturn(GuaraniBeneficioResponse.builder()
+                .requisito(10).porcentajeBeneficio(BigDecimal.TEN).build());
+
+        mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "10"))
+                .assertThat().hasStatusOk();
+    }
+
+    private void assertBadRequest(String payload) {
+        mockMvc.post().uri("/api/tesoreria/core/guaraniBeneficio/")
+                .contentType(MediaType.APPLICATION_JSON).content(payload)
+                .assertThat().hasStatus(400);
+    }
+
+    private String json(Integer requisito, String porcentaje) {
+        return "{\"requisito\":" + requisito + ",\"porcentajeBeneficio\":" + porcentaje + "}";
+    }
+}

--- a/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/controller/GuaraniBeneficioControllerTest.java
+++ b/src/test/java/um/tesoreria/core/hexagonal/guarani/guaraniBeneficio/infrastructure/web/controller/GuaraniBeneficioControllerTest.java
@@ -41,15 +41,16 @@ class GuaraniBeneficioControllerTest {
                 .contentType(MediaType.APPLICATION_JSON).content(json(10, "0"))
                 .assertThat().hasStatusOk();
         mockMvc.post().uri("/api/tesoreria/core/guaraniBeneficio/")
-                .contentType(MediaType.APPLICATION_JSON).content(json(10, "100"))
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "1"))
                 .assertThat().hasStatusOk();
     }
 
     @Test
     void add_rejectsInvalidBenefitConfiguration() throws Exception {
         assertBadRequest(json(10, "-0.01"));
-        assertBadRequest(json(10, "100.01"));
-        assertBadRequest(json(10, "500"));
+        assertBadRequest(json(10, "1.01"));
+        assertBadRequest(json(10, "50"));
+        assertBadRequest(json(10, "0.001"));
         assertBadRequest("{\"requisito\":10}");
         assertBadRequest("{\"porcentajeBeneficio\":10}");
     }
@@ -57,21 +58,21 @@ class GuaraniBeneficioControllerTest {
     @Test
     void add_translatesDuplicateToConflict() throws Exception {
         when(mapper.toDomain(any())).thenReturn(GuaraniBeneficio.builder().requisito(10)
-                .porcentajeBeneficio(BigDecimal.TEN).build());
+                .porcentajeBeneficio(new BigDecimal("0.50")).build());
         when(service.create(any())).thenThrow(new GuaraniBeneficioException("duplicado"));
 
         mockMvc.post().uri("/api/tesoreria/core/guaraniBeneficio/")
-                .contentType(MediaType.APPLICATION_JSON).content(json(10, "10"))
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "0.50"))
                 .assertThat().hasStatus(409);
     }
 
     @Test
     void update_appliesSameInputValidation() throws Exception {
         mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
-                .contentType(MediaType.APPLICATION_JSON).content(json(10, "100.01"))
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "1.01"))
                 .assertThat().hasStatus(400);
         mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
-                .contentType(MediaType.APPLICATION_JSON).content(json(10, "500"))
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "50"))
                 .assertThat().hasStatus(400);
         mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
                 .contentType(MediaType.APPLICATION_JSON).content(json(10, "-0.01"))
@@ -92,7 +93,7 @@ class GuaraniBeneficioControllerTest {
         when(mapper.toResponse(domain)).thenReturn(GuaraniBeneficioResponse.builder()
                 .requisito(10).porcentajeBeneficio(BigDecimal.ZERO).build());
 
-        for (String porcentaje : List.of("0", "50", "100")) {
+        for (String porcentaje : List.of("0", "0.50", "1")) {
             mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
                     .contentType(MediaType.APPLICATION_JSON).content(json(10, porcentaje))
                     .assertThat().hasStatusOk();
@@ -101,8 +102,8 @@ class GuaraniBeneficioControllerTest {
 
     @Test
     void findEndpoints_returnMappedBenefitsAndNotFoundForMissingRequirement() throws Exception {
-        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(BigDecimal.TEN).build();
-        var response = GuaraniBeneficioResponse.builder().requisito(10).porcentajeBeneficio(BigDecimal.TEN).build();
+        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(new BigDecimal("0.50")).build();
+        var response = GuaraniBeneficioResponse.builder().requisito(10).porcentajeBeneficio(new BigDecimal("0.50")).build();
         when(service.findAll()).thenReturn(List.of(domain));
         when(service.findByRequisito(10)).thenReturn(domain);
         when(mapper.toResponse(domain)).thenReturn(response);
@@ -119,10 +120,10 @@ class GuaraniBeneficioControllerTest {
 
     @Test
     void findByRequisitos_returnsOnlyConfiguredBenefits() throws Exception {
-        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(BigDecimal.TEN).build();
+        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(new BigDecimal("0.50")).build();
         when(service.findByRequisitos(List.of(10, 99))).thenReturn(List.of(domain));
         when(mapper.toResponse(domain)).thenReturn(GuaraniBeneficioResponse.builder()
-                .requisito(10).porcentajeBeneficio(BigDecimal.TEN).build());
+                .requisito(10).porcentajeBeneficio(new BigDecimal("0.50")).build());
 
         mockMvc.post().uri("/api/tesoreria/core/guaraniBeneficio/requisitos")
                 .contentType(MediaType.APPLICATION_JSON).content("[10,99]")
@@ -131,14 +132,14 @@ class GuaraniBeneficioControllerTest {
 
     @Test
     void update_mapsAndReturnsUpdatedBenefit() throws Exception {
-        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(BigDecimal.TEN).build();
+        var domain = GuaraniBeneficio.builder().requisito(10).porcentajeBeneficio(new BigDecimal("0.50")).build();
         when(mapper.toDomain(any())).thenReturn(domain);
         when(service.updateByRequisito(10, domain)).thenReturn(domain);
         when(mapper.toResponse(domain)).thenReturn(GuaraniBeneficioResponse.builder()
-                .requisito(10).porcentajeBeneficio(BigDecimal.TEN).build());
+                .requisito(10).porcentajeBeneficio(new BigDecimal("0.50")).build());
 
         mockMvc.put().uri("/api/tesoreria/core/guaraniBeneficio/requisito/10")
-                .contentType(MediaType.APPLICATION_JSON).content(json(10, "10"))
+                .contentType(MediaType.APPLICATION_JSON).content(json(10, "0.50"))
                 .assertThat().hasStatusOk();
     }
 

--- a/src/test/java/um/tesoreria/core/service/transactional/spoter/SpoterServiceTest.java
+++ b/src/test/java/um/tesoreria/core/service/transactional/spoter/SpoterServiceTest.java
@@ -1,0 +1,134 @@
+package um.tesoreria.core.service.transactional.spoter;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.factory.ChequeraCuotaFactory;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.application.service.ChequeraCuotaService;
+import um.tesoreria.core.hexagonal.chequera.chequeraCuota.domain.model.ChequeraCuota;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.application.service.ChequeraSerieService;
+import um.tesoreria.core.hexagonal.chequera.chequeraSerie.domain.model.ChequeraSerie;
+import um.tesoreria.core.hexagonal.chequera.chequeraTotal.application.service.ChequeraTotalService;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.application.service.LectivoCuotaService;
+import um.tesoreria.core.hexagonal.chequera.lectivoCuota.domain.model.LectivoCuota;
+import um.tesoreria.core.hexagonal.personas.domicilio.application.service.DomicilioService;
+import um.tesoreria.core.hexagonal.personas.legajo.application.service.LegajoService;
+import um.tesoreria.core.hexagonal.personas.persona.application.service.PersonaService;
+import um.tesoreria.core.kotlin.model.Build;
+import um.tesoreria.core.kotlin.model.CarreraChequera;
+import um.tesoreria.core.kotlin.model.Curso;
+import um.tesoreria.core.kotlin.model.SpoterData;
+import um.tesoreria.core.model.ChequeraSerieControl;
+import um.tesoreria.core.service.BuildService;
+import um.tesoreria.core.service.ChequeraAlternativaService;
+import um.tesoreria.core.service.ChequeraSerieControlService;
+import um.tesoreria.core.service.LectivoAlternativaService;
+import um.tesoreria.core.service.LectivoTotalService;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SpoterServiceTest {
+
+    @Test
+    void makeChequeraSpoter_characterizesLegacyZeroBenefitQuotaValues() {
+        var buildService = mock(BuildService.class);
+        var personaService = mock(PersonaService.class);
+        var serieService = mock(ChequeraSerieService.class);
+        var domicilioService = mock(DomicilioService.class);
+        var controlService = mock(ChequeraSerieControlService.class);
+        var legajoService = mock(LegajoService.class);
+        var lectivoTotalService = mock(LectivoTotalService.class);
+        var totalService = mock(ChequeraTotalService.class);
+        var lectivoAlternativaService = mock(LectivoAlternativaService.class);
+        var alternativaService = mock(ChequeraAlternativaService.class);
+        var lectivoCuotaService = mock(LectivoCuotaService.class);
+        var cuotaService = mock(ChequeraCuotaService.class);
+        var build = mock(Build.class);
+        when(build.getBuild()).thenReturn(1L);
+        when(buildService.findLast()).thenReturn(build);
+        when(personaService.findByUnique(any(), anyInt())).thenReturn(mock(um.tesoreria.core.hexagonal.personas.persona.domain.model.Persona.class));
+        when(domicilioService.findByUnique(any(), anyInt())).thenReturn(mock(um.tesoreria.core.hexagonal.personas.domicilio.domain.model.Domicilio.class));
+        var control = new ChequeraSerieControl(null, 1, 2, 3L, (byte) 0, 0, 0, 0L, (byte) 0);
+        when(controlService.findLastByTipoChequera(1, 2)).thenReturn(control);
+        when(controlService.add(any())).thenReturn(control);
+        when(legajoService.findByFacultadIdAndPersonaIdAndDocumentoId(anyInt(), any(), anyInt()))
+                .thenReturn(mock(um.tesoreria.core.hexagonal.personas.legajo.domain.model.Legajo.class));
+        when(serieService.add(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(lectivoTotalService.findAllByTipo(1, 99, 2)).thenReturn(List.of());
+        when(totalService.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(lectivoAlternativaService.findAllByTipo(1, 99, 2, 1)).thenReturn(List.of());
+        when(alternativaService.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        var vencimiento1 = OffsetDateTime.now().plusDays(1);
+        var lectivoCuota = LectivoCuota.builder().productoId(3).alternativaId(1).cuotaId(4).mes(5).anho(2026)
+                .tramoId(99).vencimiento1(vencimiento1).importe1(new BigDecimal("100.50"))
+                .vencimiento2(vencimiento1.plusDays(10)).importe2(new BigDecimal("120.50"))
+                .vencimiento3(vencimiento1.plusDays(20)).importe3(new BigDecimal("140.50")).build();
+        when(lectivoCuotaService.findAllByTipo(1, 99, 2, 1)).thenReturn(List.of(lectivoCuota));
+        when(cuotaService.calculateCodigoBarras(any())).thenReturn("barcode");
+        when(cuotaService.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var spoter = mock(SpoterData.class);
+        when(spoter.getPersonaId()).thenReturn(BigDecimal.ONE);
+        when(spoter.getDocumentoId()).thenReturn(10);
+        when(spoter.getFacultadId()).thenReturn(1);
+        when(spoter.getGeograficaId()).thenReturn(4);
+        when(spoter.getPlanId()).thenReturn(5);
+        when(spoter.getCarreraId()).thenReturn(6);
+        var curso = mock(Curso.class);
+        when(curso.getCursoId()).thenReturn(7);
+        var carrera = mock(CarreraChequera.class);
+        when(carrera.getFacultadId()).thenReturn(1);
+        when(carrera.getTipoChequeraId()).thenReturn(2);
+
+        service(buildService, personaService, serieService, domicilioService, controlService, legajoService,
+                lectivoTotalService, totalService, lectivoAlternativaService, alternativaService, lectivoCuotaService,
+                new ChequeraCuotaFactory(cuotaService), cuotaService).makeChequeraSpoter(spoter, 99, curso, carrera);
+
+        var series = ArgumentCaptor.forClass(ChequeraSerie.class);
+        org.mockito.Mockito.verify(serieService).add(series.capture());
+        assertThat(series.getValue().getBecaPorcentaje()).isEqualByComparingTo(BigDecimal.ZERO);
+        var cuotas = captor(ChequeraCuota.class);
+        org.mockito.Mockito.verify(cuotaService).saveAll(cuotas.capture());
+        var cuota = cuotas.getValue().getFirst();
+        assertThat(cuota.getTramoId()).isZero();
+        assertThat(cuota.getVencimiento1()).isEqualTo(lectivoCuota.getVencimiento1());
+        assertThat(cuota.getVencimiento2()).isEqualTo(lectivoCuota.getVencimiento2());
+        assertThat(cuota.getVencimiento3()).isEqualTo(lectivoCuota.getVencimiento3());
+        assertThat(cuota.getImporte1()).isEqualByComparingTo(lectivoCuota.getImporte1());
+        assertThat(cuota.getImporte2()).isEqualByComparingTo(lectivoCuota.getImporte2());
+        assertThat(cuota.getImporte3()).isEqualByComparingTo(lectivoCuota.getImporte3());
+        assertThat(cuota.getImporte1Original()).isEqualByComparingTo(lectivoCuota.getImporte1());
+        assertThat(cuota.getImporte2Original()).isEqualByComparingTo(lectivoCuota.getImporte2());
+        assertThat(cuota.getImporte3Original()).isEqualByComparingTo(lectivoCuota.getImporte3());
+        assertThat(cuota.getCodigoBarras()).isEqualTo("barcode");
+        assertThat(cuota.getPagado()).isZero();
+        assertThat(cuota.getBaja()).isZero();
+        assertThat(cuota.getManual()).isZero();
+        assertThat(cuota.getCompensada()).isZero();
+    }
+
+    private static SpoterService service(BuildService buildService, PersonaService personaService,
+                                         ChequeraSerieService serieService, DomicilioService domicilioService,
+                                         ChequeraSerieControlService controlService, LegajoService legajoService,
+                                         LectivoTotalService lectivoTotalService, ChequeraTotalService totalService,
+                                         LectivoAlternativaService lectivoAlternativaService,
+                                         ChequeraAlternativaService alternativaService,
+                                         LectivoCuotaService lectivoCuotaService, ChequeraCuotaFactory factory,
+                                         ChequeraCuotaService cuotaService) {
+        return new SpoterService(buildService, personaService, serieService, domicilioService, controlService,
+                legajoService, lectivoTotalService, totalService, lectivoAlternativaService, alternativaService,
+                lectivoCuotaService, factory, cuotaService);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static ArgumentCaptor<List<ChequeraCuota>> captor(Class<ChequeraCuota> ignored) {
+        return ArgumentCaptor.forClass((Class) List.class);
+    }
+}


### PR DESCRIPTION
## Resumen

- Calcula el beneficio máximo elegible desde los requisitos de ingreso activos y lo persiste en `becaPorcentaje`.
- Usa la escala fraccional persistida: `0.50` representa 50 % y `1.00`, 100 %.
- Aplica la bonificación con redondeo `HALF_UP` a los tres tramos, preservando los importes originales.
- Recalcula totales por producto desde las cuotas activas y conserva productos configurados sin cuotas con total cero.
- Unifica la creación de cuotas para preuniversitario y Spoter; Spoter continúa sin beneficio.
- Valida altas y actualizaciones de beneficios entre `0.00` y `1.00`, y responde conflicto ante requisitos duplicados.
- El detector de inconsistencias entiende cuotas bonificadas y no aborta ante datos históricos incompletos.

## Validación

- `mvn -B verify`: 111 tests, 0 fallos, `BUILD SUCCESS`.
- JaCoCo: el gate específico de cobertura al 80 % pasó.
- Revisión de pre-lanzamiento: sin bloqueadores tras las correcciones de totales, nulos y cobertura.

## Alcance pendiente

Linked to #338 (partial delivery — not auto-closing).

Quedan gates externos: validar en staging el payload con `requisitoRel`, ejecutar la matriz real 0 %/parcial/100 % (incluyendo `send-chequera`), revisar inconsistencias sobre chequeras bonificadas y medir filas históricas con importes nulos.

La comunicación por correo/PDF del importe de lista, porcentaje bonificado e importe a pagar se resolverá en la issue separada.

## Documentación

- Actualizados el diagrama del flujo de beneficios, la misión, el stack técnico y el changelog para v4.2.0.
- Documentado el gate de escala para validar base, Sender y una emisión de prueba antes del despliegue.
